### PR TITLE
Fix postgresql schema

### DIFF
--- a/templates/server-job-postgres.yaml
+++ b/templates/server-job-postgres.yaml
@@ -49,7 +49,7 @@ spec:
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           command: ['sh', '-c', 'until pg_isready --host={{ .Values.server.config.persistence.default.sql.host }} --port={{ .Values.server.config.persistence.default.sql.port }}; do echo waiting for postgres to start; sleep 1; done;']
         {{- range $store := (list "temporal" "temporal_visibility") }}
-        - name: create-{{ $store }}-store
+        - name: create-{{ $store | replace "_" "-"}}-store
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres create']
@@ -65,7 +65,7 @@ spec:
         {{- end }}
       containers:
         {{- range $store := (list "temporal" "temporal_visibility") }}
-        - name: {{ $store }}-schema
+        - name: {{ $store | replace "_" "-"}}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres setup-schema -v 0.0']
@@ -146,14 +146,13 @@ spec:
           command: ['sh', '-c', 'until pg_isready --host={{ $.Values.server.config.persistence.default.sql.host }} --port={{ $.Values.server.config.persistence.default.sql.port }}; do echo waiting for postgres to start; sleep 1; done;']
       containers:
         {{- range $store := (list "temporal" "temporal_visibility") }}
-        - name: {{ $store }}-schema
+        - name: {{ $store | replace "_" "-" }}-schema-update
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-        - name: {{ $store }}-schema
           {{ if eq $store "temporal" }}
           command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/temporal/versioned']
           {{ else }}
-          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/visibility/versioned']
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store | replace "_" "-" }} --plugin postgres update-schema -d ./schema/postgresql/v96/visibility/versioned']
           {{ end }}
           env:
             - name: SQL_HOST
@@ -165,72 +164,6 @@ spec:
             - name: SQL_PASSWORD
               value: {{ $.Values.server.config.persistence.default.sql.password }}
         {{- end }}
