### PR TITLE
Overwrite the schema during initialization step

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -89,7 +89,7 @@ spec:
         - name: {{ $store }}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ["temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool", "setup-schema", "-v", "0.0"]
+          command: ["temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool", "setup-schema", "-o", "-v", "0.0"]
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a flag to overwrite schema during the schema initialization step.
```
$ temporal-cassandra-tool setup-schema -h
NAME:
   temporal-cassandra-tool setup-schema - setup initial version of cassandra schema

USAGE:
   temporal-cassandra-tool setup-schema [command options] [arguments...]

OPTIONS:
   --version value, -v value      initial version of the schema, cannot be used with disable-versioning
   --schema-file value, -f value  path to the .cql schema file; if un-specified, will just setup versioning tables
   --disable-versioning, -d       disable setup of schema versioning
   --overwrite, -o                drop all existing tables before setting up new schema
```

## Why?
Sometimes the schema-update step fails due to incorrectly setup-schema results. I guess the job is being restarted in the middle of the process, leaving the DB in the wrong state and not allowing it to proceed with the schema-update process.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
CICD

3. Any docs updates needed?
No