### PR TITLE
Remove unreliable not required service check using nslookup

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -272,10 +272,6 @@ spec:
       {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
-        # TODO: replace it with dig as nslookup is unreliable
-        # - name: check-elasticsearch-service
-        #   image: busybox
-        #   command: ['sh', '-c', 'until nslookup {{ .Values.elasticsearch.host }}; do echo waiting for elasticsearch service; sleep 1; done;']
         - name: check-elasticsearch
           image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -272,9 +272,10 @@ spec:
       {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
-        - name: check-elasticsearch-service
-          image: busybox
-          command: ['sh', '-c', 'until nslookup {{ .Values.elasticsearch.host }}; do echo waiting for elasticsearch service; sleep 1; done;']
+        # TODO: replace it with dig as nslookup is unreliable
+        # - name: check-elasticsearch-service
+        #   image: busybox
+        #   command: ['sh', '-c', 'until nslookup {{ .Values.elasticsearch.host }}; do echo waiting for elasticsearch service; sleep 1; done;']
         - name: check-elasticsearch
           image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}

--- a/values.yaml
+++ b/values.yaml
@@ -327,7 +327,7 @@ elasticsearch:
   replicas: 3
   persistence:
     enabled: false
-  imageTag: 7.16.2
+  imageTag: 7.17.3
   host: elasticsearch-master-headless
   scheme: http
   port: 9200


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Removed unreliable not required service check using nslookup
Updated default values elasticsearch image tag version to match Chart dependencies. 

## Why?
nslookup returns with an exit status of 1 if any query failed and 0 otherwise.
```
% kubectl exec -it temporaltest-admintools-7bf55d4b8f-nhrxb -- cat /etc/resolv.conf
search default.svc.cluster.local svc.cluster.local cluster.local
nameserver 10.96.0.10
options ndots:5

% kubectl exec -it temporaltest-admintools-7bf55d4b8f-nhrxb -- bash -c 'set -x; nslookup -type=a -debug elasticsearch-master-headless; echo $?'
+ nslookup -type=a -debug elasticsearch-master-headless
Server:		10.96.0.10
Address:	10.96.0.10:53

Query #2 completed in 10ms:
** server can't find elasticsearch-master-headless.cluster.local: NXDOMAIN

Query #1 completed in 10ms:
** server can't find elasticsearch-master-headless.svc.cluster.local: NXDOMAIN

Query #0 completed in 10ms:
authoritative answer:
Name:	elasticsearch-master-headless.default.svc.cluster.local
Address: 10.244.2.95
Name:	elasticsearch-master-headless.default.svc.cluster.local
Address: 10.244.3.83
Name:	elasticsearch-master-headless.default.svc.cluster.local
Address: 10.244.1.91

+ echo 1
1

% kubectl exec -it temporaltest-admintools-7bf55d4b8f-nhrxb -- bash -c 'set -x; nslookup -type=a -debug elasticsearch-master-headless.default.svc.cluster.local; echo $?'
+ nslookup -type=a -debug elasticsearch-master-headless.default.svc.cluster.local
Server:		10.96.0.10
Address:	10.96.0.10:53

Query #0 completed in 10ms:
authoritative answer:
Name:	elasticsearch-master-headless.default.svc.cluster.local
Address: 10.244.2.95
Name:	elasticsearch-master-headless.default.svc.cluster.local
Address: 10.244.1.91
Name:	elasticsearch-master-headless.default.svc.cluster.local
Address: 10.244.3.83

+ echo 0
0
```

This check is unnecessary as the next check will block waiting for elasticsearch to start.
In case this check is required, replace it with `dig`.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
Locally

3. Any docs updates needed?
No