### PR TITLE
Set right TEMPORAL_CLI_ADDRESS in admintools pod

### DIFF
--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -38,7 +38,7 @@ spec:
               protocol: TCP
           env:
             - name: TEMPORAL_CLI_ADDRESS
-              value: {{ .Release.Name }}-frontend:{{ include "temporal.frontend.grpcPort" . }}
+              value: "{{ include "temporal.componentname" (list . "frontend") }}:{{ include "temporal.frontend.grpcPort" . }}"
           livenessProbe:
               exec:
                 command:


### PR DESCRIPTION
It was set as <release-name>-frontend but the frontend service name
would be set as <release-name>-temporal-frontend. This patch update it
to right service name

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Set right TEMPORAL_CLI_ADDRESS in admintools pod.
## Why?
It was set as <release-name>-frontend but the frontend service name
would be set as <release-name>-temporal-frontend. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
