### PR TITLE
Use `emptyDir` for Temporal configuration mount path

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -127,6 +127,8 @@ spec:
                port: rpc
           {{- end }}
           volumeMounts:
+            - name: config-store
+              mountPath: /etc/temporal/config
             - name: config
               mountPath: /etc/temporal/config/config_template.yaml
               subPath: config_template.yaml
@@ -146,6 +148,8 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: config-store
+          emptyDir: {}
         - name: config
           configMap:
             name: "{{ include "temporal.fullname" $ }}-config"


### PR DESCRIPTION
## What was changed

This change codifies the suggestion in the following issue/comment:
https://github.com/temporalio/helm-charts/issues/225#issuecomment-932263282

Using an empty directory here is a chart/app version agnostic fix.

## Why?

Details in https://github.com/temporalio/helm-charts/issues/225.

## Checklist

1. Closes #225 

2. How was this tested: we're using a custom version of the Helm chart with this change and it behaves as expected.

3. Any docs updates needed? Unlikely, this should be expected behavior.