### PR TITLE
add hints for prod deployments

### DIFF
--- a/values/values.postgresql.yaml
+++ b/values/values.postgresql.yaml
@@ -11,8 +11,15 @@ server:
           database: temporal
           user: _USERNAME_
           password: _PASSWORD_
+          # for a production deployment use this instead of `password` and provision the secret beforehand e.g. with a sealed secret
+          # it has a single key called `password`
+          # existingSecret: temporal-default-store
           maxConns: 20
           maxConnLifetime: "1h"
+          # tls:
+          #  enabled: true
+          #  enableHostVerification: true
+          #  serverName: _HOST_ # this is strictly required when using serverless CRDB offerings
 
       visibility:
         driver: "sql"
@@ -24,8 +31,15 @@ server:
           database: temporal_visibility
           user: _USERNAME_
           password: _PASSWORD_
+          # for a production deployment use this instead of `password` and provision the secret beforehand e.g. with a sealed secret
+          # it has a single key called `password`
+          # existingSecret: temporal-visibility-store
           maxConns: 20
           maxConnLifetime: "1h"
+          # tls:
+          #  enabled: true
+          #  enableHostVerification: true
+          #  serverName: _HOST_ # this is strictly required when using serverless CRDB offerings
 
 cassandra:
   enabled: false
@@ -34,6 +48,15 @@ mysql:
   enabled: false
 
 postgresql:
+  enabled: true
+
+prometheus:
+  enabled: true
+
+grafana:
+  enabled: true
+  
+elasticsearch:
   enabled: true
 
 schema:


### PR DESCRIPTION
## What was changed
This adds more example values to the postgres values file

## Why?
It took me far too long to figure out these values as the aren't documented and I had look through the source code

## Checklist
2. How was this tested:
It's only commented out/already set default values. But when commenting those then, that's what we use for our deployments

3. Any docs updates needed?
Maybe it would make sense to add this to the docs too, but they are already pretty long and the point you to this file anyway
