### PR TITLE
feat: add custom secret label and annotation options to chart

### DIFF
--- a/templates/server-secret.yaml
+++ b/templates/server-secret.yaml
@@ -16,6 +16,13 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/part-of: {{ $.Chart.Name }}
+  {{- with $.Values.server.secretLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.server.secretAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}

--- a/values.yaml
+++ b/values.yaml
@@ -63,6 +63,8 @@ server:
       timerType: histogram
   podAnnotations: {}
   podLabels: {}
+  secretLabels: {}
+  secretAnnotations: {}
   resources:
     {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This is a relatively small change and motivation is same as #280, so directly create a PR.

## What was changed

This PR adds the ability to set custom labels and annotations to the secret resources. It only supports cluster level configuration knob, so users cannot add component level extra labels and annotations to the secret resources.

## Why?

In our case, we inject sensitive data (e.g. database password) from remote secret store (e.g. [GCP Secret Manager](https://cloud.google.com/secret-manager)) using mutating admission webhook, and adding labels to tell our custom admission webhook to inject sensitive data or not. Other common use-case might be adding annotations to the secret resources and mutate them by [Vault Agent Injector](https://www.vaultproject.io/docs/platform/k8s/injector/annotations). I'm not sure there are some use-cases to require component level labels and annotations, so just add cluster level options.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
    I ran this PR through `helm template temporal -n temporal -f values.yaml .` and confirmed no change to the output from previous, then added some label and annotation key:value pairs and confirmed the appeared in the correct places in the YAML.

1. Any docs updates needed?
    No. The existing custom pod level labels and annotations functionality is also undocumented.
