### PR TITLE
Support adding custom service account

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -32,6 +32,22 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create the name of the service account
+*/}}
+{{- define "temporal.serviceAccountName" -}}
+{{ default (include "temporal.fullname" .) .Values.serviceAccount.name }}
+{{- end -}}
+
+{{/*
+Define the service account as needed
+*/}}
+{{- define "temporal.serviceAccount" -}}
+{{- if .Values.serviceAccount.create -}}
+serviceAccountName: {{ include "temporal.serviceAccountName" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified component name from the full app name and a component name.
 We truncate the full name at 63 - 1 (last dash) - len(component name) chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
 and we want to make sure that the component is included in the name.

--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -28,6 +28,7 @@ spec:
         app.kubernetes.io/component: admintools
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
+      {{ include "temporal.serviceAccount" . }}
       containers:
         - name: admin-tools
           image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{ include "temporal.serviceAccount" $ }}
       {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       {{- if semverCompare ">=1.13.0" $.Chart.AppVersion}}
       securityContext:

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -36,6 +36,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
+      {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
         {{- if or .Values.cassandra.enabled }}
@@ -157,6 +158,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
+      {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
         {{- if .Values.cassandra.enabled }}
@@ -248,6 +250,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
+      {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
         - name: check-elasticsearch-service

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "temporal.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-10"
+    {{- with .Values.serviceAccount.extraAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end -}}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{ include "temporal.serviceAccount" . }}
       volumes:
         - name: {{ .Chart.Name }}-web-config
           configMap:

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,17 @@ fullnameOverride: ""
 # (eg. disable helm hook delete policy)
 debug: false
 
+# Custom Service account management
+serviceAccount:
+  # Whether to create service account or not
+  create: false
+
+  # Name of the service account, default: temporal.fullname
+  name:
+
+  # extraAnnotations would let users add additional annotations
+  extraAnnotations:
+
 server:
   enabled: true
   sidecarContainers:


### PR DESCRIPTION
Fixes: issue #245



<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This patch make the changes that need to fix the issue/feature request added in #245  :

* Add option in values.yaml that enable optionaly creating custom
  service account, with following properties:
  * values.yaml has set with serviceAccount.create to false, so by
    default they use kubernetes default service account - this will
    make this change backward compatible
  * Once serviceAccount.create is marked to true, it use default name
    which is temporal.fullname, but can be customized with serviceAccount.name
  * Users can add extraAnnotations to add any additional annotations for
    service acccounts
    * Usually associating k8s service account with public cloud IAM role
      is done by adding custom annotation to serviceAccount, so this
      will enable users to pass such annotations to temporal
      serviceAccount
* Created a custom serviceAccount with pre-install helm hook with low
  hook-weight as temporal server job is running with pre-install
  helm hook in some cases and serviceAccount should be created before
  job execution for the jobs run with custom serviceAccount
## Why?
Details added in issue #245 

## Checklist
1. Closes #245 

2. How was this tested:
    * In all scenarios below all the pods of deployments and jobs have serviceAcountName defined
    * Ran helm install with serviceAcccount.create=true in which case serviceAccount with name equal to temporal.fullname is created and is used for all pods
    * Ran helm install with serviceAcccount.create=true, serviceAccount.name="myserviceaccount" and serviceAccount with name "myserviceaccount" is created and is used for all pods
    * Ran helm install with serviceAcccount.create=true, and added serviceAccount.extraAnnotations which are key value pairs,  and erviceAccount with name equal to temporal.fullname is created and those annotations added in addition to other annotations defined in the templates and the service account is used for all pods
    * Ran helm install with serviceAcccount.create=false in which case  no service accounts are created and the serviceAccount with name "default", is used for all pods. NOTE that "default" is the default serviceAccount k8s assign all pods to.

3. Any docs updates needed?

