### PR TITLE
Adding serviceAccountName configuration.

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -41,6 +41,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if (default $.Values.server.serviceAccountName $serviceValues.serviceAccountName) }}
+      serviceAccountName: {{ (default $.Values.server.serviceAccountName $serviceValues.serviceAccountName) }}
+      {{- end }}
       initContainers:
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -29,6 +29,9 @@ spec:
         app.kubernetes.io/component: web
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
+      {{- if .Values.web.serviceAccountName }}
+      serviceAccountName: {{ .Values.web.serviceAccountName }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-web
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->

- This change supports adding service accounts to all deployments or individual Temporal service deployments.

## Why?
<!-- Tell your future self why have you made these changes -->

- I needed to add a service account so that I can access AWS S3 for archival.

##  How was this tested:

- I added the service account in the values file and tested that the serviceAccountName was added to the deployment's spec.

Example values.yaml:

```yaml
...

server:
    serviceAccountName: my-service-account-name

...
```


