### PR TITLE
Add support for ingressClassName

### DIFF
--- a/templates/web-ingress.yaml
+++ b/templates/web-ingress.yaml
@@ -22,6 +22,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  {{- with .Values.web.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
   {{- if .Values.web.ingress.tls }}
   tls:
     {{- range .Values.web.ingress.tls }}

--- a/values.yaml
+++ b/values.yaml
@@ -278,6 +278,7 @@ web:
 
   ingress:
     enabled: false
+    # className:
     annotations: {}
     # kubernetes.io/ingress.class: traefik
     # ingress.kubernetes.io/ssl-redirect: "false"


### PR DESCRIPTION
Hi! Thanks for the good software!

## What was changed

Support custom `ingressClassName`

https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource

## Why?

For our use case we use a non-default ingressClassName.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

No issue

2. How was this tested:

I ran `helm template` locally and confirmed that `ingressClassName` worked with or without `.Values.web.ingress.className`.

3. Any docs updates needed?

There was no documentation for value.yaml.
So I wrote an example in value.yaml
