### PR TITLE
add custom pod label options to chart

### DIFF
--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -28,6 +28,9 @@ spec:
         app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
         app.kubernetes.io/component: admintools
         app.kubernetes.io/part-of: {{ .Chart.Name }}
+        {{- with $.Values.admintools.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{ include "temporal.serviceAccount" . }}
       containers:

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -30,6 +30,9 @@ spec:
         app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
         app.kubernetes.io/component: {{ $service }}
         app.kubernetes.io/part-of: {{ $.Chart.Name }}
+        {{- with (default $.Values.server.podLabels $serviceValues.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/server-configmap.yaml") $ | sha256sum }}
         {{- if (default $.Values.server.metrics.annotations.enabled $serviceValues.metrics.annotations.enabled) }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -28,6 +28,9 @@ spec:
         app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
         app.kubernetes.io/component: web
         app.kubernetes.io/part-of: {{ .Chart.Name }}
+        {{- with .Values.web.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.web.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -62,6 +62,7 @@ server:
     prometheus:
       timerType: histogram
   podAnnotations: {}
+  podLabels: {}
   resources:
     {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -170,6 +171,7 @@ server:
       prometheus: {}
       # timerType: histogram
     podAnnotations: {}
+    podLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -188,6 +190,7 @@ server:
       prometheus: {}
       # timerType: histogram
     podAnnotations: {}
+    podLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -206,6 +209,7 @@ server:
       prometheus: {}
       # timerType: histogram
     podAnnotations: {}
+    podLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -224,6 +228,7 @@ server:
       prometheus: {}
       # timerType: histogram
     podAnnotations: {}
+    podLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -240,6 +245,7 @@ admintools:
     type: ClusterIP
     port: 22
     annotations: {}
+  podLabels: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -286,6 +292,7 @@ web:
     #      - chart-example.local
 
   podAnnotations: {}
+  podLabels: {}
 
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This is a relatively minor quality-of-life change that I asked about in Slack and got a positive response about.

## What was changed
This PR adds the ability to add custom labels to the deployment specs, so that pods all launch with them. It supports adding labels to the pods in the cluster itself (by service type, as well as globally), the web UI pods, and the admintools pod.

## Why?
In my case, we control how log output is parsed through pod labels, and adding labels to tell our log aggregator to parse temporal's logs as JSON was a required step. Other use-cases might be adding tags from deployment systems noting who triggered the deployment, or other bookkeeping tasks.

## Checklist
2. How was this tested:
I ran this PR through `helm template -f values.yaml .` and confirmed no change to the output from previous, then added some label key:value pairs and confirmed the appeared in the correct places in the YAML.

3. Any docs updates needed?
As far as I can tell, the existing custom annotation functionality is undocumented; custom pod labels in value.yaml files seems to be a very common idiom across helm charts, so I'm not sure there's much temporal-specific documentation required.
