### PR TITLE
make chart more configurable

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -49,7 +49,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.20.0
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -55,6 +55,18 @@ spec:
                 - /
               initialDelaySeconds: 5
               periodSeconds: 5
+          {{- with .Values.admintools.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.admintools.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.admintools.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -44,12 +44,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{ include "temporal.serviceAccount" $ }}
+      {{- include "temporal.serviceAccount" $ }}
       {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       {{- if semverCompare ">=1.13.0" $.Chart.AppVersion}}
+      {{- with $.Values.server.securityContext }}
       securityContext:
-        fsGroup: 1000 #temporal group
-        runAsUser: 1000 #temporal user
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       initContainers:
         {{- if $.Values.cassandra.enabled }}
@@ -141,10 +142,13 @@ spec:
             {{- end }}
           resources:
             {{- toYaml (default $.Values.server.resources $serviceValues.resources) | nindent 12 }}
+          {{- with $serviceValues.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if $.Values.server.sidecarContainers }}
         {{- toYaml $.Values.server.sidecarContainers | nindent 8 }}
         {{- end }}
-
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}
@@ -172,6 +176,10 @@ spec:
     {{- end }}
     {{- with (default $.Values.server.tolerations $serviceValues.tolerations) }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with $serviceValues.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
     {{- end }}
 ---

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -36,7 +36,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
-      {{ include "temporal.serviceAccount" . }}
+      {{- include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
         {{- if or .Values.cassandra.enabled (eq (include "temporal.persistence.driver" (list $ "default")) "cassandra") (eq (include "temporal.persistence.driver" (list $ "visibility")) "cassandra") }}
@@ -115,6 +115,18 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
+          {{- with .Values.schema.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.schema.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.schema.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -170,7 +182,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
-      {{ include "temporal.serviceAccount" . }}
+      {{- include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
         {{- if .Values.cassandra.enabled }}
@@ -218,6 +230,18 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
+          {{- with .Values.schema.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.schema.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.schema.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default $.Values.admintools.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -269,7 +293,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
-      {{ include "temporal.serviceAccount" . }}
+      {{- include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
         - name: check-elasticsearch
@@ -284,6 +308,18 @@ spec:
           args:
             - 'curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_{{ .Values.elasticsearch.version }}.json" 2>&1 &&
               curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }} 2>&1'
+          {{- with .Values.schema.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.schema.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.schema.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (default $.Values.admintools.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/server-pdb.yaml
+++ b/templates/server-pdb.yaml
@@ -1,0 +1,27 @@
+{{- if $.Values.server.enabled }}
+{{- range $service := (list "frontend" "history" "matching" "worker") }}
+{{- $serviceValues := index $.Values.server $service -}}
+{{- if and (gt ($serviceValues.replicaCount | int) 1) ($serviceValues.podDisruptionBudget) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: 
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" $ }}
+    helm.sh/chart: {{ include "temporal.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: {{ $service }}
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
+spec:
+  {{ toYaml $serviceValues.podDisruptionBudget }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "temporal.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/component: {{ $service }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -54,6 +54,14 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
+          {{- with .Values.web.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.web.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.web.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,7 @@ serviceAccount:
 
 server:
   enabled: true
-  sidecarContainers:
+  sidecarContainers: {}
   image:
     repository: temporalio/server
     tag: 1.20.0
@@ -80,6 +80,9 @@ server:
   affinity: {}
   additionalVolumes: []
   additionalVolumeMounts: []
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
 
   config:
     logLevel: "debug,info"
@@ -158,7 +161,7 @@ server:
           #   tx_isolation: 'READ-COMMITTED'
 
   frontend:
-    # replicaCount: 1
+    replicaCount: 1
     service:
       annotations: {} # Evaluated as template
       type: ClusterIP
@@ -176,9 +179,12 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    containerSecurityContext: {}
+    topologySpreadConstraints: {}
+    podDisruptionBudget: {}
 
   history:
-    # replicaCount: 1
+    replicaCount: 1
     service:
       # type: ClusterIP
       port: 7234
@@ -195,9 +201,12 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    containerSecurityContext: {}
+    topologySpreadConstraints: {}
+    podDisruptionBudget: {}
 
   matching:
-    # replicaCount: 1
+    replicaCount: 1
     service:
       # type: ClusterIP
       port: 7235
@@ -214,9 +223,12 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    containerSecurityContext: {}
+    topologySpreadConstraints: {}
+    podDisruptionBudget: {}
 
   worker:
-    # replicaCount: 1
+    replicaCount: 1
     service:
       # type: ClusterIP
       port: 7239
@@ -233,6 +245,9 @@ server:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    containerSecurityContext: {}
+    topologySpreadConstraints: {}
+    podDisruptionBudget: {}
 
 admintools:
   enabled: true
@@ -250,6 +265,10 @@ admintools:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  resources: {}
+  containerSecurityContext: {}
+  securityContext: {}
+  podDisruptionBudget: {}
 
 web:
   enabled: true
@@ -314,6 +333,10 @@ web:
 
   affinity: {}
 
+  containerSecurityContext: {}
+  
+  securityContext: {}
+
 schema:
   setup:
     enabled: true
@@ -321,6 +344,9 @@ schema:
   update:
     enabled: true
     backoffLimit: 100
+  resources: {}
+  containerSecurityContext: {}
+  securityContext: {}
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

* make securityContexts for pod & container configurable everywhere
* add resources config where not possible yet (schema & server-job)
* added configurable topologySpreadConstraints
* added configurable podDisruptionBudget for server components
* removed some blank lines from rendered resources
* current default settings are not changed

## Why?
<!-- Tell your future self why have you made these changes -->

* some resources not configurable which is problematic in clusters which enforce some of these settings via policies

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

`helm template .`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
