### PR TITLE
Fix yaml indents in web-deployment

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -48,11 +48,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- with .Values.web.affinity }}
-    affinity:
-      {{- toYaml . | nindent 8 }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.web.tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 8 }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Affinity and tolerations belong to `PodSpec` instead of `PodTemplate`, other yaml files got it right: https://github.com/temporalio/temporal-helm-charts/blob/master/templates/server-deployment.yaml#L119-L126