### PR TITLE
Fix TEMPORAL_CLI_ADDRESS for non-default namespace deployments (#158)

### DIFF
--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -38,7 +38,7 @@ spec:
               protocol: TCP
           env:
             - name: TEMPORAL_CLI_ADDRESS
-              value: {{ .Release.Name }}-frontend:{{ include "temporal.frontend.grpcPort" . }}
+              value: {{ include "temporal.fullname" . }}-frontend:{{ include "temporal.frontend.grpcPort" . }}
           livenessProbe:
               exec:
                 command:


### PR DESCRIPTION
## What was changed:
The `admintools` service did not have a valid hostname set for TEMPORAL_CLI_ADDRESS when deployed in a non-default namespace.  The new value for the prepended service name follows the same pattern as the web-deployment.

## Why?
It didn't work in its current implementation.  From my experience.

## Checklist
1. Closes issue: #158

2. How was this tested:
Deployed a fresh temporal stack from the helm chart, exec'd into the admintools, and ran `tctl namespace list`.  It worked without complaint.

3. Any docs updates needed?
N/A
