### PR TITLE
Bump elasticsearch chart version to v7.17.3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     condition: prometheus.enabled
   - name: elasticsearch
     repository: https://helm.elastic.co
-    version: 7.16.3
+    version: 7.17.3
     condition: elasticsearch.enabled
   - name: grafana
     repository: https://grafana.github.io/helm-charts


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bumped elasticsearch chart version to v7.17.3

## Why?
Getting the error on K8s v1.25:
```
unable to build kubernetes objects from release manifest: resource mapping not found for name: \"elasticsearch-master-pdb\" namespace: \"\" from \"\": no matches for kind \"PodDisruptionBudget\" in version \"policy/v1beta1\"\nensure CRDs are installed first"
```

policy/v1beta1 PodDisruptionBudget is deprecated in K8s v1.21+, unavailable in K8s  v1.25+
policy/v1 PodDisruptionBudget should be used instead.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No

2. How was this tested:
Locally using `Server Version: v1.25.3`.

3. Any docs updates needed?
No