-      {{- with (default $.Values.admintools.nodeSelector) }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.admintools.affinity }}
-      affinity:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.admintools.tolerations }}
-      tolerations:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
----
-{{- end }}
-{{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{ include "temporal.componentname" (list . "es-index-setup") }}
-  labels:
-    app.kubernetes.io/name: {{ include "temporal.name" . }}
-    helm.sh/chart: {{ include "temporal.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
-    app.kubernetes.io/component: database
-    app.kubernetes.io/part-of: {{ .Chart.Name }}
-  annotations:
-    {{- if .Values.elasticsearch.external }}
-    "helm.sh/hook": pre-install
-    {{- else }}
-    "helm.sh/hook": post-install
-    {{- end }}
-    "helm.sh/hook-weight": "0"
-    {{- if not .Values.debug }}
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
-    {{- end }}
-spec:
-  backoffLimit: {{ .Values.schema.setup.backoffLimit }}
-  template:
-    metadata:
-      name: {{ include "temporal.componentname" (list . "es-index-setup") }}
-      labels:
-        app.kubernetes.io/name: {{ include "temporal.name" . }}
-        helm.sh/chart: {{ include "temporal.chart" . }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
-        app.kubernetes.io/component: database
-        app.kubernetes.io/part-of: {{ .Chart.Name }}
-    spec:
-      {{ include "temporal.serviceAccount" . }}
-      restartPolicy: "OnFailure"
-      initContainers:
-        - name: check-elasticsearch
-          image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
-          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'until curl --silent --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
-      containers:
-        - name: create-elasticsearch-index
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
-          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c']
-          args:
-            - 'curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_{{ .Values.elasticsearch.version }}.json" 2>&1 &&
-              curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }} 2>&1'
       {{- with (default $.Values.admintools.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/server-job-postgres.yaml
+++ b/templates/server-job-postgres.yaml
@@ -1,0 +1,243 @@
+{{- if $.Values.server.enabled }}
+{{- if .Values.schema.setup.enabled }}
+{{- if and (eq .Values.server.config.persistence.default.driver "sql") (eq .Values.server.config.persistence.default.sql.driver "postgres")}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "temporal.componentname" (list . "schema-setup") }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if .Values.postgresql.enabled }}
+    "helm.sh/hook": post-install
+    {{- else }}
+    "helm.sh/hook": pre-install
+    {{- end }}
+    "helm.sh/hook-weight": "0"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.setup.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "temporal.componentname" (list . "schema-setup") }}
+      labels:
+        app.kubernetes.io/name: {{ include "temporal.name" . }}
+        helm.sh/chart: {{ include "temporal.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      {{ include "temporal.serviceAccount" . }}
+      restartPolicy: "OnFailure"
+      initContainers:
+        - name: check-postgresql-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ .Values.server.config.persistence.default.sql.host }}; do echo waiting for postgresql domain; sleep 1; done;']
+        - name: check-postgresql
+          image: "{{ .Values.postgresql.image.repo }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          command: ['sh', '-c', 'until pg_isready --host={{ .Values.server.config.persistence.default.sql.host }} --port={{ .Values.server.config.persistence.default.sql.port }}; do echo waiting for postgres to start; sleep 1; done;']
+        {{- range $store := (list "temporal" "temporal_visibility") }}
+        - name: create-{{ $store }}-store
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres create']
+          env:
+            - name: SQL_HOST
+              value: {{ $.Values.server.config.persistence.default.sql.host }}
+            - name: SQL_PORT
+              value: {{ $.Values.server.config.persistence.default.sql.port }}
+            - name: SQL_USER
+              value: {{ $.Values.server.config.persistence.default.sql.user }}
+            - name: SQL_PASSWORD
+              value: {{ $.Values.server.config.persistence.default.sql.password }}
+        {{- end }}
+      containers:
+        {{- range $store := (list "temporal" "visibility") }}
+        - name: {{ $store }}-schema
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres setup-schema -v 0.0']
+          env:
+            - name: SQL_HOST
+              value: {{ $.Values.server.config.persistence.default.sql.host }}
+            - name: SQL_PORT
+              value: {{ $.Values.server.config.persistence.default.sql.port }}
+            - name: SQL_USER
+              value: {{ $.Values.server.config.persistence.default.sql.user }}
+            - name: SQL_PASSWORD
+              value: {{ $.Values.server.config.persistence.default.sql.password }}
+        {{- end }}
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default $.Values.server.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+{{- end }}
+{{- if .Values.schema.update.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "temporal.componentname" (list . "schema-update") }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if .Values.postgresql.enabled }}
+    "helm.sh/hook": post-install,pre-upgrade
+    {{- else }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    {{- end }}
+    "helm.sh/hook-weight": "1"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.update.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "temporal.componentname" (list . "schema-update") }}
+      labels:
+        app.kubernetes.io/name: {{ include "temporal.name" . }}
+        helm.sh/chart: {{ include "temporal.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      {{ include "temporal.serviceAccount" . }}
+      restartPolicy: "OnFailure"
+      initContainers:
+        - name: check-postgresql-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ $.Values.server.config.persistence.default.sql.host }}; do echo waiting for postgresql domain; sleep 1; done;']
+        - name: check-postgresql
+          image: "{{ $.Values.postgresql.image.repo }}:{{ $.Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ $.Values.postgresql.image.pullPolicy }}
+          command: ['sh', '-c', 'until pg_isready --host={{ $.Values.server.config.persistence.default.sql.host }} --port={{ $.Values.server.config.persistence.default.sql.port }}; do echo waiting for postgres to start; sleep 1; done;']
+      containers:
+        {{- range $store := (list "temporal" "temporal_visibility") }}
+        - name: {{ $store }}-schema
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/temporal/versioned']
+          env:
+            - name: SQL_HOST
+              value: {{ $.Values.server.config.persistence.default.sql.host }}
+            - name: SQL_PORT
+              value: {{ $.Values.server.config.persistence.default.sql.port }}
+            - name: SQL_USER
+              value: {{ $.Values.server.config.persistence.default.sql.user }}
+            - name: SQL_PASSWORD
+              value: {{ $.Values.server.config.persistence.default.sql.password }}
+        {{- end }}
+      {{- with (default $.Values.admintools.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+{{- end }}
+{{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "temporal.componentname" (list . "es-index-setup") }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if .Values.elasticsearch.external }}
+    "helm.sh/hook": pre-install
+    {{- else }}
+    "helm.sh/hook": post-install
+    {{- end }}
+    "helm.sh/hook-weight": "0"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.setup.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "temporal.componentname" (list . "es-index-setup") }}
+      labels:
+        app.kubernetes.io/name: {{ include "temporal.name" . }}
+        helm.sh/chart: {{ include "temporal.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      {{ include "temporal.serviceAccount" . }}
+      restartPolicy: "OnFailure"
+      initContainers:
+        - name: check-elasticsearch
+          image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'until curl --silent --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
+      containers:
+        - name: create-elasticsearch-index
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c']
+          args:
+            - 'curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_{{ .Values.elasticsearch.version }}.json" 2>&1 &&
+              curl -X PUT --fail --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}/{{ .Values.elasticsearch.visibilityIndex }} 2>&1'
+      {{- with (default $.Values.admintools.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/server-job-postgres.yaml
+++ b/templates/server-job-postgres.yaml
@@ -139,7 +139,7 @@ spec:
       initContainers:
         - name: check-postgresql-service
           image: busybox
-          command: ['sh', '-c', 'until nslookup {{ $.Values.server.config.persistence.default.sql.host }}; do echo waiting for postgresql domain; sleep 1; done;']
+          command: ['sh', '-c', 'until nslookup {{ .Values.server.config.persistence.default.sql.host }}; do echo waiting for postgresql domain; sleep 1; done;']
         - name: check-postgresql
           image: "{{ $.Values.postgresql.image.repo }}:{{ $.Values.postgresql.image.tag }}"
           imagePullPolicy: {{ $.Values.postgresql.image.pullPolicy }}

--- a/templates/server-job-postgres.yaml
+++ b/templates/server-job-postgres.yaml
@@ -1,6 +1,6 @@
 {{- if $.Values.server.enabled }}
-{{- if .Values.schema.setup.enabled }}
 {{- if and (eq .Values.server.config.persistence.default.driver "sql") (eq .Values.server.config.persistence.default.sql.driver "postgres")}}
+{{- if .Values.schema.setup.enabled }}
 
 apiVersion: batch/v1
 kind: Job
@@ -57,23 +57,24 @@ spec:
             - name: SQL_HOST
               value: {{ $.Values.server.config.persistence.default.sql.host }}
             - name: SQL_PORT
-              value: {{ $.Values.server.config.persistence.default.sql.port }}
+              value: {{ $.Values.server.config.persistence.default.sql.port | quote }}
             - name: SQL_USER
               value: {{ $.Values.server.config.persistence.default.sql.user }}
             - name: SQL_PASSWORD
               value: {{ $.Values.server.config.persistence.default.sql.password }}
         {{- end }}
       containers:
-        {{- range $store := (list "temporal" "temporal_visibility") }}
+        {{- range $store := (list "default" "visibility") }}
+        {{- $storeConfig := index $.Values.server.config.persistence $store }}
         - name: {{ $store | replace "_" "-"}}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres setup-schema -v 0.0']
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $storeConfig.sql.database }} --plugin postgres setup-schema -v 0.0']
           env:
             - name: SQL_HOST
               value: {{ $.Values.server.config.persistence.default.sql.host }}
             - name: SQL_PORT
-              value: {{ $.Values.server.config.persistence.default.sql.port }}
+              value: {{ $.Values.server.config.persistence.default.sql.port | quote }}
             - name: SQL_USER
               value: {{ $.Values.server.config.persistence.default.sql.user }}
             - name: SQL_PASSWORD
@@ -143,22 +144,19 @@ spec:
         - name: check-postgresql
           image: "{{ $.Values.postgresql.image.repo }}:{{ $.Values.postgresql.image.tag }}"
           imagePullPolicy: {{ $.Values.postgresql.image.pullPolicy }}
-          command: ['sh', '-c', 'until pg_isready --host={{ $.Values.server.config.persistence.default.sql.host }} --port={{ $.Values.server.config.persistence.default.sql.port }}; do echo waiting for postgres to start; sleep 1; done;']
+          command: ['sh', '-c', 'until pg_isready --host={{ $.Values.server.config.persistence.default.sql.host }} --port={{ $.Values.server.config.persistence.default.sql.port }} --dbname={{ $.Values.server.config.persistence.default.sql.database }}; do echo waiting for postgres to start; sleep 1; done;']
       containers:
-        {{- range $store := (list "temporal" "temporal_visibility") }}
+        {{- range $store := (list "default" "visibility") }}
+        {{- $storeConfig := index $.Values.server.config.persistence $store }}
         - name: {{ $store | replace "_" "-" }}-schema-update
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          {{ if eq $store "temporal" }}
-          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/temporal/versioned']
-          {{ else }}
-          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store | replace "_" "-" }} --plugin postgres update-schema -d ./schema/postgresql/v96/visibility/versioned']
-          {{ end }}
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $storeConfig.sql.database }} --plugin postgres update-schema -d ./schema/postgresql/v96/{{ include "temporal.persistence.schema" $store }}/versioned']
           env:
             - name: SQL_HOST
               value: {{ $.Values.server.config.persistence.default.sql.host }}
             - name: SQL_PORT
