### PR TITLE
add values for improving pod scheduling

### DIFF
--- a/values/values.antiaffinity.yaml
+++ b/values/values.antiaffinity.yaml
@@ -1,0 +1,49 @@
+server:
+  frontend:
+    affinity:
+      podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - frontend
+            topologyKey: kubernetes.io/hostname
+ 
+  history:
+    affinity:
+      podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - history
+            topologyKey: kubernetes.io/hostname
+  
+
+  matching:
+    affinity:
+      podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - matching
+            topologyKey: kubernetes.io/hostname
+
+  worker:
+    affinity:
+      podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - worker
+            topologyKey: kubernetes.io/hostname

--- a/values/values.resources.yaml
+++ b/values/values.resources.yaml
@@ -1,0 +1,24 @@
+server:
+  frontend:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+
+  history:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+
+  matching:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+
+  worker:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi


### PR DESCRIPTION
keep replicas of the same temporal services from running on the same node and include arbitrary but small resource requests to help spread