### PR TITLE
fix: missing command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ export SQL_PORT=3306
 export SQL_USER=mysql_user
 export SQL_PASSWORD=mysql_password
 
+make temporal-sql-tool
+
 ./temporal-sql-tool create-database -database temporal
 SQL_DATABASE=temporal ./temporal-sql-tool setup-schema -v 0.0
 SQL_DATABASE=temporal ./temporal-sql-tool update -schema-dir schema/mysql/v57/temporal/versioned
@@ -180,6 +182,8 @@ export SQL_HOST=postgresql_host
 export SQL_PORT=5432
 export SQL_USER=postgresql_user
 export SQL_PASSWORD=postgresql_password
+
+make temporal-sql-tool
 
 ./temporal-sql-tool create-database -database temporal
 SQL_DATABASE=temporal ./temporal-sql-tool setup-schema -v 0.0


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added missing `make temporal-sql-tool` command in README.

## Why?
<!-- Tell your future self why have you made these changes -->
During my build, I found that the `Install with your own PostgreSQL` stage was missing the method that how to build the temporal-sql-tool.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

None.

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Testing on my own device.

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Yes. The README.md was changed.
