### PR TITLE
allow for sql db setup/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,37 @@ Example:
 
 You might already be operating a MySQL instance that you want to use with Temporal.
 
+#### Configuring using the chart
+
+In this case, create your database host and user with a permissions grant that allows the user to create databases and execute database schema changes.
+
+Once you initialized the database server, fill in the configuration values in `values/values.mysql.yaml`, change `schema.setup.enabled: true`, change `schema.update.enabled: true`
+
+*NOTE:* For MYSQL <5.7.20 (e.g AWS Aurora MySQL) use `values/values.aurora-mysql.yaml`
+
+```bash
+# in https://github.com/temporalio/helm-charts git repo dir
+helm install -f values/values.mysql.yaml temporaltest . --timeout 900s
+```
+
+Alternatively, instead of modifying `values/values.mysql.yaml`, you can supply those values in your command line:
+
+```bash
+# in https://github.com/temporalio/helm-charts git repo dir
+helm install -f values/values.mysql.yaml temporaltest \
+  --set elasticsearch.enabled=false \
+  --set schema.setup.enabled=true \
+  --set schema.update.enabled=true \
+  --set server.config.persistence.default.sql.user=mysql_user \
+  --set server.config.persistence.default.sql.password=mysql_password \
+  --set server.config.persistence.visibility.sql.user=mysql_user \
+  --set server.config.persistence.visibility.sql.password=mysql_password \
+  --set server.config.persistence.default.sql.host=mysql_host \
+  --set server.config.persistence.visibility.sql.host=mysql_host . --timeout 900s
+```
+
+#### Configuring outside the context of the chart
+
 In this case, create and configure temporal databases on your MySQL host with `temporal-sql-tool`. The tool is part of [temporal repo](https://github.com/temporalio/temporal), and it relies on the schema definition, in the same repo.
 
 Here are examples of commands you can use to create and initialize the databases:
@@ -143,6 +174,8 @@ SQL_DATABASE=temporal_visibility ./temporal-sql-tool update -schema-dir schema/m
 
 Once you initialized the two databases, fill in the configuration values in `values/values.mysql.yaml`, and run
 
+*NOTE:* For MYSQL <5.7.20 (e.g AWS Aurora MySQL) use `values/values.aurora-mysql.yaml`
+
 ```bash
 # in https://github.com/temporalio/helm-charts git repo dir
 helm install -f values/values.mysql.yaml temporaltest . --timeout 900s
@@ -161,7 +194,6 @@ helm install -f values/values.mysql.yaml temporaltest \
   --set server.config.persistence.default.sql.host=mysql_host \
   --set server.config.persistence.visibility.sql.host=mysql_host . --timeout 900s
 ```
-*NOTE:* For MYSQL <5.7.20 (e.g AWS Aurora MySQL) use `values/values.aurora-mysql.yaml`
 
 ### Install with your own PostgreSQL
 

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -38,7 +38,6 @@ spec:
     spec:
       restartPolicy: "OnFailure"
       initContainers:
-        {{- if or .Values.cassandra.enabled }}
         {{- if .Values.cassandra.enabled }}
         - name: check-cassandra-service
           image: busybox
@@ -55,6 +54,9 @@ spec:
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
           command: ['sh', '-c', 'temporal-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }} --replication-factor {{ $storeConfig.cassandra.replicationFactor }}']
+          {{- end }}
+          {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+          command: ['sh', '-c', 'temporal-sql-tool create-database --db {{ $storeConfig.sql.database }}']
           {{- end }}
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
@@ -73,9 +75,20 @@ spec:
               value: {{ $storeConfig.cassandra.password }}
             {{- end }}
             {{- end }}
-        {{- end }}
-        {{- else }}
-          []
+            {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ $storeConfig.sql.driver }}
+            - name: SQL_HOST
+              value: {{ $storeConfig.sql.host }}
+            - name: SQL_PORT
+              value: "{{ $storeConfig.sql.port }}"
+            - name: SQL_USER
+              value: {{ $storeConfig.sql.user }}
+            - name: SQL_PASSWORD
+              value: {{ $storeConfig.sql.password }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
+            {{- end }}
         {{- end }}
       containers:
         {{- range $store := (list "default" "visibility") }}
@@ -100,6 +113,20 @@ spec:
             - name: CASSANDRA_PASSWORD
               value: {{ $storeConfig.cassandra.password }}
             {{- end }}
+            {{- end }}
+            {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ $storeConfig.sql.driver }}
+            - name: SQL_HOST
+              value: {{ $storeConfig.sql.host }}
+            - name: SQL_PORT
+              value: "{{ $storeConfig.sql.port }}"
+            - name: SQL_USER
+              value: {{ $storeConfig.sql.user }}
+            - name: SQL_PASSWORD
+              value: {{ $storeConfig.sql.password }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
             {{- end }}
         {{- end }}
       {{- with $.Values.imagePullSecrets }}
@@ -179,6 +206,14 @@ spec:
           {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
           command: ['sh', '-c', 'temporal-cassandra-tool update-schema -d /etc/temporal/schema/cassandra/{{ include "temporal.persistence.schema" $store }}/versioned']
           {{- end }}
+          {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+          {{- if eq $store "default" }}
+          command: ['sh', '-c', 'temporal-sql-tool update-schema -d /etc/temporal/schema/{{ $storeConfig.sql.driver }}/**/temporal/versioned']
+          {{- end }}
+          {{- if eq $store "visibility" }}
+          command: ['sh', '-c', 'temporal-sql-tool update-schema -d /etc/temporal/schema/{{ $storeConfig.sql.driver }}/**/visibility/versioned']
+          {{- end }}
+          {{- end }}
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
@@ -195,6 +230,20 @@ spec:
             - name: CASSANDRA_PASSWORD
               value: {{ $storeConfig.cassandra.password }}
             {{- end }}
+            {{- end }}
+            {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ $storeConfig.sql.driver }}
+            - name: SQL_HOST
+              value: {{ $storeConfig.sql.host }}
+            - name: SQL_PORT
+              value: "{{ $storeConfig.sql.port }}"
+            - name: SQL_USER
+              value: {{ $storeConfig.sql.user }}
+            - name: SQL_PASSWORD
+              value: {{ $storeConfig.sql.password }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
             {{- end }}
         {{- end }}
       {{- with (default $.Values.admintools.nodeSelector) }}


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
This allows an external sql database to be setup and updated with the chart like Cassandra can be. Using the follow values set, a functioning external sql database is seeded with data. 

```
schema:
  setup:
    enabled: true
  update:
    enabled: true

server:
  config:
    persistence:
      default:
        driver: sql
        sql:
          driver: mysql
          host: dbhost
          port: 3306
          database: temporal
          user: myuser
          password: mypassword
      visibility:
        driver: sql
        sql:
          driver: mysql
          host: dbhost
          port: 3306
          database: temporal_visibility
          user: myuser
          password: mypassword
```

## Why?
When installing into kubernetes using an sql server, one shouldn't be required to download and run the sql-setup tool to get a functioning db backend.

## Checklist

1. How was this tested:
Using the above persistence configuration the chart successfully installed, created the database in mysql, setup the initial 0.0 schema, and then upgraded to the latest schema for the container image used.

3. Any docs updates needed?
README.md has been updated.