### PR TITLE
Use pre-install hook in case of external ES

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -203,7 +203,11 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/part-of: {{ .Chart.Name }}
   annotations:
-    "helm.sh/hook": post-install,pre-upgrade
+    {{- if .Values.elasticsearch.external }}
+    "helm.sh/hook": pre-install
+    {{- else }}
+    "helm.sh/hook": post-install
+    {{- end }}
     "helm.sh/hook-weight": "0"
     {{- if not .Values.debug }}
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed


### PR DESCRIPTION
Similar to cassandra use `pre-install` hook if external instance of ES is used. 