### PR TITLE
support sidecar containers and provide cloudsqlproxy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ Other components (Prometheus, Kafka, Grafana) can be omitted from the installati
     temporaltest . --timeout 900s
 ```
 
+### Install with sidecar containers
+
+You may need to provide your own sidecar containers. 
+
+To do so, you may look at the example for Google's `cloud sql proxy` in the `values/values.cloudsqlproxy.yaml` and pass that file to `helm install`. 
+
+Example:
+
+```bash
+~/temporal-helm$ helm install -f values/values.cloudsqlproxy.yaml temporaltest . --timeout 900s
+```
+
 ### Install with your own ElasticSearch
 
 You might already be operating an instance of ElasticSearch that you want to use with Temporal.

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -126,6 +126,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml (default $.Values.server.resources $serviceValues.resources) | nindent 12 }}
+        {{- if $.Values.server.sidecarContainers }}
+        {{- toYaml $.Values.server.sidecarContainers | nindent 8 }}
+        {{- end }}
+
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,7 @@ debug: false
 
 server:
   enabled: true
+  sidecarContainers:
   image:
     repository: temporalio/server
     tag: 1.8.0

--- a/values/values.cloudsqlproxy.yaml
+++ b/values/values.cloudsqlproxy.yaml
@@ -1,0 +1,20 @@
+server:
+  sidecarContainers:
+    - name: cloud-sql-proxy
+      image: gcr.io/cloudsql-docker/gce-proxy:1.17
+      command:
+        - "/cloud_sql_proxy"
+        - "-ip_address_types=PRIVATE"
+        - "-instances=_PROJECTNAME_:_REGION_:_INSTANCENAME_=tcp:5432"
+        - "-credential_file=/etc/google-cloud-key/key.json"
+      securityContext:
+        runAsNonRoot: true
+      volumeMounts:
+        - name: google-cloud-key
+          mountPath: /etc/google-cloud-key
+          readOnly: true
+
+  additionalVolumes:
+    - name: google-cloud-key
+      secret:
+        secretName: cloud-sql-proxy-sa


### PR DESCRIPTION
This PR extends the helm templates to support sidecar containers. An example for adding a Google cloud sql proxy sidecar is provided.