### PR TITLE
Pass SQL configuration env variables to schema update & setup jobs

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -333,6 +333,17 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- include (printf "temporal.persistence.%s.secretKey" (include "temporal.persistence.driver" (list $global $store))) (list $global $store) -}}
 {{- end -}}
 
+{{- define "temporal.persistence.sql.database" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.database -}}
+{{- $storeConfig.sql.database -}}
+{{- else -}}
+{{- required (printf "Please specify database for %s store" $store) -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 All Cassandra hosts.
 */}}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -114,6 +114,29 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
+            {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ include "temporal.persistence.sql.driver" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "temporal.persistence.sql.host" (list $ $store) }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
+            - name: SQL_PORT
+              value: {{ include "temporal.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_USER
+              value: {{ include "temporal.persistence.sql.user" (list $ $store) }}
+            {{- if (or $storeConfig.sql.password $storeConfig.sql.existingSecret) }}
+            - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ $storeConfig.sql.password }}
+              {{- end }}
+              {{- end }}
+            {{- end }}
         {{- end }}
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
@@ -192,6 +215,10 @@ spec:
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
           command: ['sh', '-c', 'temporal-cassandra-tool update-schema -d /etc/temporal/schema/cassandra/{{ include "temporal.persistence.schema" $store }}/versioned']
+          {{- else if eq (include "temporal.persistence.sql.driver" (list $ $store)) "mysql" }}
+          command: [ 'temporal-sql-tool', 'update', '-schema-dir', 'schema/mysql/v57/{{ include "temporal.persistence.schema" $store }}/versioned' ]
+          {{- else if eq (include "temporal.persistence.sql.driver" (list $ $store)) "postgres"}}
+          command: [ 'temporal-sql-tool', 'update', '-schema-dir', 'schema/postgresql/v96/{{ include "temporal.persistence.schema" $store }}/versioned' ]
           {{- end }}
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
@@ -216,6 +243,29 @@ spec:
               value: {{ $storeConfig.cassandra.password }}
               {{- end }}
             {{- end }}
+            {{- end }}
+            {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ include "temporal.persistence.sql.driver" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "temporal.persistence.sql.host" (list $ $store) }}
+            - name: SQL_DATABASE
+              value: {{ include "temporal.persistence.sql.database" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "temporal.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_USER
+              value: {{ include "temporal.persistence.sql.user" (list $ $store) }}
+            {{- if (or $storeConfig.sql.password $storeConfig.sql.existingSecret) }}
+            - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ $storeConfig.sql.password }}
+              {{- end }}
+              {{- end }}
             {{- end }}
         {{- end }}
       {{- with (default $.Values.admintools.nodeSelector) }}


### PR DESCRIPTION
## What was changed
Update server-job.yaml to include the required environment variables to connect to a SQL database.

## Why?
With MySQL used as the persistence store, the schema setup & update jobs failed to connect to the database. 

## Checklist

1. Closes  #310

2. How was this tested:

### Plain Password
#### Generate YAML
```bash
helm template -f values/values.mysql.yaml temporaltest \
  --set schema.setup.enabled=true \
  --set schema.update.enabled=true \
  --set server.config.persistence.default.sql.user=DEFAULT_USER \
  --set server.config.persistence.default.sql.password=DEFAULT_PASSWORD \
  --set server.config.persistence.default.sql.host=DEFAULT_HOST \
  --set server.config.persistence.visibility.sql.user=VISIBILITY_USER \
  --set server.config.persistence.visibility.sql.password=VISIBILITY_PASSWORD \
  --set server.config.persistence.visibility.sql.host=VISIBILITY_HOST .
```

#### Schema Setup
```yaml
# Source: temporal/templates/server-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: temporaltest-schema-setup
  labels:
    app.kubernetes.io/name: temporal
    helm.sh/chart: temporal-0.17.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: temporaltest
    app.kubernetes.io/version: 1.17.1
    app.kubernetes.io/component: database
    app.kubernetes.io/part-of: temporal
  annotations:
    "helm.sh/hook": pre-install
    "helm.sh/hook-weight": "0"
    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
spec:
  backoffLimit: 100
  template:
    metadata:
      name: temporaltest-schema-setup
      labels:
        app.kubernetes.io/name: temporal
        helm.sh/chart: temporal-0.17.1
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/instance: temporaltest
        app.kubernetes.io/version: 1.17.1
        app.kubernetes.io/component: database
        app.kubernetes.io/part-of: temporal
    spec:
      
      restartPolicy: "OnFailure"
      initContainers:
          []
      containers:
        - name: default-schema
          image: "temporalio/admin-tools:1.17.1"
          imagePullPolicy: IfNotPresent
          command: ["temporal-sql-tool", "setup-schema", "-v", "0.0"]
          env:
            - name: SQL_DATABASE
              value: temporal
            - name: SQL_HOST
              value: DEFAULT_HOST
            - name: SQL_PORT
              value: "3306"
            - name: SQL_USER
              value: DEFAULT_USER
            - name: SQL_PASSWORD
              value: DEFAULT_PASSWORD
        - name: visibility-schema
          image: "temporalio/admin-tools:1.17.1"
          imagePullPolicy: IfNotPresent
          command: ["temporal-sql-tool", "setup-schema", "-v", "0.0"]
          env:
            - name: SQL_DATABASE
              value: temporal_visibility
            - name: SQL_HOST
              value: VISIBILITY_HOST
            - name: SQL_PORT
              value: "3306"
            - name: SQL_USER
              value: VISIBILITY_USER
            - name: SQL_PASSWORD
              value: VISIBILITY_PASSWORD
```

