### PR TITLE
Run as nonRoot with Cassandra and Elasticsearch disabled

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -45,12 +45,12 @@ spec:
         {{- end }}
     spec:
       {{ include "temporal.serviceAccount" $ }}
-      {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       {{- if semverCompare ">=1.13.0" $.Chart.AppVersion}}
       securityContext:
         fsGroup: 1000 #temporal group
         runAsUser: 1000 #temporal user
       {{- end }}
+      {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       initContainers:
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service


### PR DESCRIPTION
## What was changed
Update server-deployment template to ensure that securityContext is added even if Cassandra and Elasticsearch are disabled (e.g. for a MySQL only installation).

## Why?
When Cassandra and Elasticsearch are disabled, containers for the `frontend`, `history`, `matching` and  `worker` services end up running with the root user. 

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/307

2. How was this tested:

Installed helm chart on local kubernetes instance with:

```sh
helm install -f values/values.mysql.yaml temporal --set elasticsearch.enabled=false .
```

3. Any docs updates needed?
No
