### PR TITLE
Fix wrong metricRelabeling key in Servicemonitor

### DIFF
--- a/templates/server-service-monitor.yaml
+++ b/templates/server-service-monitor.yaml
@@ -21,7 +21,7 @@ spec:
   endpoints:
   - port: metrics
     interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
-    {{- with (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.interval) }}
+    {{- with (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) }}
     metricRelabelings:
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Helm chart was unable to render due to misconfiguration in service monitor value selector for relabelings