### PR TITLE
Revert services replicaCount to inherit from the global config

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -163,7 +163,6 @@ server:
           #   tx_isolation: 'READ-COMMITTED'
 
   frontend:
-    replicaCount: 1
     service:
       annotations: {} # Evaluated as template
       type: ClusterIP
@@ -187,7 +186,6 @@ server:
     podDisruptionBudget: {}
 
   history:
-    replicaCount: 1
     service:
       # type: ClusterIP
       port: 7234
@@ -210,7 +208,6 @@ server:
     podDisruptionBudget: {}
 
   matching:
-    replicaCount: 1
     service:
       # type: ClusterIP
       port: 7235
@@ -233,7 +230,6 @@ server:
     podDisruptionBudget: {}
 
   worker:
-    replicaCount: 1
     service:
       # type: ClusterIP
       port: 7239


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Reverted the `replicaCount` change for services made in #365.

## Why?
Allow inheriting the value from the global config of the `server.replicaCount`.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
CICD

3. Any docs updates needed?
No