### PR TITLE
Fixes issue where helm chart was assigning incorrectly typed value to the cassandra consistency field

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -91,6 +91,10 @@ server:
           # datacenter: "us-east-1a"
           # maxQPS: 1000
           # maxConns: 2
+          consistency:
+            default:
+              consistency: "local_quorum"
+              serialConsistency: "local_serial"
 
         sql:
           driver: "mysql"

--- a/values.yaml
+++ b/values.yaml
@@ -60,7 +60,10 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
-          consistency: One
+          consistency:
+            default:
+              consistency: "local_quorum"
+              serialConsistency: "local_serial"
           # datacenter: "us-east-1a"
           # maxQPS: 1000
           # maxConns: 2
@@ -85,7 +88,6 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
-          consistency: One
           # datacenter: "us-east-1a"
           # maxQPS: 1000
           # maxConns: 2

--- a/values/values.cassandra.yaml
+++ b/values/values.cassandra.yaml
@@ -30,6 +30,10 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
+          consistency:
+            default:
+              consistency: "local_quorum"
+              serialConsistency: "local_serial"
 
 cassandra:
   enabled: false

--- a/values/values.cassandra.yaml
+++ b/values/values.cassandra.yaml
@@ -15,7 +15,10 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
-          consistency: One
+          consistency:
+            default:
+              consistency: "local_quorum"
+              serialConsistency: "local_serial"
 
       visibility:
         driver: "cassandra"
@@ -27,7 +30,6 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
-          consistency: One
 
 cassandra:
   enabled: false


### PR DESCRIPTION
The helm chart was assigning "consistency:'One'" value to the cassandra section in our config.yaml. This consistency field was never used, and then we recently introduced a strongly typed definition for consistency, which is now causing validation errors on load. This diff fixes up the helm chart.