### PR TITLE
Bump default server version values to 1.19.0

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ server:
   sidecarContainers:
   image:
     repository: temporalio/server
-    tag: 1.18.5
+    tag: 1.19.0
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -238,7 +238,7 @@ admintools:
   enabled: true
   image:
     repository: temporalio/admin-tools
-    tag: 1.18.5
+    tag: 1.19.0
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bumped default server version values to 1.19.0

## Why?
To match the latest release version.

## Checklist
<!--- add/delete as needed --->

1. Closes #344

3. How was this tested:
Locally.

4. Any docs updates needed?
Release process update.
