### PR TITLE
fixes issue #209 - By enabling the server's ServiceMonitor (server.metrics.serviceMonitor.enabled: true) an invalid ServiceMonitor resource is rendered

### DIFF
--- a/templates/server-service-monitor.yaml
+++ b/templates/server-service-monitor.yaml
@@ -21,7 +21,10 @@ spec:
   endpoints:
   - port: metrics
     interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
-    metricRelabelings: {{ toYaml (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) | nindent 4 }}
+    {{- with (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.interval) }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   jobLabel: {{ include "temporal.componentname" (list $ $service) }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
Signed-off-by: denismaggior8 <denis.maggiorotto@sunnyvale.it>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
The way to construct the metricRelabelings array has changed as showed here after:

```diff
diff --git a/templates/server-service-monitor.yaml b/templates/server-service-monitor.yaml
index d1c762e..83a78c6 100644
--- a/templates/server-service-monitor.yaml
+++ b/templates/server-service-monitor.yaml
@@ -21,7 +21,12 @@ spec:
   endpoints:
   - port: metrics
     interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
-    metricRelabelings: {{ toYaml (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) | nindent 4 }}
+    {{- with (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.interval) }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  
+
   jobLabel: {{ include "temporal.componentname" (list $ $service) }}
   namespaceSelector:
     matchNames:
```

## Why?
To fix the issue #209 

## Checklist

1. Closes #209 

2. How was this tested:

```console
$ helm template myrelease -n myns . --debug -s templates/server-service-monitor.yaml
```

Using both:

```yaml
serviceMonitor:
      enabled: true
      interval: 30s
      # Set Prometheus metric_relabel_configs via ServiceMonitor
      # Use metricRelabelings to adjust metric and label names as needed
      metricRelabelings: 
       - action: replace
         sourceLabels:
         - exported_namespace
         targetLabel: temporal_namespace
       - action: replace
         regex: service_errors_(.+)
         replacement: ${1}
         sourceLabels:
         - __name__
         targetLabel: temporal_error_kind
```

and

```yaml
serviceMonitor:
      enabled: true
      interval: 30s
      # Set Prometheus metric_relabel_configs via ServiceMonitor
      # Use metricRelabelings to adjust metric and label names as needed
      metricRelabelings: []
```

sample values.


3. Any docs updates needed?
N/A
