### PR TITLE
Using dynamic config in helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,15 +299,12 @@ Forwarding from [::1]:8081 -> 3000
 ### Updating dynamic config
 By default dynamic config is empty, if you want to override some properties for your cluster, you should:
 1. Create a yaml file with your config (for example dc.yaml).
-2. Populate it with some values under server.dynamicConfig prefix, for example:
+2. Populate it with some values under server.dynamicConfig prefix (use the sample provided at `values/values.dynamic_config.yaml` as a starting point)
+3. Install or upgrade your helm configuration:
+```bash
+$ helm install -f values/values.dynamic_config.yaml temporaltest . --timeout 900s
 ```
-server:
-  dynamicConfig:
-    frontend.enableClientVersionCheck:
-    - value: true
-      constraints: {}
-```
-3. Install or upgrade your helm configuration passing `-f dc.yaml` as a parameter to helm.
+
 
 ## Uninstalling
 

--- a/README.md
+++ b/README.md
@@ -300,11 +300,14 @@ Forwarding from [::1]:8081 -> 3000
 By default dynamic config is empty, if you want to override some properties for your cluster, you should:
 1. Create a yaml file with your config (for example dc.yaml).
 2. Populate it with some values under server.dynamicConfig prefix (use the sample provided at `values/values.dynamic_config.yaml` as a starting point)
-3. Install or upgrade your helm configuration:
+3. Install your helm configuration:
 ```bash
 $ helm install -f values/values.dynamic_config.yaml temporaltest . --timeout 900s
 ```
-
+Note that if you already have a running cluster you could use upgrade command to change dynamic config values:
+```bash
+$ helm upgrade -f values/values.dynamic_config.yaml temporaltest . --timeout 900s
+```
 
 ## Uninstalling
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,18 @@ Forwarding from [::1]:8081 -> 3000
 
 3. Navigate to the forwarded Grafana port in your browser (http://localhost:8081/), login as `admin` (using the password from step 1), and click on the "Home" button (upper left corner) to see available dashboards.
 
+### Updating dynamic config
+By default dynamic config is empty, if you want to override some properties for your cluster, you should:
+1. Create a yaml file with your config (for example dc.yaml).
+2. Populate it with some values under server.dynamicConfig prefix, for example:
+```
+server:
+  dynamicConfig:
+    frontend.enableClientVersionCheck:
+    - value: true
+      constraints: {}
+```
+3. Install or upgrade your helm configuration passing `-f dc.yaml` as a parameter to helm.
 
 ## Uninstalling
 

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -184,6 +184,7 @@ data:
       pollInterval: "10s"
 
   dynamic_config.yaml: |-
-    {{- toYaml .Values.server.dynamic_config | nindent 4 }}
-
+  {{- if $.Values.server.dynamicConfig }}
+    {{- toYaml .Values.server.dynamicConfig | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -184,41 +184,10 @@ data:
       pollInterval: "10s"
 
   dynamic_config.yaml: |-
-    frontend.enableClientVersionCheck:
-    - value: true
-      constraints: {}
-    system.minRetentionDays:
-    - value: 0
-      constraints: {}
-    history.persistenceMaxQPS:
-    - value: 3000
-      constraints: {}
-    frontend.persistenceMaxQPS:
-    - value: 3000
-      constraints: {}
-    frontend.historyMgrNumConns:
-    - value: 10
-      constraints: {}
-    frontend.throttledLogRPS:
-    - value: 20
-      constraints: {}
-    history.historyMgrNumConns:
-    - value: 50
-      constraints: {}
-    system.advancedVisibilityWritingMode:
-    - value: "off"
-      constraints: {}
-    history.defaultActivityRetryPolicy:
-    - value:
-        InitialIntervalInSeconds: 2
-        MaximumIntervalCoefficient: 100.0
-        BackoffCoefficient: 2.0
-        MaximumAttempts: 0
-    history.defaultWorkflowRetryPolicy:
-    - value:
-        InitialIntervalInSeconds: {{ .Values.server.history.workflowRetryPolicy.initialIntervalInSeconds }}
-        MaximumIntervalCoefficient: 100.0
-        BackoffCoefficient: 2.0
-        MaximumAttempts: 0
+    # Add properties here.
+    # matching.numTaskqueueReadPartitions:
+    # - value: 5
+    # matching.numTaskqueueWritePartitions:
+    # - value: 5
 
 {{- end }}

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -184,10 +184,6 @@ data:
       pollInterval: "10s"
 
   dynamic_config.yaml: |-
-    # Add properties here.
-    # matching.numTaskqueueReadPartitions:
-    # - value: 5
-    # matching.numTaskqueueWritePartitions:
-    # - value: 5
+    {{- toYaml .Values.server.dynamic_config | nindent 4 }}
 
 {{- end }}

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -178,4 +178,47 @@ data:
 
     publicClient:
       hostPort: "{{ include "temporal.componentname" (list . "frontend") }}:{{ .Values.server.frontend.service.port }}"
+
+    dynamicConfigClient:
+      filepath: "/etc/temporal/config/dynamic_config.yaml"
+      pollInterval: "10s"
+
+  dynamic_config.yaml: |-
+    frontend.enableClientVersionCheck:
+    - value: true
+      constraints: {}
+    system.minRetentionDays:
+    - value: 0
+      constraints: {}
+    history.persistenceMaxQPS:
+    - value: 3000
+      constraints: {}
+    frontend.persistenceMaxQPS:
+    - value: 3000
+      constraints: {}
+    frontend.historyMgrNumConns:
+    - value: 10
+      constraints: {}
+    frontend.throttledLogRPS:
+    - value: 20
+      constraints: {}
+    history.historyMgrNumConns:
+    - value: 50
+      constraints: {}
+    system.advancedVisibilityWritingMode:
+    - value: "off"
+      constraints: {}
+    history.defaultActivityRetryPolicy:
+    - value:
+        InitialIntervalInSeconds: 2
+        MaximumIntervalCoefficient: 100.0
+        BackoffCoefficient: 2.0
+        MaximumAttempts: 0
+    history.defaultWorkflowRetryPolicy:
+    - value:
+        InitialIntervalInSeconds: {{ .Values.server.history.workflowRetryPolicy.initialIntervalInSeconds }}
+        MaximumIntervalCoefficient: 100.0
+        BackoffCoefficient: 2.0
+        MaximumAttempts: 0
+
 {{- end }}

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -104,6 +104,9 @@ spec:
             - name: config
               mountPath: /etc/temporal/config/config_template.yaml
               subPath: config_template.yaml
+            - name: dynamic-config
+              mountPath: /etc/temporal/config/dynamic_config.yaml
+              subPath: dynamic_config.yaml
           resources:
             {{- toYaml (default $.Values.server.resources $serviceValues.resources) | nindent 12 }}
       {{- with $.Values.imagePullSecrets }}
@@ -112,6 +115,9 @@ spec:
       {{- end }}
       volumes:
         - name: config
+          configMap:
+            name: {{ include "temporal.fullname" $ }}
+        - name: dynamic-config
           configMap:
             name: {{ include "temporal.fullname" $ }}
       {{- with (default $.Values.server.nodeSelector $serviceValues.nodeSelector) }}

--- a/values.yaml
+++ b/values.yaml
@@ -144,6 +144,8 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    workflowRetryPolicy:
+      initialIntervalInSeconds: 1
 
   matching:
     # replicaCount: 1

--- a/values.yaml
+++ b/values.yaml
@@ -144,8 +144,6 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
-    workflowRetryPolicy:
-      initialIntervalInSeconds: 1
 
   matching:
     # replicaCount: 1

--- a/values/values.dynamic_config.yaml
+++ b/values/values.dynamic_config.yaml
@@ -1,0 +1,9 @@
+server:
+  dynamicConfig:
+    matching.numTaskqueueReadPartitions:
+    - value: 5
+      constraints: {}
+      matching.numTaskqueueWritePartitions:
+    - value: 5
+      constraints: {}
+


### PR DESCRIPTION
This diff presents helm configuration change that allows users to provide and modify dynamic config properties for the k8s cluster.

In order to modify property values user would simply go to `values.yaml` file and change property value to their liking and then they could run `upgrade` command in order to propagate changes.

New properties would have to be added to the `templates/server-configmap.yaml` into dynamic_config.yaml section.