### PR TITLE
Add a flag for disabling version check

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -89,8 +89,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "visibility") }}
                   key: {{ include "temporal.persistence.secretKey" (list $ "visibility") }}
+          {{- if $.Values.server.versionCheckDisabled }}
             - name: TEMPORAL_VERSION_CHECK_DISABLED
-              value: "{{ $.Values.server.versionCheckDisabled }}"
+              value: "1"
+          {{- end }}
           ports:
             - name: rpc
               containerPort: {{ include (printf "temporal.%s.grpcPort" $service) $ }}

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -89,6 +89,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "visibility") }}
                   key: {{ include "temporal.persistence.secretKey" (list $ "visibility") }}
+            - name: TEMPORAL_VERSION_CHECK_DISABLED
+              value: "{{ $.Values.server.versionCheckDisabled }}"
           ports:
             - name: rpc
               containerPort: {{ include (printf "temporal.%s.grpcPort" $service) $ }}


### PR DESCRIPTION
Users should be able to run clusters with version check feature disabled.
This can be done by providing `--set server.versionCheckDisabled=1` to helm install command.