### PR TITLE
Guard security context based on appVersion

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -49,7 +49,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.12.2
+version: 0.12.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -42,9 +42,11 @@ spec:
         {{- end }}
     spec:
       {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
+      {{- if semverCompare ">=1.13.0" $.Chart.AppVersion}}
       securityContext:
         fsGroup: 1000 #temporal group
         runAsUser: 1000 #temporal user
+      {{- end }}
       initContainers:
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added an appVersion guard around the server security context.

## Why?

Older docker images have permission issues with directories and prevent the
dynamic configuration generation from working. This change only runs the
temporal server as a different user if the image can support it.


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

#225 

2. How was this tested:

Locally with Kind.

```console
$ helm install \
    --set server.replicaCount=1 \
    --set cassandra.config.cluster_size=1 \
    --set prometheus.enabled=false \
    --set grafana.enabled=false \
    --set elasticsearch.enabled=false \
    temporaltest . --timeout 15m
```

