### PR TITLE
feat: Enable LivenessProbe for workers

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -124,12 +124,10 @@ spec:
             - name: metrics
               containerPort: 9090
               protocol: TCP
-          {{- if ne $service "worker"}}
           livenessProbe:
              initialDelaySeconds: 150
              tcpSocket:
                port: rpc
-          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/temporal/config/config_template.yaml


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This pull request removes the loop to not add livenessProbe for workers

## Why?
Every service should have a livenessProbe, in case of failure the kubelet be capable to restart the pod.

## Checklist
<!--- add/delete as needed --->

1. Closes #298

2. How was this tested:
It was applied via helm in our cluster.

3. Any docs updates needed?
No
