### PR TITLE
feat: add additional env values

### DIFF
--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -48,6 +48,9 @@ spec:
           env:
             - name: TEMPORAL_CLI_ADDRESS
               value: {{ include "temporal.fullname" . }}-frontend:{{ include "temporal.frontend.grpcPort" . }}
+          {{- if .Values.admintools.additionalEnv }}
+          {{- toYaml .Values.admintools.additionalEnv | nindent 12 }}
+          {{- end }}
           livenessProbe:
               exec:
                 command:

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -117,6 +117,9 @@ spec:
             - name: TEMPORAL_VERSION_CHECK_DISABLED
               value: "1"
           {{- end }}
+          {{- if or $.Values.server.additionalEnv $serviceValues.additionalEnv }}
+          {{- toYaml (default $.Values.server.additionalEnv $serviceValues.additionalEnv) | nindent 12 }}
+          {{- end }}
           ports:
             - name: rpc
               containerPort: {{ include (printf "temporal.%s.grpcPort" $service) $ }}
@@ -137,7 +140,7 @@ spec:
             - name: dynamic-config
               mountPath: /etc/temporal/dynamic_config
             {{- if $.Values.server.additionalVolumeMounts }}
-            {{- toYaml $.Values.server.additionalVolumeMounts | nindent 12}}  
+            {{- toYaml $.Values.server.additionalVolumeMounts | nindent 12}}
             {{- end }}
           resources:
             {{- toYaml (default $.Values.server.resources $serviceValues.resources) | nindent 12 }}
@@ -160,7 +163,7 @@ spec:
             - key: dynamic_config.yaml
               path: dynamic_config.yaml
         {{- if $.Values.server.additionalVolumes }}
-        {{- toYaml $.Values.server.additionalVolumes | nindent 8}}  
+        {{- toYaml $.Values.server.additionalVolumes | nindent 8}}
         {{- end }}
       {{- with (default $.Values.server.nodeSelector $serviceValues.nodeSelector) }}
       nodeSelector:

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -48,6 +48,9 @@ spec:
           env:
             - name: TEMPORAL_ADDRESS
               value: "{{ include "temporal.fullname" . }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
