### PR TITLE
Configure cassandra replication factor

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -54,7 +54,7 @@ spec:
           image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
-          args: ['sh', '-c', 'temporal-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }}']
+          args: ['sh', '-c', 'temporal-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }} --replication-factor {{ $storeConfig.cassandra.replicationFactor }}']
           {{- end }}
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}

--- a/values.yaml
+++ b/values.yaml
@@ -63,6 +63,7 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
+          replicationFactor: 1
           consistency:
             default:
               consistency: "local_quorum"
@@ -94,6 +95,7 @@ server:
           # datacenter: "us-east-1a"
           # maxQPS: 1000
           # maxConns: 2
+          replicationFactor: 1
           consistency:
             default:
               consistency: "local_quorum"

--- a/values/values.cassandra.yaml
+++ b/values/values.cassandra.yaml
@@ -15,6 +15,7 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
+          replicationFactor: 1
           consistency:
             default:
               consistency: "local_quorum"
@@ -30,6 +31,7 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
+          replicationFactor: 1
           consistency:
             default:
               consistency: "local_quorum"


### PR DESCRIPTION
Allow for configuring Cassandra replication factor. Example:

```
$ helm install temporaltest --set cassandra.config.cluster_size=5 --set server.config.persistence.default.cassandra.replicationFactor=3 --set server.config.persistence.visibility.cassandra.replicationFactor=3 --set server.replicaCount=3 . --timeout 15m
```

Side note:

With this change, when running the example above, it takes longer for the Cassandra cluster to reach full availability –– now **3** instances of Cassandra need to be online before data could be inserted, as opposed to just one.

During my testing I noticed that the longer Cassandra "time to full availability" started triggering frequent "table {schema_version | schema_update_history} already exist" failures.

The ability to create keyspaces and tables comes online before the ability to create tables, so initial temporal-cassandra-tool runs fail mid-flight, when attempting to insert table, after having created keyspaces and tabls. Subsequent reruns fail because the tables already exist, so db never fully initializes. This change addresses this problem: https://github.com/temporalio/temporal/pull/697.  