### PR TITLE
fix: local elasticsearch not starting up on minikube

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -254,6 +254,7 @@ schema:
 elasticsearch:
   enabled: true
   replicas: 3
+  antiAffinity: "soft"
   persistence:
     enabled: false
   imageTag: 6.8.8


### PR DESCRIPTION
With the default elasticsearch values in the chart I was having trouble running elasticsearch locally on minikube. This is because the antiAffinity rules by default don't allow the elasticsearch instances to all run on one node and minikube usually only runs on one node.
Changing the antiAffinity value to "soft" means that elasticsearch will try to run the instances on different nodes but if there's not enough it will run them on the same node.
If this chart is meant to be used more for production I think keeping the "hard" value is ok, but I think it would be good for it to be explicitly set in the root values.yaml so people can more easily find the issue if they're using something like minikube.