+          {{- if .Values.web.additionalEnv }}
+          {{- toYaml .Values.web.additionalEnv | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/values.yaml
+++ b/values.yaml
@@ -63,8 +63,7 @@ server:
       timerType: histogram
   podAnnotations: {}
   podLabels: {}
-  resources:
-    {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -80,6 +79,7 @@ server:
   affinity: {}
   additionalVolumes: []
   additionalVolumeMounts: []
+  additionalEnv: []
 
   config:
     logLevel: "debug,info"
@@ -122,7 +122,7 @@ server:
           maxConns: 20
           maxConnLifetime: "1h"
           # connectAttributes:
-            # tx_isolation: 'READ-COMMITTED'
+          # tx_isolation: 'READ-COMMITTED'
 
       visibility:
         driver: "cassandra"
@@ -176,6 +176,7 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    additionalEnv: []
 
   history:
     # replicaCount: 1
@@ -195,6 +196,7 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    additionalEnv: []
 
   matching:
     # replicaCount: 1
@@ -214,6 +216,7 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    additionalEnv: []
 
   worker:
     # replicaCount: 1
@@ -233,6 +236,7 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    additionalEnv: []
 
 admintools:
   enabled: true
@@ -250,6 +254,7 @@ admintools:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  additionalEnv: []
 
 web:
   enabled: true
@@ -260,7 +265,6 @@ web:
     routing:
       default_to_namespace: # internal use only
       issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums
-
 
   replicaCount: 1
 
@@ -314,6 +318,8 @@ web:
 
   affinity: {}
 
+  additionalEnv: []
+
 schema:
   setup:
     enabled: true
@@ -355,49 +361,49 @@ grafana:
     dashboardproviders.yaml:
       apiVersion: 1
       providers:
-      - name: 'default'
-        orgId: 1
-        folder: ''
-        type: file
-        disableDeletion: false
-        editable: true
-        options:
-          path: /var/lib/grafana/dashboards/default
+        - name: "default"
+          orgId: 1
+          folder: ""
+          type: file
+          disableDeletion: false
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/default
   datasources:
-   datasources.yaml:
-     apiVersion: 1
-     datasources:
-     - name: TemporalMetrics
-       type: prometheus
-       url: http://{{ .Release.Name }}-prometheus-server
-       access: proxy
-       isDefault: true
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: TemporalMetrics
+          type: prometheus
+          url: http://{{ .Release.Name }}-prometheus-server
+          access: proxy
+          isDefault: true
   dashboards:
-     default:
-       server-general-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/server/server-general.json
-         datasource: TemporalMetrics
-       sdk-general-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/sdk/sdk-general.json
-         datasource: TemporalMetrics
-       misc-advanced-visibility-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/advanced-visibility-specific.json
-         datasource: TemporalMetrics
-       misc-clustermonitoring-kubernetes-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/clustermonitoring-kubernetes.json
-         datasource: TemporalMetrics
-       misc-frontend-service-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/frontend-service-specific.json
-         datasource: TemporalMetrics
-       misc-history-service-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/history-service-specific.json
-         datasource: TemporalMetrics
-       misc-matching-service-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/matching-service-specific.json
-         datasource: TemporalMetrics
-       misc-worker-service-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/worker-service-specific.json
-         datasource: TemporalMetrics
+    default:
+      server-general-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/server/server-general.json
+        datasource: TemporalMetrics
+      sdk-general-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/sdk/sdk-general.json
+        datasource: TemporalMetrics
+      misc-advanced-visibility-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/advanced-visibility-specific.json
+        datasource: TemporalMetrics
+      misc-clustermonitoring-kubernetes-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/clustermonitoring-kubernetes.json
+        datasource: TemporalMetrics
+      misc-frontend-service-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/frontend-service-specific.json
+        datasource: TemporalMetrics
+      misc-history-service-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/history-service-specific.json
+        datasource: TemporalMetrics
+      misc-matching-service-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/matching-service-specific.json
+        datasource: TemporalMetrics
+      misc-worker-service-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/worker-service-specific.json
+        datasource: TemporalMetrics
 
 cassandra:
   enabled: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Ability to have additional environment variable in deployment like so : 

- Globally for server (will be applied to all service deployment)

```yaml
server:
  additionalEnv:
    - name: "HELLO"
      valueFrom:
        secretKeyRef:
          name: temporal-default-store
          key: world
    - name: "WORLD"
      valueFrom:
        secretKeyRef:
          name: temporal-default-store
          key: hello
```

- For specific services only

```yaml
server:
  frontend:
    additionalEnv:
      - name: "HELLO"
        valueFrom:
          secretKeyRef:
            name: temporal-default-store
            key: world
      - name: "WORLD"
        valueFrom:
          secretKeyRef:
            name: temporal-default-store
            key: hello
```

- For global server + service override

```yaml
server:
  additionalEnv:
    - name: "HELLO"
      valueFrom:
        secretKeyRef:
          name: temporal-default-store
          key: world
    - name: "WORLD"
      valueFrom:
        secretKeyRef:
          name: temporal-default-store
          key: hello

  history:
    additionalEnv:
      - name: "HELLO_OVERRIDE"
        valueFrom:
          secretKeyRef:
            name: temporal-default-store
            key: world
      - name: "WORLD_OVERRIDE"
        valueFrom:
          secretKeyRef:
            name: temporal-default-store
            key: hello
```

- For web deployment

```yaml
web:
  additionalEnv:
    - name: "HELLO"
      valueFrom:
        secretKeyRef:
          name: temporal-default-store
          key: world
    - name: "WORLD"
      valueFrom:
        secretKeyRef:
          name: temporal-default-store
          key: hello
```

- For admintools deployment

```yaml
admintools:
  additionalEnv:
    - name: "HELLO"
      valueFrom:
        secretKeyRef:
          name: temporal-default-store
          key: world
    - name: "WORLD"
      valueFrom:
        secretKeyRef:
          name: temporal-default-store
          key: hello
```

## Why?
It's a commonly asked feature to add additional environment variables to deployments

## Checklist
<!--- add/delete as needed --->

1. Closes
No

3. How was this tested:
Locally with multiple additional environment variables

4. Any docs updates needed?
No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
