### PR TITLE
Splits Dynamic Config file mount into a separately mounted ConfigMap volume 

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ If a rolling upgrade is not desirable, you can also generate the ConfigMap file 
 ```bash
 $ kubectl apply -f dynamicconfigmap.yaml
 ```
-You can use helm upgrade with the "--dry-run" option to generate the template for the dynamicconfigmap.yaml.
+You can use helm upgrade with the "--dry-run" option to generate the content for the dynamicconfigmap.yaml.
 
 The dynamic-config ConfigMap is referenced as a mounted volume within the Temporal Containers, so any applied change will be automatically picked up by all pods within a few minutes without the need for pod recycling. See k8S documentation (https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically) for more details on how this works.
 

--- a/README.md
+++ b/README.md
@@ -437,9 +437,6 @@ You can use helm upgrade with the "--dry-run" option to generate the content for
 
 The dynamic-config ConfigMap is referenced as a mounted volume within the Temporal Containers, so any applied change will be automatically picked up by all pods within a few minutes without the need for pod recycling. See k8S documentation (https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically) for more details on how this works.
 
-
-
-
 ## Uninstalling
 
 Note: in this example chart, uninstalling a Temporal instance also removes all the data that might have been created during its  lifetime.

--- a/README.md
+++ b/README.md
@@ -421,12 +421,24 @@ By default dynamic config is empty, if you want to override some properties for 
 ```bash
 $ helm install -f values/values.dynamic_config.yaml temporaltest . --timeout 900s
 ```
-Note that if you already have a running cluster you could use upgrade command to change dynamic config values:
+Note that if you already have a running cluster you can use the "helm upgrade" command to change dynamic config values:
 ```bash
 $ helm upgrade -f values/values.dynamic_config.yaml temporaltest . --timeout 900s
 ```
 
-Note that doing so will trigger a rolling upgrade of your system.
+WARNING: The "helm upgrade" approach will trigger a rolling upgrade of all the pods.
+
+If a rolling upgrade is not desirable, you can also generate the ConfigMap file explicitly and then apply it using the following command:
+
+```bash
+$ kubectl apply -f dynamicconfigmap.yaml
+```
+You can use helm upgrade with the "--dry-run" option to generate the template for the dynamicconfigmap.yaml.
+
+The dynamic-config ConfigMap is referenced as a mounted volume within the Temporal Containers, so any applied change will be automatically picked up by all pods within a few minutes without the need for pod recycling. See k8S documentation (https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically) for more details on how this works.
+
+
+
 
 ## Uninstalling
 

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "temporal.fullname" . }}
+  name: "{{ include "temporal.fullname" . }}-config"
   labels:
     app.kubernetes.io/name: {{ include "temporal.name" . }}
     helm.sh/chart: {{ include "temporal.chart" . }}
@@ -180,11 +180,6 @@ data:
       hostPort: "{{ include "temporal.componentname" (list . "frontend") }}:{{ .Values.server.frontend.service.port }}"
 
     dynamicConfigClient:
-      filepath: "/etc/temporal/config/dynamic_config.yaml"
+      filepath: "/etc/temporal/dynamic_config/dynamic_config.yaml"
       pollInterval: "10s"
-
-  dynamic_config.yaml: |-
-  {{- if $.Values.server.dynamicConfig }}
-    {{- toYaml .Values.server.dynamicConfig | nindent 4 }}
-  {{- end }}
 {{- end }}

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -111,8 +111,7 @@ spec:
               mountPath: /etc/temporal/config/config_template.yaml
               subPath: config_template.yaml
             - name: dynamic-config
-              mountPath: /etc/temporal/config/dynamic_config.yaml
-              subPath: dynamic_config.yaml
+              mountPath: /etc/temporal/dynamic_config
           resources:
             {{- toYaml (default $.Values.server.resources $serviceValues.resources) | nindent 12 }}
       {{- with $.Values.imagePullSecrets }}
@@ -122,10 +121,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "temporal.fullname" $ }}
+            name: "{{ include "temporal.fullname" $ }}-config"
         - name: dynamic-config
           configMap:
-            name: {{ include "temporal.fullname" $ }}
+            name: "{{ include "temporal.fullname" $ }}-dynamic-config"
+            items:
+            - key: dynamic_config.yaml
+              path: dynamic_config.yaml
       {{- with (default $.Values.server.nodeSelector $serviceValues.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/server-dynamicconfigmap.yaml
+++ b/templates/server-dynamicconfigmap.yaml
@@ -1,0 +1,18 @@
+{{- if $.Values.server.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "temporal.fullname" . }}-dynamic-config"
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+data:
+  dynamic_config.yaml: |-
+  {{- if $.Values.server.dynamicConfig }}
+    {{- toYaml .Values.server.dynamicConfig | nindent 4 }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
- Splits the singular ConfigMap into two separate ConfigMaps.
- Mounts the dynamic_config.yaml file onto a separate read-only volume that can detect configuration change updates on the fly.
- Changes the default configuration to search for the dynamic_config.yaml file in the newly mounted volume.
- Updates README instructions.

Validated with private deployment