### PR TITLE
add more antiaffinity rules

### DIFF
--- a/values/values.antiaffinity.yaml
+++ b/values/values.antiaffinity.yaml
@@ -1,49 +1,96 @@
+cassandra:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/component
+            operator: In
+            values:
+            - frontend
+            - zookeeper
+            - kafka
+          - key: app
+            operator: In
+            values:
+            - cassandra
+            - elasticsearch-master
+        topologyKey: kubernetes.io/hostname
+
 server:
   frontend:
     affinity:
       podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                - frontend
-            topologyKey: kubernetes.io/hostname
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - frontend
+              - zookeeper
+              - kafka
+            - key: app
+              operator: In
+              values:
+              - cassandra
+              - elasticsearch-master
+          topologyKey: kubernetes.io/hostname
  
   history:
     affinity:
       podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                - history
-            topologyKey: kubernetes.io/hostname
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - history
+              - zookeeper
+              - kafka
+            - key: app
+              operator: In
+              values:
+              - cassandra
+              - elasticsearch-master
+          topologyKey: kubernetes.io/hostname
   
 
   matching:
     affinity:
       podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                - matching
-            topologyKey: kubernetes.io/hostname
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - matching
+              - zookeeper
+              - kafka
+            - key: app
+              operator: In
+              values:
+              - cassandra
+              - elasticsearch-master
+          topologyKey: kubernetes.io/hostname
 
   worker:
     affinity:
       podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                - worker
-            topologyKey: kubernetes.io/hostname
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - worker
+              - zookeeper
+              - kafka
+            - key: app
+              operator: In
+              values:
+              - cassandra
+              - elasticsearch-master
+          topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
to prevent temporal services from running on nodes with datastores
and some other services.