### PR TITLE
Add Elasticsearch index creation job

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -187,5 +187,56 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
+
+---
+{{- end }}
+{{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "temporal.componentname" (list . "es-index-setup") }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.setup.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "temporal.componentname" (list . "es-index-setup") }}
+      labels:
+        app.kubernetes.io/name: {{ include "temporal.name" . }}
+        helm.sh/chart: {{ include "temporal.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      restartPolicy: "OnFailure"
+      initContainers:
+        - name: check-elasticsearch-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "elasticsearch.host" $ }}; do echo waiting for elasticsearch service; sleep 1; done;']
+        - name: check-elasticsearch
+          image: "{{ .Values.admintools.image.repo }}:{{ .Values.admintools.image.tag }}"
+          imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until curl -s {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
+        - name: create-elasticsearch-index
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
+          args: ['sh', '-c', 'curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/_template/temporal-visibility-template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/{{ .Values.elasticsearch.version }}/visibility/index_template.json"; curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }};']
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -230,13 +230,11 @@ spec:
           command: ['sh', '-c', 'until nslookup {{ include "elasticsearch.host" $ }}; do echo waiting for elasticsearch service; sleep 1; done;']
         - name: check-elasticsearch
           image: "{{ .Values.admintools.image.repo }}:{{ .Values.admintools.image.tag }}"
-          imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'until curl -s {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
         - name: create-elasticsearch-index
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
           args: ['sh', '-c', 'curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/_template/temporal-visibility-template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/{{ .Values.elasticsearch.version }}/visibility/index_template.json"; curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }};']
-          {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -231,11 +231,11 @@ spec:
         - name: check-elasticsearch
           image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'until curl -s {{ .Values.elasticsearch.schema }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
+          command: ['sh', '-c', 'until curl -s {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
       containers:
         - name: create-elasticsearch-index
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'curl -X PUT {{ .Values.elasticsearch.schema }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/_template/temporal-visibility-template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/{{ .Values.elasticsearch.version }}/visibility/index_template.json"; curl -X PUT {{ .Values.elasticsearch.schema }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }};']
+          command: ['sh', '-c', 'curl -X PUT {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/_template/temporal-visibility-template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/{{ .Values.elasticsearch.version }}/visibility/index_template.json"; curl -X PUT {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }};']
 {{- end }}
 {{- end }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -232,6 +232,7 @@ spec:
           image: "{{ .Values.admintools.image.repo }}:{{ .Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'until curl -s {{ .Values.elasticsearch.schema }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
+      containers:
         - name: create-elasticsearch-index
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -229,7 +229,7 @@ spec:
           image: busybox
           command: ['sh', '-c', 'until nslookup {{ .Values.elasticsearch.host }}; do echo waiting for elasticsearch service; sleep 1; done;']
         - name: check-elasticsearch
-          image: "{{ .Values.admintools.image.repo }}:{{ .Values.admintools.image.tag }}"
+          image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'until curl -s {{ .Values.elasticsearch.schema }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
       containers:

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -235,6 +235,6 @@ spec:
         - name: create-elasticsearch-index
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          args: ['sh', '-c', 'curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/_template/temporal-visibility-template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/{{ .Values.elasticsearch.version }}/visibility/index_template.json"; curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }};']
+          command: ['sh', '-c', 'curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/_template/temporal-visibility-template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/{{ .Values.elasticsearch.version }}/visibility/index_template.json"; curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }};']
 {{- end }}
 {{- end }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -227,14 +227,14 @@ spec:
       initContainers:
         - name: check-elasticsearch-service
           image: busybox
-          command: ['sh', '-c', 'until nslookup {{ include "elasticsearch.host" $ }}; do echo waiting for elasticsearch service; sleep 1; done;']
+          command: ['sh', '-c', 'until nslookup {{ .Values.elasticsearch.host }}; do echo waiting for elasticsearch service; sleep 1; done;']
         - name: check-elasticsearch
           image: "{{ .Values.admintools.image.repo }}:{{ .Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'until curl -s {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
+          command: ['sh', '-c', 'until curl -s {{ .Values.elasticsearch.schema }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
         - name: create-elasticsearch-index
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/_template/temporal-visibility-template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/{{ .Values.elasticsearch.version }}/visibility/index_template.json"; curl -X PUT {{ .Values.elasticsearch.schema }}://{{ include "elasticsearch.host" $ }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }};']
+          command: ['sh', '-c', 'curl -X PUT {{ .Values.elasticsearch.schema }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/_template/temporal-visibility-template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/{{ .Values.elasticsearch.version }}/visibility/index_template.json"; curl -X PUT {{ .Values.elasticsearch.schema }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }};']
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Elasticsearch index won't be created from the image itself after https://github.com/temporalio/temporal/pull/1501 is merged. This new job should create it instead.