### PR TITLE
Inject Elastic Search scheme into temporal containers via ES_SCHEME env var

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -75,6 +75,8 @@ spec:
               value: {{ $.Values.elasticsearch.host }}
             - name: ES_PORT
               value: "{{ $.Values.elasticsearch.port }}"
+            - name: ES_SCHEME
+              value: "{{ $.Values.elasticsearch.scheme }}"
             - name: SERVICES
               value: {{ $service }}
             - name: TEMPORAL_STORE_PASSWORD


### PR DESCRIPTION
This is part of the change for https://github.com/temporalio/temporal/issues/562:

With this change, Temporal containers will get an environment variables which defines the scheme to be used for Elastic Search connectivity (e. g. `http` or `https`). 