### PR TITLE
Fixes breaking change on kafka configuration block in server-configmap

### DIFF
--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -142,7 +142,6 @@ data:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.worker.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
 
-    {{- if or $.Values.kafka.enabled $.Values.kafka.external }}
     kafka:
         tls:
             enabled: false
@@ -159,7 +158,7 @@ data:
             visibility:
                 topic: temporal-visibility-dev
                 dlq-topic: temporal-visibility-dev-dlq
-    {{- end }}
+
     clusterMetadata:
       enableGlobalDomain: false
       failoverVersionIncrement: 10

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -142,6 +142,7 @@ data:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.worker.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
 
+    {{- if $.Values.kafka.omitConfig }}
     kafka:
         tls:
             enabled: false
@@ -158,6 +159,7 @@ data:
             visibility:
                 topic: temporal-visibility-dev
                 dlq-topic: temporal-visibility-dev-dlq
+    {{- end }}
 
     clusterMetadata:
       enableGlobalDomain: false

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -142,7 +142,7 @@ data:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.worker.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
 
-    {{- if $.Values.kafka.omitConfig }}
+    {{- if not $.Values.kafka.omitConfig }}
     kafka:
         tls:
             enabled: false


### PR DESCRIPTION
Recently, a change was added to only condition supply the kafka configuration section if kafka is enabled or kafka is external.

Unfortunately, for existing deployments in production that rely on this helm chart and rely on an external kafka, if they were to simply deploy this updated helm-chart version, Temporal gets stuck in a CrashLoop state because advanced visibility is enabled, but the Kafka section is missing.

Someone who is using external kafka would have to consciously also set the kafka.external value to true to avoid this, which is a breaking change on existing deployments. So instead, we will have a variable that one has to explicitly set in order to omit the Kafka configuration. Existing users are not impacted, and others can opt-in if they don't want the kafka section.

Temporal is removing its dependency on Kafka very soon, at which point this section will be removed.