### PR TITLE
add prometheus job name

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -33,6 +33,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/server-configmap.yaml") $ | sha256sum }}
         {{- if (default $.Values.server.metrics.annotations.enabled $serviceValues.metrics.annotations.enabled) }}
+        prometheus.io/job: {{ $.Chart.Name }}-{{ $service }}
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9090'
         {{- end }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -42,6 +42,7 @@ metadata:
     app.kubernetes.io/component: {{ $service }}
     app.kubernetes.io/part-of: {{ $.Chart.Name }}
     app.kubernetes.io/headless: 'true'
+    prometheus.io/job: {{ $.Chart.Name }}-{{ $service }}
     prometheus.io/scrape: 'true'
     prometheus.io/scheme: http
     prometheus.io/port: "9090"


### PR DESCRIPTION
based on chart name (temporal) and service (frontend,matching,history,worker)

this is used in some 3rd party tooling and might be beneficial to others as well.