### PR TITLE
Add `quote` filter to Ingress TLS hosts

### DIFF
--- a/templates/web-ingress.yaml
+++ b/templates/web-ingress.yaml
@@ -25,7 +25,7 @@ spec:
     {{- range .Values.web.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-      - {{ . }}
+      - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
       {{- end }}


### PR DESCRIPTION
## What was changed

This is useful when your TLS hosts values have wildcard asterisks so
they aren't confused with YAML anchors. This should be an otherwise
non-functional change.

## Why?

Without this change, it is not possible to have wildcard asterisks in
these values.

## Checklist

1. Closes n/a

2. How was this tested: we're using a custom version of the Helm chart with this change. We enable Ingress and have a wildcard asterisk and it behaves as expected.

3. Any docs updates needed? Unlikely, this should be expected behavior.