### PR TITLE
Fix indentation of annotations metadata for the `web` templates

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -53,7 +53,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/web-ingress.yaml
+++ b/templates/web-ingress.yaml
@@ -15,10 +15,10 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: web
     app.kubernetes.io/part-of: {{ .Chart.Name }}
-  {{- with .Values.web.ingress.annotations }}
+{{- with .Values.web.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
-    {{- end }}
+{{- end }}
 spec:
   {{- if .Values.web.ingress.tls }}
   tls:

--- a/templates/web-service.yaml
+++ b/templates/web-service.yaml
@@ -11,10 +11,10 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: web
     app.kubernetes.io/part-of: {{ .Chart.Name }}
-  {{- with .Values.web.service.annotations }}
-annotations:
-  {{ toYaml . | indent 4 }}
-  {{- end }}
+{{- with .Values.web.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   {{- with .Values.web.service.loadBalancerIP }}
   loadBalancerIP: {{.}}


### PR DESCRIPTION
Changed the `web-ingress` and `web-service` templates to adapt the
annotations metadata subsection to match what the [Helm
docs](https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md#ingress) do.