### PR TITLE
Render schema-setup job's init-containers when using external Cassandra cluster

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -39,7 +39,9 @@ spec:
       {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
-        {{- if or .Values.cassandra.enabled }}
+        {{- if or .Values.cassandra.enabled
+                  (eq (include "temporal.persistence.driver" (list $ "default")) "cassandra")
+                  (eq (include "temporal.persistence.driver" (list $ "visibility")) "cassandra") }}
         {{- if .Values.cassandra.enabled }}
         - name: check-cassandra-service
           image: busybox
@@ -51,14 +53,12 @@ spec:
         {{- end }}
         {{- range $store := (list "default" "visibility") }}
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
+        {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
         - name: create-{{ $store }}-store
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
           command: ['sh', '-c', 'temporal-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }} --replication-factor {{ $storeConfig.cassandra.replicationFactor }}']
-          {{- end }}
           env:
-            {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
               value: {{ first (splitList "," (include "temporal.persistence.cassandra.hosts" (list $ $store))) }}
             - name: CASSANDRA_PORT
@@ -80,7 +80,7 @@ spec:
               value: {{ $storeConfig.cassandra.password }}
               {{- end }}
             {{- end }}
-            {{- end }}
+        {{- end }}
         {{- end }}
         {{- else }}
           []


### PR DESCRIPTION
## What was changed

This PR fixes the bug described in issue #264 

## Why?

The `schema-setup` job will not render its `init-containers` when provided with an external Cassandra cluster (`cassandra.enable=false` set in the chart)

## Checklist

1. Closes #264

2. How was this tested:

```
helm template temporal . --values values/values.cassandra.yaml --set schema.setup.enabled=true
```

Before the fix, init-containers are missing, after the fix they are correctly rendered.

3. Any docs updates needed?

- none