-              value: {{ $.Values.server.config.persistence.default.sql.port }}
+              value: {{ $.Values.server.config.persistence.default.sql.port | quote }}
             - name: SQL_USER
               value: {{ $.Values.server.config.persistence.default.sql.user }}
             - name: SQL_PASSWORD

--- a/templates/server-job-postgres.yaml
+++ b/templates/server-job-postgres.yaml
@@ -64,7 +64,7 @@ spec:
               value: {{ $.Values.server.config.persistence.default.sql.password }}
         {{- end }}
       containers:
-        {{- range $store := (list "temporal" "visibility") }}
+        {{- range $store := (list "temporal" "temporal_visibility") }}
         - name: {{ $store }}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
@@ -149,7 +149,12 @@ spec:
         - name: {{ $store }}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+        - name: {{ $store }}-schema
+          {{ if eq $store "temporal" }}
           command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/temporal/versioned']
+          {{ else }}
+          command: ['sh', '-c', 'temporal-sql-tool --ep $SQL_HOST -p $SQL_PORT -u $SQL_USER --pw $SQL_PASSWORD --db {{ $store }} --plugin postgres update-schema -d ./schema/postgresql/v96/visibility/versioned']
+          {{ end }}
           env:
             - name: SQL_HOST
               value: {{ $.Values.server.config.persistence.default.sql.host }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -1,4 +1,5 @@
 {{- if $.Values.server.enabled }}
+{{- if and (eq .Values.server.config.persistence.default.driver "sql") (eq .Values.server.config.persistence.default.sql.driver "cassandra")}}
 {{- if .Values.schema.setup.enabled }}
 apiVersion: batch/v1
 kind: Job
@@ -332,5 +333,6 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/values/values.postgresql.yaml
+++ b/values/values.postgresql.yaml
@@ -49,6 +49,10 @@ mysql:
 
 postgresql:
   enabled: true
+  image:
+    repo: postgres
+    tag: 15.1
+    pullPolicy: IfNotPresent
 
 prometheus:
   enabled: true
@@ -61,6 +65,6 @@ elasticsearch:
 
 schema:
   setup:
-    enabled: false
+    enabled: true
   update:
-    enabled: false
+    enabled: true

--- a/values/values.postgresql.yaml
+++ b/values/values.postgresql.yaml
@@ -6,7 +6,7 @@ server:
 
         sql:
           driver: "postgres"
-          host: _HOST_
+          host: "rokerage-dev-db-temporal.cluster-cy2utjok3e0t.eu-central-1.rds.amazonaws.com"
           port: 5432
           database: temporal
           user: _USERNAME_
@@ -26,7 +26,7 @@ server:
 
         sql:
           driver: "postgres"
-          host: _HOST_
+          host: "rokerage-dev-db-temporal.cluster-cy2utjok3e0t.eu-central-1.rds.amazonaws.com"
           port: 5432
           database: temporal_visibility
           user: _USERNAME_

--- a/values/values.postgresql.yaml
+++ b/values/values.postgresql.yaml
@@ -6,7 +6,7 @@ server:
 
         sql:
           driver: "postgres"
-          host: "rokerage-dev-db-temporal.cluster-cy2utjok3e0t.eu-central-1.rds.amazonaws.com"
+          host: _HOST_
           port: 5432
           database: temporal
           user: _USERNAME_
@@ -26,7 +26,7 @@ server:
 
         sql:
           driver: "postgres"
-          host: "rokerage-dev-db-temporal.cluster-cy2utjok3e0t.eu-central-1.rds.amazonaws.com"
+          host: _HOST_
           port: 5432
           database: temporal_visibility
           user: _USERNAME_

--- a/values/values.postgresql.yaml
+++ b/values/values.postgresql.yaml
@@ -48,7 +48,7 @@ mysql:
   enabled: false
 
 postgresql:
-  enabled: true
+  enabled: false
   image:
     repo: postgres
     tag: 15.1


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add kubernetes job to support database schema migration and updates on PostgreSQL.

## Why?
<!-- Tell your future self why have you made these changes -->
Current workplace uses a Bring Your Own PostgreSQL and having this change upstream would be simple for more people.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/349

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Deployed Postgresql helm chart then deployed Temporal helm 
Complete logs :

```bash


amine@amine-Latitude-5420:~/Work/Temporal-helm-charts$ helm -n temporal ls
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/amine/.kube/config
NAME      	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART            	APP VERSION
postgresql	temporal 	1       	2023-04-06 10:40:28.211826433 +0000 UTC	deployed	postgresql-12.1.6	15.1.0     


amine@amine-Latitude-5420:~/Work/Temporal-helm-charts$ helm -n temporal install -f temporal-values.yml temporal .
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/amine/.kube/config
NAME: temporal
LAST DEPLOYED: Tue May 16 21:50:23 2023
NAMESPACE: temporal
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
To verify that Temporal has started, run:

  kubectl --namespace=temporal get pods -l "app.kubernetes.io/instance=temporal"



amine@amine-Latitude-5420:~/Work/Temporal-helm-charts$ k -n temporal get pods
NAME                                   READY   STATUS      RESTARTS   AGE
postgresql-0                           1/1     Running     0          40d
temporal-admintools-6ff979d5fb-z5dwr   1/1     Running     0          98s
temporal-frontend-79fc54b7db-mknsd     1/1     Running     0          98s
temporal-history-dd6467bb7-jpt62       1/1     Running     0          98s
temporal-matching-5689b4b4f9-j4bsm     1/1     Running     0          98s
temporal-schema-setup-lzh9n            0/2     Completed   0          2m14s
temporal-schema-update-rlcrm           0/2     Completed   0          108s
temporal-web-fcbfff8c6-cvktl           1/1     Running     0          98s
temporal-worker-7b47ff8568-2xtdk       1/1     Running     0          98s


amine@amine-Latitude-5420:~/Work/Temporal-helm-charts$ helm -n temporal get values temporal
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/amine/.kube/config
USER-SUPPLIED VALUES:
cassandra:
  enabled: false
debug: true
elasticsearch:
  enabled: false
grafana:
  enabled: false
postgresql:
  enabled: false
  image:
    pullPolicy: IfNotPresent
    repo: postgres
    tag: 15.1
prometheus:
  enabled: false
server:
  config:
    persistence:
      default:
        driver: sql
        sql:
          database: temporal
          driver: postgres
          host: postgresql.temporal.svc.cluster.local
          maxConnLifetime: 1h
          maxConns: 20
          password: ********** # Masked password
          port: 5432
          user: postgres
      visibility:
        driver: sql
        sql:
          database: temporal_visibility
          driver: postgres
          host: postgresql.temporal.svc.cluster.local
          maxConnLifetime: 1h
          maxConns: 20
          password: ********** # Masked password
          port: 5432
          user: postgres
  replicaCount: 1
web:
  image:
    tag: 2.12.0


amine@amine-Latitude-5420:~/Work/Temporal-helm-charts$ k logs temporal-schema-update-rlcrm -n temporal
Defaulted container "default-schema-update" out of: default-schema-update, visibility-schema-update, check-postgresql-service (init), check-postgresql (init)
2023-05-16T19:50:58.561Z	INFO	UpdateSchemeTask started	{"config": {"DBName":"","TargetVersion":"","SchemaDir":"./schema/postgresql/v96/temporal/versioned","IsDryRun":false}, "logging-call-at": "updatetask.go:98"}
2023-05-16T19:50:58.566Z	DEBUG	Schema Dirs: []	{"logging-call-at": "updatetask.go:187"}
2023-05-16T19:50:58.567Z	DEBUG	found zero updates from current version 1.9	{"logging-call-at": "updatetask.go:128"}
2023-05-16T19:50:58.567Z	INFO	UpdateSchemeTask done	{"logging-call-at": "updatetask.go:121"}


```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
I think that in the readme the part where schema setup and update for postgresql should be removed
https://github.com/temporalio/helm-charts#install-with-your-own-postgresql




It's an extension of this PL https://github.com/temporalio/helm-charts/pull/350

