### PR TITLE
Bugfix #115 kubernetes 1.22 support

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     condition: cassandra.enabled
   - name: prometheus
     repository: https://prometheus-community.github.io/helm-charts
-    version: 11.0.4
+    version: 15.1.3
     condition: prometheus.enabled
   - name: elasticsearch
     repository: https://helm.elastic.co

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     condition: prometheus.enabled
   - name: elasticsearch
     repository: https://helm.elastic.co
-    version: 7.6.2
+    version: 7.16.3
     condition: elasticsearch.enabled
   - name: grafana
     repository: https://grafana.github.io/helm-charts

--- a/templates/web-ingress.yaml
+++ b/templates/web-ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.web.ingress.enabled -}}
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
   {{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
 apiVersion: extensions/v1beta1
@@ -37,8 +39,17 @@ spec:
         http:
           paths:
             - path: /{{ rest $url | join "/" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              pathType: Prefix
+              backend:
+                service:
+                  name: {{ include "temporal.fullname" $ }}-web
+                  port:
+                    number: {{ $.Values.web.service.port }}
+              {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
               backend:
                 serviceName: {{ include "temporal.fullname" $ }}-web
                 servicePort: {{ $.Values.web.service.port }}
-        {{- end}}
-        {{- end }}
+              {{- end }}
+      {{- end}}
+    {{- end }}


### PR DESCRIPTION
## What was changed
Upgraded some objects to meet current Kubernetes versions.

## Why?
Per #115, the helm charts no longer work on Kubernetes 1.22+

## Checklist
1. Closes #115 

2. How was this tested:
Deployed on a 1.22 cluster. Note that I was only able to test that the `Ingress` resource was successfully created; I don't have a running Ingress controller at this time to see if it's actually functional.

3. Any docs updates needed?
Likely not. Probably should deprecate Kubernetes<1.19 by now.
