### PR TITLE
Fix anti affinity issue

### DIFF
--- a/values/values.antiaffinity.yaml
+++ b/values/values.antiaffinity.yaml
@@ -8,8 +8,14 @@ cassandra:
             operator: In
             values:
             - frontend
+            - history
+            - matching
+            - worker
             - zookeeper
             - kafka
+        topologyKey: kubernetes.io/hostname
+      - labelSelector:
+          matchExpressions:
           - key: app
             operator: In
             values:
@@ -28,13 +34,13 @@ server:
               operator: In
               values:
               - frontend
-              - zookeeper
-              - kafka
+          topologyKey: kubernetes.io/hostname
+        - labelSelector:
+            matchExpressions:
             - key: app
               operator: In
               values:
               - cassandra
-              - elasticsearch-master
           topologyKey: kubernetes.io/hostname
  
   history:
@@ -47,13 +53,13 @@ server:
               operator: In
               values:
               - history
-              - zookeeper
-              - kafka
+          topologyKey: kubernetes.io/hostname
+        - labelSelector:
+            matchExpressions:
             - key: app
               operator: In
               values:
               - cassandra
-              - elasticsearch-master
           topologyKey: kubernetes.io/hostname
   
 
@@ -67,13 +73,13 @@ server:
               operator: In
               values:
               - matching
-              - zookeeper
-              - kafka
+          topologyKey: kubernetes.io/hostname
+        - labelSelector:
+            matchExpressions:
             - key: app
               operator: In
               values:
               - cassandra
-              - elasticsearch-master
           topologyKey: kubernetes.io/hostname
 
   worker:
@@ -86,11 +92,11 @@ server:
               operator: In
               values:
               - worker
-              - zookeeper
-              - kafka
+          topologyKey: kubernetes.io/hostname
+        - labelSelector:
+            matchExpressions:
             - key: app
               operator: In
               values:
               - cassandra
-              - elasticsearch-master
           topologyKey: kubernetes.io/hostname

--- a/values/values.antiaffinity.yaml
+++ b/values/values.antiaffinity.yaml
@@ -1,32 +1,101 @@
 cassandra:
   affinity:
     podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - frontend
+              - history
+              - matching
+              - worker
+              - web
+          topologyKey: kubernetes.io/hostname
+      - weight: 75
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - elasticsearch-master
+          topologyKey: kubernetes.io/hostname
+      - weight: 25
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - kafka
+              - zookeeper                            
+          topologyKey: kubernetes.io/hostname
+      - weight: 15
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - prometheus
+          topologyKey: kubernetes.io/hostname
+      - weight: 5
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - grafana
+          topologyKey: kubernetes.io/hostname
       requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app.kubernetes.io/component
-            operator: In
-            values:
-            - frontend
-            - history
-            - matching
-            - worker
-            - zookeeper
-            - kafka
-        topologyKey: kubernetes.io/hostname
       - labelSelector:
           matchExpressions:
           - key: app
             operator: In
             values:
             - cassandra
-            - elasticsearch-master
         topologyKey: kubernetes.io/hostname
 
 server:
   frontend:
     affinity:
       podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - cassandra
+            topologyKey: kubernetes.io/hostname
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - elasticsearch-master
+            topologyKey: kubernetes.io/hostname
+        - weight: 25
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - history
+                - worker
+                - matching
+                - web
+            topologyKey: kubernetes.io/hostname  
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
@@ -35,17 +104,41 @@ server:
               values:
               - frontend
           topologyKey: kubernetes.io/hostname
-        - labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-              - cassandra
-          topologyKey: kubernetes.io/hostname
  
   history:
     affinity:
       podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - cassandra
+            topologyKey: kubernetes.io/hostname
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - elasticsearch-master
+            topologyKey: kubernetes.io/hostname
+        - weight: 25
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - frontend
+                - worker
+                - matching
+                - web
+            topologyKey: kubernetes.io/hostname  
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
@@ -54,18 +147,41 @@ server:
               values:
               - history
           topologyKey: kubernetes.io/hostname
-        - labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-              - cassandra
-          topologyKey: kubernetes.io/hostname
-  
 
   matching:
     affinity:
       podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - cassandra
+            topologyKey: kubernetes.io/hostname
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - elasticsearch-master
+            topologyKey: kubernetes.io/hostname
+        - weight: 25
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - frontend
+                - history
+                - worker
+                - web
+            topologyKey: kubernetes.io/hostname    
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
@@ -74,17 +190,41 @@ server:
               values:
               - matching
           topologyKey: kubernetes.io/hostname
-        - labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-              - cassandra
-          topologyKey: kubernetes.io/hostname
 
   worker:
     affinity:
       podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - cassandra
+            topologyKey: kubernetes.io/hostname
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - elasticsearch-master
+            topologyKey: kubernetes.io/hostname
+        - weight: 25
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - frontend
+                - history
+                - matching
+                - web
+            topologyKey: kubernetes.io/hostname
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
@@ -92,11 +232,4 @@ server:
               operator: In
               values:
               - worker
