### PR TITLE
add service accounts to deployments

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -1,6 +1,11 @@
 {{- if $.Values.server.enabled }}
 {{- range $service := (list "frontend" "history" "matching" "worker") }}
 {{- $serviceValues := index $.Values.server $service -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Chart.Name }}-{{ $service }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,6 +46,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ $.Chart.Name }}-{{ $service }}
       initContainers:
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.web.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Chart.Name }}-web
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,6 +34,7 @@ spec:
         app.kubernetes.io/component: web
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
+      serviceAccountName: {{ $.Chart.Name }}-web
       containers:
         - name: {{ .Chart.Name }}-web
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"


### PR DESCRIPTION
This change provides a service account per deployment to allow the use of Consul Connect Inject with ACL's enabled.

While this will enable the Consul service mesh to work it also is probably appropriate to allow configuration of the service bind address to configure proxy only access to the services.  That change is more invasive as there appears to be a gossip port for membership as well as an rpc port.

Any advice on how you'd like that addressed potentially would be good.