### PR TITLE
Summary: Fixes #110 for AWS MySQL Aurora Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ helm install -f values/values.mysql.yaml temporaltest \
   --set server.config.persistence.default.sql.host=mysql_host \
   --set server.config.persistence.visibility.sql.host=mysql_host . --timeout 900s
 ```
-
+*NOTE:* For MYSQL <5.7.20 (e.g AWS Aurora MySQL) use `values/values.aurora-mysql.yaml`
 
 ### Install with your own PostgreSQL
 

--- a/values.yaml
+++ b/values.yaml
@@ -104,6 +104,8 @@ server:
           secretName: ""
           maxConns: 20
           maxConnLifetime: "1h"
+          # connectAttributes:
+            # tx_isolation: 'READ-COMMITTED'
 
       visibility:
         driver: "cassandra"
@@ -135,6 +137,8 @@ server:
           secretName: ""
           maxConns: 20
           maxConnLifetime: "1h"
+          # connectAttributes:
+          #   tx_isolation: 'READ-COMMITTED'
 
   frontend:
     # replicaCount: 1

--- a/values/values.aurora-mysql.yaml
+++ b/values/values.aurora-mysql.yaml
@@ -1,0 +1,47 @@
+server:
+  config:
+    persistence:
+      default:
+        driver: "sql"
+
+        sql:
+          driver: "mysql"
+          host: _HOST_
+          port: 3306
+          database: temporal
+          user: _USERNAME_
+          password: _PASSWORD_
+          maxConns: 20
+          maxConnLifetime: "1h"
+          connectAttributes:
+            tx_isolation: 'READ-COMMITTED'
+
+      visibility:
+        driver: "sql"
+
+        sql:
+          driver: "mysql"
+          host: _HOST_
+          port: 3306
+          database: temporal_visibility
+          user: _USERNAME_
+          password: _PASSWORD_
+          maxConns: 20
+          maxConnLifetime: "1h"
+          connectAttributes:
+            tx_isolation: 'READ-COMMITTED'          
+
+cassandra:
+  enabled: false
+
+mysql:
+  enabled: true
+
+postgresql:
+  enabled: false
+
+schema:
+  setup:
+    enabled: false
+  update:
+    enabled: false


### PR DESCRIPTION
Changesets:
- Add example for Aurora MySQL using connectAttributes
- Add note in README about MySQL <5.7.20