### PR TITLE
Add example of metricRelabelings and fix helm chart template

### DIFF
--- a/templates/server-service-monitor.yaml
+++ b/templates/server-service-monitor.yaml
@@ -21,7 +21,7 @@ spec:
   endpoints:
     - port: metrics
       interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
-      {{- with (default $.Values.server.metrics.serviceMonitor.relabellings $serviceValues.metrics.serviceMonitor.relabellings) }}
+      {{- with (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) }}
       metricRelabelings:
         {{- toYaml . | indent 8 }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -29,23 +29,23 @@ server:
       interval: 30s
       # Set Prometheus metric_relabel_configs via ServiceMonitor
       # Use metricRelabelings to adjust metric and label names as needed
-      metricRelabelings:
-       - action: replace
-         sourceLabels:
-         - exported_namespace
-         targetLabel: temporal_namespace
-       - action: replace
-         regex: service_errors_(.+)
-         replacement: ${1}
-         sourceLabels:
-         - __name__
-         targetLabel: temporal_error_kind
-       - action: replace
-         regex: service_errors_.+
-         replacement: temporal_service_errors
-         sourceLabels:
-         - __name__
-         targetLabel: __name__
+      #metricRelabelings:
+      # - action: replace
+      #   sourceLabels:
+      #   - exported_namespace
+      #   targetLabel: temporal_namespace
+      # - action: replace
+      #   regex: service_errors_(.+)
+      #   replacement: ${1}
+      #   sourceLabels:
+      #   - __name__
+      #   targetLabel: temporal_error_kind
+      # - action: replace
+      #   regex: service_errors_.+
+      #   replacement: temporal_service_errors
+      #   sourceLabels:
+      #   - __name__
+      #   targetLabel: __name__
     prometheus:
       timerType: histogram
   podAnnotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,25 @@ server:
     serviceMonitor:
       enabled: false
       interval: 30s
+      # Set Prometheus metric_relabel_configs via ServiceMonitor
+      # Use metricRelabelings to adjust metric and label names as needed
+      metricRelabelings:
+       - action: replace
+         sourceLabels:
+         - exported_namespace
+         targetLabel: temporal_namespace
+       - action: replace
+         regex: service_errors_(.+)
+         replacement: ${1}
+         sourceLabels:
+         - __name__
+         targetLabel: temporal_error_kind
+       - action: replace
+         regex: service_errors_.+
+         replacement: temporal_service_errors
+         sourceLabels:
+         - __name__
+         targetLabel: __name__
     prometheus:
       timerType: histogram
   podAnnotations: {}


### PR DESCRIPTION
servicemonitor relabeling was mispelled and applied to metric relabeling - added an example of relabeling to the disabled service monitor