### PR TITLE
feat: add the ability to customise existing secret key

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -203,7 +203,7 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- $store := index . 1 -}}
 {{- $storeConfig := index $global.Values.server.config.persistence $store -}}
 {{/* Cassandra password is optional, but we will create an empty secret for it */}}
-{{- print "password" -}}
+{{- default "password" $storeConfig.cassandra.existingSecretKey -}}
 {{- end -}}
 
 {{- define "temporal.persistence.sql.driver" -}}
@@ -311,7 +311,7 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- $store := index . 1 -}}
 {{- $storeConfig := index $global.Values.server.config.persistence $store -}}
 {{- if or $storeConfig.sql.existingSecret $storeConfig.sql.password -}}
-{{- print "password" -}}
+{{- default "password" $storeConfig.sql.existingSecretKey -}}
 {{- else if and $global.Values.mysql.enabled (and (eq (include "temporal.persistence.driver" (list $global $store)) "sql") (eq (include "temporal.persistence.sql.driver" (list $global $store)) "mysql")) -}}
 {{- print "mysql-password" -}}
 {{- else if and $global.Values.postgresql.enabled (and (eq (include "temporal.persistence.driver" (list $global $store)) "sql") (eq (include "temporal.persistence.sql.driver" (list $global $store)) "postgres")) -}}

--- a/values.yaml
+++ b/values.yaml
@@ -100,6 +100,7 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
+          existingSecretKey: "password"
           replicationFactor: 1
           consistency:
             default:
@@ -117,6 +118,7 @@ server:
           user: "temporal"
           password: "temporal"
           existingSecret: ""
+          existingSecretKey: "password"
           secretName: ""
           maxConns: 20
           maxConnLifetime: "1h"
@@ -133,6 +135,7 @@ server:
           user: "user"
           password: "password"
           existingSecret: ""
+          existingSecretKey: "password"
           # datacenter: "us-east-1a"
           # maxQPS: 1000
           # maxConns: 2
@@ -150,6 +153,7 @@ server:
           user: "temporal"
           password: "temporal"
           existingSecret: ""
+          existingSecretKey: "password"
           secretName: ""
           maxConns: 20
           maxConnLifetime: "1h"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Add a custom chart value for `existingSecretKey`.

## Why?
<!-- Tell your future self why have you made these changes -->

Adds more flexibility when deploying databases using unrelated charts.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/268

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Manual testing via Helm CLI

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
