### PR TITLE
add service.serviceMonitor options

### DIFF
--- a/templates/server-service-monitor.yaml
+++ b/templates/server-service-monitor.yaml
@@ -17,11 +17,14 @@ metadata:
     {{- with (default $.Values.server.metrics.serviceMonitor.additionalLabels $serviceValues.metrics.serviceMonitor.additionalLabels) }}
     {{- toYaml . | indent 4 }}
     {{- end }}
+  {{- if or $.Values.server.metrics.serviceMonitor.namespaceOverride $serviceValues.metrics.serviceMonitor.namespaceOverride }}
+  namespace: {{ default $.Values.server.metrics.serviceMonitor.namespaceOverride $serviceValues.metrics.serviceMonitor.namespaceOverride }}
+  {{- end }}
 spec:
   endpoints:
   - port: metrics
     interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
-    metricRelabelings: {{ toYaml (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) | nindent 4 }}
+    metricRelabelings: {{ toYaml (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) | nindent 6 }}
   jobLabel: {{ include "temporal.componentname" (list $ $service) }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
* `nindent 6` worked for me, because yaml renders in next line
* `namespaceOverride` for cases when prom-operator installed in another namespace