### PR TITLE
Set number of tokens on Cassandra cluster from 256 (default) to 4

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -332,7 +332,7 @@ cassandra:
     cluster_size: 3
     ports:
       cql: 9042
-    num_tokens: 0
+    num_tokens: 4
     max_heap_size: 512M
     heap_new_size: 128M
     seed_size: 0


### PR DESCRIPTION
Relevant documentation here: https://thelastpickle.com/blog/2019/01/30/new-cluster-recommendations.html

Relevant text:
"When the initial work on vnodes in Cassandra was started on the mailing list, 256 tokens was chosen in order to ensure even distribution. This carried over into CASSANDRA-4119 and became part of the implementation. Unfortunately, there were several unforeseen (and unpredictable) consequences of choosing a number this high. Without spending a lot of time on the subject, 256 can cause issues with bootstrapping new nodes (lots of SSTables), repair takes longer, and CPU usage is overall higher. Since Cassandra 3.0, we’ve had the ability to allocate tokens in a more predictable manner that avoids hotspots and leverages the advantage of vnodes. We thus recommend using a value of 4 here, which gives a significant improvement in token allocation. In order to use this please ensure you’re using the allocate_tokens_for_keyspace setting in cassandra.yaml file. It’s important to do this up front as there’s not an easy way to change this without setting up a new data center and doing migration."