### PR TITLE
Fix handling of empty metricRelabelings

### DIFF
--- a/templates/server-service-monitor.yaml
+++ b/templates/server-service-monitor.yaml
@@ -21,7 +21,9 @@ spec:
   endpoints:
   - port: metrics
     interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
+    {{- if (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) }}
     metricRelabelings: {{ toYaml (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) | nindent 4 }}
+    {{- end }}
   jobLabel: {{ include "temporal.componentname" (list $ $service) }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->
Without this safeguard, current default values.yaml failed with prometheus enabled because the nindent 4 is causing empty array to be formatted incorrectly causing this error

```
Error: YAML parse error on temporal/templates/server-service-monitor.yaml: error converting YAML to JSON: yaml: line 19: could not find expected ':'
helm.go:81: [debug] error converting YAML to JSON: yaml: line 19: could not find expected ':'
```
<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->


## Why?
<!-- Tell your future self why have you made these changes -->
To fix the bug.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
tested locally  with `helm install -n ring0 temporaltest ./manifests/dev/helmchart --dry-run`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
