### PR TITLE
[Fix] tolerations & affinity in web deployment

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -52,11 +52,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- with .Values.web.affinity }}
-    affinity:
+      affinity:
       {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.web.tolerations }}
-    tolerations:
+      tolerations:
       {{- toYaml . | nindent 8 }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix tolerations & affinity  in web deployment template

## Why?
Deployment was failing 

```Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template): unknown field "tolerations" in io.k8s.api.core.v1.PodTemplateSpec```
## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Did the deployment

2. Any docs updates needed?
no
