### PR TITLE
Bump default UI version to 2.15.0

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -289,7 +289,7 @@ web:
 
   image:
     repository: temporalio/ui
-    tag: 2.9.0
+    tag: 2.15.0
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bumped default UI version to 2.15.0

## Why?
To have the most recent UI version.

## Checklist
<!--- add/delete as needed --->

1. Closes #385

2. How was this tested:
CICD

3. Any docs updates needed?
No