### PR TITLE
Add PostgreSQL schema jobs

### DIFF
--- a/templates/server-job-postgres.yaml
+++ b/templates/server-job-postgres.yaml
@@ -49,7 +49,7 @@ spec:
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           command: ['sh', '-c', 'until pg_isready --host={{ .Values.server.config.persistence.default.sql.host }} --port={{ .Values.server.config.persistence.default.sql.port }}; do echo waiting for postgres to start; sleep 1; done;']
         {{- range $store := (list "temporal" "temporal_visibility") }}
-        - name: create-{{ $store }}-store
+        - name: create-{{ $store | replace "_" "-"}}-store
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres create']
@@ -65,7 +65,7 @@ spec:
         {{- end }}
       containers:
         {{- range $store := (list "temporal" "temporal_visibility") }}
-        - name: {{ $store }}-schema
+        - name: {{ $store | replace "_" "-"}}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres setup-schema -v 0.0']
@@ -146,14 +146,13 @@ spec:
           command: ['sh', '-c', 'until pg_isready --host={{ $.Values.server.config.persistence.default.sql.host }} --port={{ $.Values.server.config.persistence.default.sql.port }}; do echo waiting for postgres to start; sleep 1; done;']
       containers:
         {{- range $store := (list "temporal" "temporal_visibility") }}
-        - name: {{ $store }}-schema
+        - name: {{ $store | replace "_" "-" }}-schema-update
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-        - name: {{ $store }}-schema
           {{ if eq $store "temporal" }}
           command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/temporal/versioned']
           {{ else }}
-          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/visibility/versioned']
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store | replace "_" "-" }} --plugin postgres update-schema -d ./schema/postgresql/v96/visibility/versioned']
           {{ end }}
           env:
             - name: SQL_HOST
@@ -165,72 +164,6 @@ spec:
             - name: SQL_PASSWORD
               value: {{ $.Values.server.config.persistence.default.sql.password }}
         {{- end }}
