### PR TITLE
Ability to set PodAnnotations on admintools

### DIFF
--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -31,6 +31,10 @@ spec:
         {{- with $.Values.admintools.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with $.Values.admintools.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{ include "temporal.serviceAccount" . }}
       containers:

--- a/values.yaml
+++ b/values.yaml
@@ -246,6 +246,7 @@ admintools:
     port: 22
     annotations: {}
   podLabels: {}
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## What was changed
It's currently not possible to set PodAnnotations on `admintool`, like you can already on the server deployments.

## Why?

Brings `admintool` to be consistent with the rest of the services. 

## Checklist

2. How was this tested:
- `helm template`
- `helm install` 

3. Any docs updates needed?
`values.yaml` updated appropriately 