### PR TITLE
Add SCC and have temporal server run as non-root user

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -42,6 +42,9 @@ spec:
         {{- end }}
     spec:
       {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
+      securityContext:
+        fsGroup: 1000 #temporal group
+        runAsUser: 1000 #temporal user
       initContainers:
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adding security context constraint for the server-deployment [Set to new `temporal` (a non-root user)] .
## Why?
<!-- Tell your future self why have you made these changes -->
In current scenario, the server is deployed as `root` user and is not a recommended practice.
## Checklist
1. Closes  https://github.com/temporalio/temporal/issues/1263.
2. Depends on  https://github.com/temporalio/temporal/pull/1814 (this PR needs to be merged for this to work).
3. How was this tested: deployed on test Kubernetes environment.
