### PR TITLE
fix: disable whitespace removal for include temporal.serviceAccount

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -44,7 +44,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "temporal.serviceAccount" $ }}
+      {{ include "temporal.serviceAccount" $ }}
       {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       {{- if semverCompare ">=1.13.0" $.Chart.AppVersion}}
       {{- with $.Values.server.securityContext }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -36,7 +36,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
-      {{- include "temporal.serviceAccount" . }}
+      {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
         {{- if or .Values.cassandra.enabled (eq (include "temporal.persistence.driver" (list $ "default")) "cassandra") (eq (include "temporal.persistence.driver" (list $ "visibility")) "cassandra") }}
@@ -182,7 +182,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
-      {{- include "temporal.serviceAccount" . }}
+      {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
         {{- if .Values.cassandra.enabled }}
@@ -293,7 +293,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
-      {{- include "temporal.serviceAccount" . }}
+      {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
       initContainers:
         - name: check-elasticsearch


### PR DESCRIPTION
Fixes issue: https://github.com/temporalio/helm-charts/issues/380

## What was changed
Removed the hyphen (`-`) at the beginning of the `include` function. It was causing all whitespaces to be removed from the output resulting in `serviceAccount: ...` to be on the same line as the previous statement. 