### PR TITLE
Remove Liveness Probe from Helm Chart for Temporal Worker

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -96,10 +96,12 @@ spec:
             - name: metrics
               containerPort: 9090
               protocol: TCP
+          {{- if ne $service "worker"}}
           livenessProbe:
              initialDelaySeconds: 150
              tcpSocket:
                port: rpc
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/temporal/config/config_template.yaml


### PR DESCRIPTION
The Temporal Worker does not open a port for incoming gRPC calls. Therefore, any liveness probes by K8S which attempt to open a TCP socket to the Worker fail. This causes k8s to periodically recycle the Worker Pod because it thinks it is unhealthy.

This PR removes the liveness probe for Worker roles so that kubernetes doesn't unnecessarily recycle them.

There is a separate PR to add a more proper liveness/health check mechanism for the Worker container in the future