### PR TITLE
fixes issue #215 - By adding additional labels in ServiceMonitor, an invalid manifest ServiceMonitor resource is rendered

### DIFF
--- a/templates/server-service-monitor.yaml
+++ b/templates/server-service-monitor.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/component: {{ $service }}
     app.kubernetes.io/part-of: {{ $.Chart.Name }}
     {{- with (default $.Values.server.metrics.serviceMonitor.additionalLabels $serviceValues.metrics.serviceMonitor.additionalLabels) }}
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   endpoints:

--- a/values.yaml
+++ b/values.yaml
@@ -22,8 +22,12 @@ server:
     # Enable Prometheus ServiceMonitor
     # Use this if you installed the Prometheus Operator (https://github.com/coreos/prometheus-operator).
     serviceMonitor:
-      enabled: false
+      enabled: true
       interval: 30s
+      # Set additional lables to all the ServiceMonitor resources
+      additionalLabels: {}
+      #  label1: value1
+      #  label2: value2
       # Set Prometheus metric_relabel_configs via ServiceMonitor
       # Use metricRelabelings to adjust metric and label names as needed
       metricRelabelings: []

--- a/values.yaml
+++ b/values.yaml
@@ -22,7 +22,7 @@ server:
     # Enable Prometheus ServiceMonitor
     # Use this if you installed the Prometheus Operator (https://github.com/coreos/prometheus-operator).
     serviceMonitor:
-      enabled: true
+      enabled: false
       interval: 30s
       # Set additional lables to all the ServiceMonitor resources
       additionalLabels: {}


### PR DESCRIPTION
Signed-off-by: denismaggior8 <denis.maggiorotto@sunnyvale.it>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

```diff
diff --git a/values.yaml b/values.yaml
index bc0850f..dacfec4 100644
--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,10 @@ server:
     serviceMonitor:
       enabled: false
       interval: 30s
+      # Set additional lables to all the ServiceMonitor resources
+      additionalLabels: {}
+      #  label1: value1
+      #  label2: value2
       # Set Prometheus metric_relabel_configs via ServiceMonitor
       # Use metricRelabelings to adjust metric and label names as needed
       metricRelabelings: []
```

```diff
diff --git a/templates/server-service-monitor.yaml b/templates/server-service-monitor.yaml
index d1c762e..83deb00 100644
--- a/templates/server-service-monitor.yaml
+++ b/templates/server-service-monitor.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/component: {{ $service }}
     app.kubernetes.io/part-of: {{ $.Chart.Name }}
     {{- with (default $.Values.server.metrics.serviceMonitor.additionalLabels $serviceValues.metrics.serviceMonitor.additionalLabels) }}
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
```

## Why?
To fix issue #215 

## Checklist
N/A

1. Closes #215 

2. How was this tested:

Given the values (only the relevant keys have been reported here after):

```yaml
server:
  enabled: true
  metrics:
    # Enable Prometheus ServiceMonitor
    # Use this if you installed the Prometheus Operator (https://github.com/coreos/prometheus-operator).
    serviceMonitor:
      enabled: true
      additionalLabels:
        label1: value1
        label2: value2
```

```console
$ helm template myrelease -n myns . --debug -s templates/server-service-monitor.yaml

---
# Source: temporal/templates/server-service-monitor.yaml

apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: myrelease-temporal-frontend
  labels:
    app.kubernetes.io/name: temporal
    helm.sh/chart: temporal-0.10.5
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: myrelease
    app.kubernetes.io/version: 1.10.5
    app.kubernetes.io/component: frontend
    app.kubernetes.io/part-of: temporal
    label1: value1
    label2: value2
...
```

Additional labels **label1** and **label2** have been places with the right indentation.

3. Any docs updates needed?
N/A
