### PR TITLE
Allow custom annotations

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -311,3 +311,17 @@ The first Cassandra host in the stateful set.
 {{- printf "%s-kafka-headless:9092" .Release.Name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Based on Bitnami charts method
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: frontend
     app.kubernetes.io/part-of: {{ .Chart.Name }}
+  {{- if .Values.server.frontend.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.server.frontend.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.server.frontend.service.type }}
   ports:

--- a/values.yaml
+++ b/values.yaml
@@ -143,6 +143,7 @@ server:
   frontend:
     # replicaCount: 1
     service:
+      annotations: {} # Evaluated as template
       type: ClusterIP
       port: 7233
     metrics:


### PR DESCRIPTION
This change allow to set custom annotations for the frontend service, in my case add an external-dns annotation
The helper is a copied from bitnami common charts so any annotations can be refactored with this method (and add more if they are missing)
fix #116 