### PR TITLE
Fix indentation in the dynamic config

### DIFF
--- a/values/values.dynamic_config.yaml
+++ b/values/values.dynamic_config.yaml
@@ -3,7 +3,6 @@ server:
     matching.numTaskqueueReadPartitions:
     - value: 5
       constraints: {}
-      matching.numTaskqueueWritePartitions:
+    matching.numTaskqueueWritePartitions:
     - value: 5
       constraints: {}
-


### PR DESCRIPTION
This should address the failure that we see on CI:
https://tinycicd.temporal.io/teams/main/pipelines/nightly-cassandra-es-byoe/jobs/run-tests/builds/67#L5f2bca35:351