### PR TITLE
Add NDC config

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -54,36 +54,67 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- end }}
 
 {{- define "temporal.frontend.grpcPort" -}}
-7233
+{{- if $.Values.server.frontend.service.port -}}
+{{- $.Values.server.frontend.service.port -}}
+{{- else -}}
+{{- 7233 -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "temporal.frontend.membershipPort" -}}
-6933
+{{- if $.Values.server.frontend.service.membershipPort -}}
+{{- $.Values.server.frontend.service.membershipPort -}}
+{{- else -}}
+{{- 6933 -}}
+{{- end -}}
 {{- end -}}
 
-
 {{- define "temporal.history.grpcPort" -}}
-7234
+{{- if $.Values.server.history.service.port -}}
+{{- $.Values.server.history.service.port -}}
+{{- else -}}
+{{- 7234 -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "temporal.history.membershipPort" -}}
-6934
+{{- if $.Values.server.history.service.membershipPort -}}
+{{- $.Values.server.history.service.membershipPort -}}
+{{- else -}}
+{{- 6934 -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "temporal.matching.grpcPort" -}}
-7235
+{{- if $.Values.server.matching.service.port -}}
+{{- $.Values.server.matching.service.port -}}
+{{- else -}}
+{{- 7235 -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "temporal.matching.membershipPort" -}}
-6935
+{{- if $.Values.server.matching.service.membershipPort -}}
+{{- $.Values.server.matching.service.membershipPort -}}
+{{- else -}}
+{{- 6935 -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "temporal.worker.grpcPort" -}}
-7239
+{{- if $.Values.server.worker.service.port -}}
+{{- $.Values.server.worker.service.port -}}
+{{- else -}}
+{{- 7239 -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "temporal.worker.membershipPort" -}}
-6939
+{{- if $.Values.server.worker.service.membershipPort -}}
+{{- $.Values.server.worker.service.membershipPort -}}
+{{- else -}}
+{{- 6939 -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "temporal.persistence.schema" -}}

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -161,6 +161,12 @@ data:
                 dlq-topic: temporal-visibility-dev-dlq
     {{- end }}
 
+    {{- if $.Values.server.config.clusterMetadata }}
+    clusterMetadata:
+    {{- with .Values.server.config.clusterMetadata }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- else }}
     clusterMetadata:
       enableGlobalDomain: false
       failoverVersionIncrement: 10
@@ -172,6 +178,7 @@ data:
           initialFailoverVersion: 1
           rpcName: "temporal-frontend"
           rpcAddress: "127.0.0.1:7933"
+    {{- end }}
 
     dcRedirectionPolicy:
       policy: "noop"

--- a/values/values.ndc.yaml
+++ b/values/values.ndc.yaml
@@ -1,0 +1,34 @@
+server:
+  config:
+    dcRedirectionPolicy:
+      policy: "selected-apis-forwarding"
+      toDC: ""
+
+    clusterMetadata:
+      enableGlobalNamespace: true
+      replicationConsumer:
+        type: rpc
+      failoverVersionIncrement: 100
+      masterClusterName: cluster_a
+      currentClusterName: # <current cluster name>
+      # clusterInformation:
+      #   <cluster name>:
+      #     enabled: true
+      #     initialFailoverVersion: <cluster initial failover version>
+      #     rpcName: "frontend"
+      #     rpcAddress: <cluster address:cluster port>
+      #   cluster_a:
+      #     enabled: true
+      #     initialFailoverVersion: 1
+      #     rpcName: "frontend"
+      #     rpcAddress: "localhost:7233"
+      #   cluster_b:
+      #     enabled: true
+      #     initialFailoverVersion: 2
+      #     rpcName: "frontend"
+      #     rpcAddress: "localhost:8233"
+      #   cluster_c:
+      #     enabled: false
+      #     initialFailoverVersion: 3
+      #     rpcName: "frontend"
+      #     rpcAddress: "localhost:9233"


### PR DESCRIPTION
existing template before this PR and after this PR does not show significant changes (except default ports):
```zsh
helm template -f values/values.postgresql.yaml temporaltest \
	--set elasticsearch.enabled=false \
	--set server.config.persistence.default.sql.user=postgres \
	--set server.config.persistence.visibility.sql.user=postgres \
	--set server.config.persistence.default.sql.password="$POSTGRES_PASSWORD" \
	--set server.config.persistence.visibility.sql.password="$POSTGRES_PASSWORD" \
	--set server.config.persistence.default.sql.host=postgresql.default.svc.cluster.local \
	--set server.config.persistence.visibility.sql.host=postgresql.default.svc.cluster.local . --timeout 900s
```

NDC configuration can be generated with no error
```zsh
helm template \
	-f values/values.postgresql.yaml \
	-f values/values.ndc.yaml \
	temporaltest \
	--set elasticsearch.enabled=false \
	--set server.frontend.service.port=8233 \
	--set server.frontend.service.membershipPort=9933 \
	--set server.history.service.port=8234 \
	--set server.history.service.membershipPort=9934 \
	--set server.matching.service.port=8235 \
	--set server.matching.service.membershipPort=9935 \
	--set server.worker.service.port=8236 \
	--set server.worker.service.membershipPort=9936 \
	--set server.config.persistence.default.sql.user=postgres \
	--set server.config.persistence.visibility.sql.user=postgres \
	--set server.config.persistence.default.sql.password="$POSTGRES_PASSWORD" \
	--set server.config.persistence.visibility.sql.password="$POSTGRES_PASSWORD" \
	--set server.config.persistence.default.sql.host=postgresql.default.svc.cluster.local \
	--set server.config.persistence.visibility.sql.host=postgresql.default.svc.cluster.local \
	--set server.config.clusterMetadata.masterClusterName=cluster_a \
	--set server.config.clusterMetadata.currentClusterName=cluster_a \
	--set server.config.clusterMetadata.clusterInformation.cluster_a.enabled=true \
	--set server.config.clusterMetadata.clusterInformation.cluster_a.initialFailoverVersion=1 \
	--set server.config.clusterMetadata.clusterInformation.cluster_a.rpcName=frontend \
	--set server.config.clusterMetadata.clusterInformation.cluster_a.rpcAddress=localhost:7233 \
	--set server.config.clusterMetadata.clusterInformation.cluster_b.enabled=true \
	--set server.config.clusterMetadata.clusterInformation.cluster_b.initialFailoverVersion=2 \
	--set server.config.clusterMetadata.clusterInformation.cluster_b.rpcName=frontend \
	--set server.config.clusterMetadata.clusterInformation.cluster_b.rpcAddress=localhost:8233 \
	--set server.config.clusterMetadata.clusterInformation.cluster_c.enabled=false \
	--set server.config.clusterMetadata.clusterInformation.cluster_c.initialFailoverVersion=3 \
	--set server.config.clusterMetadata.clusterInformation.cluster_c.rpcName=frontend \
	--set server.config.clusterMetadata.clusterInformation.cluster_c.rpcAddress=localhost:9233 \
	. --timeout 900s
```