-          topologyKey: kubernetes.io/hostname
-        - labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-              - cassandra
           topologyKey: kubernetes.io/hostname

--- a/values/values.antiaffinity.yaml
+++ b/values/values.antiaffinity.yaml
@@ -10,12 +10,27 @@ cassandra:
               operator: In
               values:
               - frontend
+          topologyKey: kubernetes.io/hostname
+      - weight: 90
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
               - history
               - matching
-              - worker
-              - web
           topologyKey: kubernetes.io/hostname
-      - weight: 75
+      - weight: 45
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - worker
+          topologyKey: kubernetes.io/hostname
+      - weight: 30
         podAffinityTerm:
           labelSelector:
             matchExpressions:
@@ -24,7 +39,7 @@ cassandra:
               values:
               - elasticsearch-master
           topologyKey: kubernetes.io/hostname
-      - weight: 25
+      - weight: 10
         podAffinityTerm:
           labelSelector:
             matchExpressions:
@@ -34,7 +49,7 @@ cassandra:
               - kafka
               - zookeeper                            
           topologyKey: kubernetes.io/hostname
-      - weight: 15
+      - weight: 5
         podAffinityTerm:
           labelSelector:
             matchExpressions:
@@ -43,7 +58,7 @@ cassandra:
               values:
               - prometheus
           topologyKey: kubernetes.io/hostname
-      - weight: 5
+      - weight: 1
         podAffinityTerm:
           labelSelector:
             matchExpressions:
@@ -75,7 +90,7 @@ server:
                 values:
                 - cassandra
             topologyKey: kubernetes.io/hostname
-        - weight: 50
+        - weight: 25
           podAffinityTerm:
             labelSelector:
               matchExpressions:
@@ -84,7 +99,7 @@ server:
                 values:
                 - elasticsearch-master
             topologyKey: kubernetes.io/hostname
-        - weight: 25
+        - weight: 90
           podAffinityTerm:
             labelSelector:
               matchExpressions:
@@ -92,10 +107,17 @@ server:
                 operator: In
                 values:
                 - history
-                - worker
                 - matching
-                - web
-            topologyKey: kubernetes.io/hostname  
+            topologyKey: kubernetes.io/hostname
+        - weight: 20
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - worker
+            topologyKey: kubernetes.io/hostname    
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
@@ -118,7 +140,7 @@ server:
                 values:
                 - cassandra
             topologyKey: kubernetes.io/hostname
-        - weight: 50
+        - weight: 25
           podAffinityTerm:
             labelSelector:
               matchExpressions:
@@ -127,7 +149,7 @@ server:
                 values:
                 - elasticsearch-master
             topologyKey: kubernetes.io/hostname
-        - weight: 25
+        - weight: 40
           podAffinityTerm:
             labelSelector:
               matchExpressions:
@@ -135,10 +157,17 @@ server:
                 operator: In
                 values:
                 - frontend
-                - worker
                 - matching
-                - web
-            topologyKey: kubernetes.io/hostname  
+            topologyKey: kubernetes.io/hostname
+        - weight: 20
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - worker
+            topologyKey: kubernetes.io/hostname    
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
@@ -161,7 +190,7 @@ server:
                 values:
                 - cassandra
             topologyKey: kubernetes.io/hostname
-        - weight: 50
+        - weight: 25
           podAffinityTerm:
             labelSelector:
               matchExpressions:
@@ -170,7 +199,7 @@ server:
                 values:
                 - elasticsearch-master
             topologyKey: kubernetes.io/hostname
-        - weight: 25
+        - weight: 40
           podAffinityTerm:
             labelSelector:
               matchExpressions:
@@ -179,9 +208,16 @@ server:
                 values:
                 - frontend
                 - history
+            topologyKey: kubernetes.io/hostname
+        - weight: 20
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
                 - worker
-                - web
-            topologyKey: kubernetes.io/hostname    
+            topologyKey: kubernetes.io/hostname        
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
@@ -195,7 +231,7 @@ server:
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
+        - weight: 50
           podAffinityTerm:
             labelSelector:
               matchExpressions:
@@ -204,7 +240,7 @@ server:
                 values:
                 - cassandra
             topologyKey: kubernetes.io/hostname
-        - weight: 50
+        - weight: 25
           podAffinityTerm:
             labelSelector:
               matchExpressions:
@@ -213,7 +249,7 @@ server:
                 values:
                 - elasticsearch-master
             topologyKey: kubernetes.io/hostname
-        - weight: 25
+        - weight: 40
           podAffinityTerm:
             labelSelector:
               matchExpressions:
@@ -223,7 +259,6 @@ server:
                 - frontend
                 - history
                 - matching
-                - web
             topologyKey: kubernetes.io/hostname
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:


### PR DESCRIPTION
- Switches from "required" to "preferred" (with weights) so that the helm chart can still deploy on smaller clusters
- Fixes bug where matchExpressions are assumed to be ANDs (meaning both conditions had to be met for a pod not to be plaed on a node), when the intent was that they were meant to be ORs.

Validated with a private environment which at least ensures that temporal and cassandra nodes are never co-located.