### PR TITLE
Added new TEMPORAL_ADDRESS env variable

### DIFF
--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -46,7 +46,10 @@ spec:
               containerPort: 22
               protocol: TCP
           env:
+            # TEMPORAL_CLI_ADDRESS is deprecated, use TEMPORAL_ADDRESS instead
             - name: TEMPORAL_CLI_ADDRESS
+              value: {{ include "temporal.fullname" . }}-frontend:{{ include "temporal.frontend.grpcPort" . }}
+            - name: TEMPORAL_ADDRESS
               value: {{ include "temporal.fullname" . }}-frontend:{{ include "temporal.frontend.grpcPort" . }}
           {{- if .Values.admintools.additionalEnv }}
           {{- toYaml .Values.admintools.additionalEnv | nindent 12 }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added new TEMPORAL_ADDRESS env variable

## Why?
TEMPORAL_CLI_ADDRESS is deprecated and was renamed in the latest Temporal CLI: https://github.com/temporalio/cli/releases/tag/v0.9.0

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
CICD

3. Any docs updates needed?
No