### PR TITLE
Add cloud sql proxy to admin tools deployment [Issue #263]

### DIFF
--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -48,6 +48,9 @@ spec:
                 - /
               initialDelaySeconds: 5
               periodSeconds: 5
+        {{- if $.Values.server.sidecarContainers }}
+        {{- toYaml $.Values.server.sidecarContainers | nindent 8 }}
+        {{- end }}
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -63,5 +66,9 @@ spec:
     {{- with .Values.admintools.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if $.Values.server.additionalVolumes }}
+      volumes:
+        {{- toYaml $.Values.server.additionalVolumes | nindent 8}}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
## What was changed
Add Cloud SQL proxy sidecar to the admin tools deployment.

## Why?
To make Cloud SQL proxy available to the admin tools pod. So we can use the `temporal-cassandra-tool` and  `temporal-sql-tool` to connect to the database like the others deployed by `server-deployment.yaml` and don't have to build it on our machine.

## Checklist
<!--- add/delete as needed --->

1. Closes
Close #263 

2. How was this tested:
Set up and install with sidecar containers as usual. Then shell into admin-tools and connect database with `temporal-sql-tool`.

3. Any docs updates needed?
No
