### PR TITLE
Update README.md with guidance on setting up database with k8s pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ SQL_DATABASE=temporal_visibility ./temporal-sql-tool setup-schema -v 0.0
 SQL_DATABASE=temporal_visibility ./temporal-sql-tool update -schema-dir schema/mysql/v57/visibility/versioned
 ```
 
+You can also run the above `temporal-sql-tool` commands from within the `temporalio/server` image. For example:
+
+```
+kubectl run temporal-setup --rm -it --image temporalio/server:<version> -- /bin/bash
+
+# inside the pod
+temporal-sql-tool --version
+```
+
 Once you initialized the two databases, fill in the configuration values in `values/values.mysql.yaml`, and run
 
 ```bash
@@ -178,6 +187,15 @@ SQL_DATABASE=temporal ./temporal-sql-tool update -schema-dir schema/postgresql/v
 ./temporal-sql-tool create-database -database temporal_visibility
 SQL_DATABASE=temporal_visibility ./temporal-sql-tool setup-schema -v 0.0
 SQL_DATABASE=temporal_visibility ./temporal-sql-tool update -schema-dir schema/postgresql/v96/visibility/versioned
+```
+
+You can also run the above `temporal-sql-tool` commands from within the `temporalio/server` image. For example:
+
+```
+kubectl run temporal-setup --rm -it --image temporalio/server:<version> -- /bin/bash
+
+# inside the pod
+temporal-sql-tool --version
 ```
 
 Once you initialized the two databases, fill in the configuration values in `values/values.postgresql.yaml`, and run


### PR DESCRIPTION
The documentation suggests setting up the database for Temporal
using `temporal-sql-tool` from another repository.

But it is also possible to set it up from within a pod in Kubernetes
using the Temporal server image (as the binary is copied into it).

This may be better as it requires less set-up, and the Kubernetes
cluster likely has easier access to the target database (networking-wise).
