### PR TITLE
Update Elasticsearch to 7.16.2

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -305,7 +305,7 @@ elasticsearch:
   replicas: 3
   persistence:
     enabled: false
-  imageTag: 7.10.1
+  imageTag: 7.16.2
   host: elasticsearch-master-headless
   scheme: http
   port: 9200


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

Set the image tag for elastic to 7.16.2