-      {{- with (default $.Values.admintools.nodeSelector) }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.admintools.affinity }}
-      affinity:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.admintools.tolerations }}
-      tolerations:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
----
-{{- end }}
-{{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{ include "temporal.componentname" (list . "es-index-setup") }}
-  labels:
-    app.kubernetes.io/name: {{ include "temporal.name" . }}
-    helm.sh/chart: {{ include "temporal.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
-    app.kubernetes.io/component: database
-    app.kubernetes.io/part-of: {{ .Chart.Name }}
-  annotations:
-    {{- if .Values.elasticsearch.external }}
-    "helm.sh/hook": pre-install
-    {{- else }}
-    "helm.sh/hook": post-install
-    {{- end }}
-    "helm.sh/hook-weight": "0"
-    {{- if not .Values.debug }}
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
-    {{- end }}
-spec:
-  backoffLimit: {{ .Values.schema.setup.backoffLimit }}
-  template:
-    metadata:
-      name: {{ include "temporal.componentname" (list . "es-index-setup") }}
-      labels:
-        app.kubernetes.io/name: {{ include "temporal.name" . }}
-        helm.sh/chart: {{ include "temporal.chart" . }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
-        app.kubernetes.io/component: database
-        app.kubernetes.io/part-of: {{ .Chart.Name }}
-    spec:
-      {{ include "temporal.serviceAccount" . }}
-      restartPolicy: "OnFailure"
-      initContainers:
-        - name: check-elasticsearch
-          image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
-          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'until curl --silent --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
-      containers:
-        - name: create-elasticsearch-index
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
-          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c']
-          args:
-            - 'curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_{{ .Values.elasticsearch.version }}.json" 2>&1 &&
-              curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }} 2>&1'
       {{- with (default $.Values.admintools.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/server-job-postgres.yaml
+++ b/templates/server-job-postgres.yaml
@@ -1,0 +1,243 @@
+{{- if $.Values.server.enabled }}
+{{- if .Values.schema.setup.enabled }}
+{{- if and (eq .Values.server.config.persistence.default.driver "sql") (eq .Values.server.config.persistence.default.sql.driver "postgres")}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "temporal.componentname" (list . "schema-setup") }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if .Values.postgresql.enabled }}
+    "helm.sh/hook": post-install
+    {{- else }}
+    "helm.sh/hook": pre-install
+    {{- end }}
+    "helm.sh/hook-weight": "0"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.setup.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "temporal.componentname" (list . "schema-setup") }}
+      labels:
+        app.kubernetes.io/name: {{ include "temporal.name" . }}
+        helm.sh/chart: {{ include "temporal.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      {{ include "temporal.serviceAccount" . }}
+      restartPolicy: "OnFailure"
+      initContainers:
+        - name: check-postgresql-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ .Values.server.config.persistence.default.sql.host }}; do echo waiting for postgresql domain; sleep 1; done;']
+        - name: check-postgresql
+          image: "{{ .Values.postgresql.image.repo }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          command: ['sh', '-c', 'until pg_isready --host={{ .Values.server.config.persistence.default.sql.host }} --port={{ .Values.server.config.persistence.default.sql.port }}; do echo waiting for postgres to start; sleep 1; done;']
+        {{- range $store := (list "temporal" "temporal_visibility") }}
+        - name: create-{{ $store }}-store
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres create']
+          env:
+            - name: SQL_HOST
+              value: {{ $.Values.server.config.persistence.default.sql.host }}
+            - name: SQL_PORT
+              value: {{ $.Values.server.config.persistence.default.sql.port }}
+            - name: SQL_USER
+              value: {{ $.Values.server.config.persistence.default.sql.user }}
+            - name: SQL_PASSWORD
+              value: {{ $.Values.server.config.persistence.default.sql.password }}
+        {{- end }}
+      containers:
+        {{- range $store := (list "temporal" "visibility") }}
+        - name: {{ $store }}-schema
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres setup-schema -v 0.0']
+          env:
+            - name: SQL_HOST
+              value: {{ $.Values.server.config.persistence.default.sql.host }}
+            - name: SQL_PORT
+              value: {{ $.Values.server.config.persistence.default.sql.port }}
+            - name: SQL_USER
+              value: {{ $.Values.server.config.persistence.default.sql.user }}
+            - name: SQL_PASSWORD
+              value: {{ $.Values.server.config.persistence.default.sql.password }}
+        {{- end }}
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default $.Values.server.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+{{- end }}
+{{- if .Values.schema.update.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "temporal.componentname" (list . "schema-update") }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if .Values.postgresql.enabled }}
+    "helm.sh/hook": post-install,pre-upgrade
+    {{- else }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    {{- end }}
+    "helm.sh/hook-weight": "1"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.update.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "temporal.componentname" (list . "schema-update") }}
+      labels:
+        app.kubernetes.io/name: {{ include "temporal.name" . }}
+        helm.sh/chart: {{ include "temporal.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      {{ include "temporal.serviceAccount" . }}
+      restartPolicy: "OnFailure"
+      initContainers:
+        - name: check-postgresql-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ $.Values.server.config.persistence.default.sql.host }}; do echo waiting for postgresql domain; sleep 1; done;']
+        - name: check-postgresql
+          image: "{{ $.Values.postgresql.image.repo }}:{{ $.Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ $.Values.postgresql.image.pullPolicy }}
+          command: ['sh', '-c', 'until pg_isready --host={{ $.Values.server.config.persistence.default.sql.host }} --port={{ $.Values.server.config.persistence.default.sql.port }}; do echo waiting for postgres to start; sleep 1; done;']
+      containers:
+        {{- range $store := (list "temporal" "temporal_visibility") }}
+        - name: {{ $store }}-schema
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/temporal/versioned']
+          env:
+            - name: SQL_HOST
+              value: {{ $.Values.server.config.persistence.default.sql.host }}
+            - name: SQL_PORT
+              value: {{ $.Values.server.config.persistence.default.sql.port }}
+            - name: SQL_USER
+              value: {{ $.Values.server.config.persistence.default.sql.user }}
+            - name: SQL_PASSWORD
+              value: {{ $.Values.server.config.persistence.default.sql.password }}
+        {{- end }}
+      {{- with (default $.Values.admintools.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+{{- end }}
+{{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "temporal.componentname" (list . "es-index-setup") }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if .Values.elasticsearch.external }}
+    "helm.sh/hook": pre-install
+    {{- else }}
+    "helm.sh/hook": post-install
+    {{- end }}
+    "helm.sh/hook-weight": "0"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.setup.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "temporal.componentname" (list . "es-index-setup") }}
+      labels:
+        app.kubernetes.io/name: {{ include "temporal.name" . }}
+        helm.sh/chart: {{ include "temporal.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      {{ include "temporal.serviceAccount" . }}
+      restartPolicy: "OnFailure"
+      initContainers:
+        - name: check-elasticsearch
+          image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'until curl --silent --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
+      containers:
+        - name: create-elasticsearch-index
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c']
+          args:
+            - 'curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_{{ .Values.elasticsearch.version }}.json" 2>&1 &&
+              curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }} 2>&1'
+      {{- with (default $.Values.admintools.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/server-job-postgres.yaml
+++ b/templates/server-job-postgres.yaml
@@ -139,7 +139,7 @@ spec:
       initContainers:
         - name: check-postgresql-service
           image: busybox
-          command: ['sh', '-c', 'until nslookup {{ $.Values.server.config.persistence.default.sql.host }}; do echo waiting for postgresql domain; sleep 1; done;']
+          command: ['sh', '-c', 'until nslookup {{ .Values.server.config.persistence.default.sql.host }}; do echo waiting for postgresql domain; sleep 1; done;']
         - name: check-postgresql
           image: "{{ $.Values.postgresql.image.repo }}:{{ $.Values.postgresql.image.tag }}"
           imagePullPolicy: {{ $.Values.postgresql.image.pullPolicy }}

--- a/templates/server-job-postgres.yaml
+++ b/templates/server-job-postgres.yaml
@@ -64,7 +64,7 @@ spec:
               value: {{ $.Values.server.config.persistence.default.sql.password }}
         {{- end }}
       containers:
-        {{- range $store := (list "temporal" "visibility") }}
+        {{- range $store := (list "temporal" "temporal_visibility") }}
         - name: {{ $store }}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
@@ -149,7 +149,12 @@ spec:
         - name: {{ $store }}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+        - name: {{ $store }}-schema
+          {{ if eq $store "temporal" }}
           command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/temporal/versioned']
+          {{ else }}
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/visibility/versioned']
+          {{ end }}
           env:
             - name: SQL_HOST
               value: {{ $.Values.server.config.persistence.default.sql.host }}

--- a/values/values.postgresql.yaml
+++ b/values/values.postgresql.yaml
@@ -35,9 +35,13 @@ mysql:
 
 postgresql:
   enabled: true
+  image:
+    repo: postgres
+    tag: 15.1
+    pullPolicy: IfNotPresent
 
 schema:
   setup:
-    enabled: false
+    enabled: true
   update:
-    enabled: false
+    enabled: true

--- a/values/values.postgresql.yaml
+++ b/values/values.postgresql.yaml
@@ -6,11 +6,11 @@ server:
 
         sql:
           driver: "postgres"
-          host: _HOST_
+          host: "rokerage-dev-db-temporal.cluster-cy2utjok3e0t.eu-central-1.rds.amazonaws.com"
           port: 5432
           database: temporal
-          user: _USERNAME_
-          password: _PASSWORD_
+          user: master
+          password: "KkLyDxZmHZssEwCtpE6D3mWpIilQL3qE"
           maxConns: 20
           maxConnLifetime: "1h"
 
@@ -19,11 +19,11 @@ server:
 
         sql:
           driver: "postgres"
-          host: _HOST_
+          host: "rokerage-dev-db-temporal.cluster-cy2utjok3e0t.eu-central-1.rds.amazonaws.com"
           port: 5432
           database: temporal_visibility
-          user: _USERNAME_
-          password: _PASSWORD_
+          user: master
+          password: "KkLyDxZmHZssEwCtpE6D3mWpIilQL3qE"
           maxConns: 20
           maxConnLifetime: "1h"
 


### PR DESCRIPTION
## What was changed
Add kubernetes job to support database schema migration and updates on PostgreSQL. Also updated `values.postgresql.yaml` to reflect this 

## Why?
Current workplace uses a Bring Your Own PostgreSQL and having this change upstream would be simple for more people.

## Checklist

1. Closes #349 

2. How was this tested:
Set up a brand new PostgreSQL; provide hostname, username, and password, and set enable 

```
schema:
  setup:
    enabled: true
  update:
    enabled: true
```

3. Any docs updates needed?
No
