### PR TITLE
Add node selector tolerations affinity to jobs

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -49,7 +49,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.13.0
+version: 0.13.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -49,7 +49,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-
 version: 0.13.2
 
 # This is the version number of the application being deployed. This version number should be

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -106,7 +106,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-
+      {{- with (default $.Values.server.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 {{- end }}
 {{- if .Values.schema.update.enabled }}
@@ -186,7 +197,18 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
-
+      {{- with (default $.Values.admintools.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 {{- end }}
 {{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
@@ -243,5 +265,17 @@ spec:
           args:
             - 'curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_{{ .Values.elasticsearch.version }}.json" 2>&1;
               curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }} 2>&1;'
+      {{- with (default $.Values.admintools.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -229,6 +229,9 @@ admintools:
     type: ClusterIP
     port: 22
     annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 web:
   enabled: true


### PR DESCRIPTION
## What was changed
Adds nodeSelector, affinity and tolerations to server-jobs

## Why?
Multi-arch clusters amd64/arm64 require nodeSelector, and since I was working on it, added the others.

## Checklist
n/a

2. How was this tested:
helm lint 
helm template

3. Any docs updates needed?
n/a