### PR TITLE
Fix TEMPORAL_GRPC_ENDPOINT value

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: TEMPORAL_GRPC_ENDPOINT
-              value: "{{ include "temporal.fullname" . }}-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.frontend.service.port }}"
+              value: "{{ include "temporal.fullname" . }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
 
           ports:
             - name: http


### PR DESCRIPTION
Service's can reach each other without FQDN
Removed not needed `svc.cluster.local` suffix as it prevents using custom k8s cluster's domains.