### PR TITLE
Fix yaml parsing error

### DIFF
--- a/templates/server-service-monitor.yaml
+++ b/templates/server-service-monitor.yaml
@@ -25,7 +25,7 @@ spec:
   jobLabel: {{ include "temporal.componentname" (list $ $service) }}
   namespaceSelector:
     matchNames:
-    - "{{ $.Release.Namespace }}"
+      - "{{ $.Release.Namespace }}"
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "temporal.name" $ }}


### PR DESCRIPTION
Fixes YAML indentation that was broken since #92
```
Error: YAML parse error on temporal/templates/server-service-monitor.yaml: error converting YAML to JSON: yaml: line 19: could not find expected ':'
```