### PR TITLE
Respect configured existingSecret in schema setup/update jobs [Issue #261]

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -69,9 +69,16 @@ spec:
             - name: CASSANDRA_USER
               value: {{ $storeConfig.cassandra.user }}
             {{- end }}
-            {{- if $storeConfig.cassandra.password }}
+            {{- if (or $storeConfig.cassandra.password $storeConfig.cassandra.existingSecret) }}
             - name: CASSANDRA_PASSWORD
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
             {{- end }}
             {{- end }}
         {{- end }}
@@ -97,9 +104,16 @@ spec:
             - name: CASSANDRA_USER
               value: {{ $storeConfig.cassandra.user }}
             {{- end }}
-            {{- if $storeConfig.cassandra.password }}
+            {{- if (or $storeConfig.cassandra.password $storeConfig.cassandra.existingSecret) }}
             - name: CASSANDRA_PASSWORD
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
             {{- end }}
             {{- end }}
         {{- end }}
@@ -193,9 +207,16 @@ spec:
             - name: CASSANDRA_USER
               value: {{ $storeConfig.cassandra.user }}
             {{- end }}
-            {{- if $storeConfig.cassandra.password }}
+            {{- if (or $storeConfig.cassandra.password $storeConfig.cassandra.existingSecret) }}
             - name: CASSANDRA_PASSWORD
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
             {{- end }}
             {{- end }}
         {{- end }}


### PR DESCRIPTION
## What was changed

This PR fixes the issue described in Issue #261.

## Why?

It prevents setting up temporal with an existing existing secret to bootstrap a cassandra cluster's schemas.

## Checklist

1. Closes #261 

2. How was this tested:

```
helm template temporal . \
  --values values/values.cassandra.yaml \
  --set server.config.persistence.default.cassandra.existingSecret=someExistingSecret \
  --set server.config.persistence.visibility.cassandra.password=aPasswordInstead
  --set schema.setup.enabled=true \
  --set schema.update.enabled=true 
```

3. Any docs updates needed?

- none