####  Schema Update
```yaml
# Source: temporal/templates/server-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: temporaltest-schema-update
  labels:
    app.kubernetes.io/name: temporal
    helm.sh/chart: temporal-0.17.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: temporaltest
    app.kubernetes.io/version: 1.17.1
    app.kubernetes.io/component: database
    app.kubernetes.io/part-of: temporal
  annotations:
    "helm.sh/hook": pre-install,pre-upgrade
    "helm.sh/hook-weight": "1"
    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
spec:
  backoffLimit: 100
  template:
    metadata:
      name: temporaltest-schema-update
      labels:
        app.kubernetes.io/name: temporal
        helm.sh/chart: temporal-0.17.1
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/instance: temporaltest
        app.kubernetes.io/version: 1.17.1
        app.kubernetes.io/component: database
        app.kubernetes.io/part-of: temporal
    spec:
      
      restartPolicy: "OnFailure"
      initContainers:
          []
      containers:
        - name: default-schema
          image: "temporalio/admin-tools:1.17.1"
          imagePullPolicy: IfNotPresent
          command: [ 'temporal-sql-tool', 'update', '-schema-dir', 'schema/mysql/v57/temporal/versioned' ]
          env:
            - name: SQL_DATABASE
              value: temporal
            - name: SQL_HOST
              value: DEFAULT_HOST
            - name: SQL_PORT
              value: "3306"
            - name: SQL_USER
              value: DEFAULT_USER
            - name: SQL_PASSWORD
              value: DEFAULT_PASSWORD
        - name: visibility-schema
          image: "temporalio/admin-tools:1.17.1"
          imagePullPolicy: IfNotPresent
          command: [ 'temporal-sql-tool', 'update', '-schema-dir', 'schema/mysql/v57/visibility/versioned' ]
          env:
            - name: SQL_DATABASE
              value: temporal_visibility
            - name: SQL_HOST
              value: VISIBILITY_HOST
            - name: SQL_PORT
              value: "3306"
            - name: SQL_USER
              value: VISIBILITY_USER
            - name: SQL_PASSWORD
              value: VISIBILITY_PASSWORD
```

### Existing secret
#### Generate YAML

```bash
helm template -f values/values.mysql.yaml temporaltest \
  --set schema.setup.enabled=true \
  --set schema.update.enabled=true \
  --set server.config.persistence.default.sql.user=DEFAULT_USER \
  --set server.config.persistence.default.sql.existingSecret=DEFAULT_SECRET \
  --set server.config.persistence.default.sql.host=DEFAULT_HOST \
  --set server.config.persistence.visibility.sql.user=VISIBILITY_USER \
  --set server.config.persistence.visibility.sql.existingSecret=VISIBILITY_SECRET \
  --set server.config.persistence.visibility.sql.host=VISIBILITY_HOST . 
```

#### Schema setup
```yaml
containers:
        - name: default-schema
          image: "temporalio/admin-tools:1.17.1"
          imagePullPolicy: IfNotPresent
          command: ["temporal-sql-tool", "setup-schema", "-v", "0.0"]
          env:
            - name: SQL_DATABASE
              value: temporal
            - name: SQL_HOST
              value: DEFAULT_HOST
            - name: SQL_PORT
              value: "3306"
            - name: SQL_USER
              value: DEFAULT_USER
            - name: SQL_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: DEFAULT_SECRET
                  key: password
        - name: visibility-schema
          image: "temporalio/admin-tools:1.17.1"
          imagePullPolicy: IfNotPresent
          command: ["temporal-sql-tool", "setup-schema", "-v", "0.0"]
          env:
            - name: SQL_DATABASE
              value: temporal_visibility
            - name: SQL_HOST
              value: VISIBILITY_HOST
            - name: SQL_PORT
              value: "3306"
            - name: SQL_USER
              value: VISIBILITY_USER
            - name: SQL_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: VISIBILITY_SECRET
                  key: password
```

#### Schema Update

```yaml
containers:
        - name: default-schema
          image: "temporalio/admin-tools:1.17.1"
          imagePullPolicy: IfNotPresent
          command: [ 'temporal-sql-tool', 'update', '-schema-dir', 'schema/mysql/v57/temporal/versioned' ]
          env:
            - name: SQL_DATABASE
              value: temporal
            - name: SQL_HOST
              value: DEFAULT_HOST
            - name: SQL_PORT
              value: "3306"
            - name: SQL_USER
              value: DEFAULT_USER
            - name: SQL_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: DEFAULT_SECRET
                  key: password
        - name: visibility-schema
          image: "temporalio/admin-tools:1.17.1"
          imagePullPolicy: IfNotPresent
          command: [ 'temporal-sql-tool', 'update', '-schema-dir', 'schema/mysql/v57/visibility/versioned' ]
          env:
            - name: SQL_DATABASE
              value: temporal_visibility
            - name: SQL_HOST
              value: VISIBILITY_HOST
            - name: SQL_PORT
              value: "3306"
            - name: SQL_USER
              value: VISIBILITY_USER
            - name: SQL_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: VISIBILITY_SECRET
                  key: password
```

3. Any docs updates needed?
No