### PR TITLE
Support to configure server Prometheus settings

### DIFF
--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -104,17 +104,23 @@ data:
 
       pprof:
         port: 7936
-        
+
       metrics:
         tags:
           type: {{ $service }}
           {{- with $.Values.server.metrics.tags }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+        {{- if $.Values.server.config.prometheus }}
+        prometheus:
+          {{- with $.Values.server.config.prometheus }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- else }}
         prometheus:
           timerType: histogram
           listenAddress: "0.0.0.0:9090"
-
+        {{- end }}
 
     services:
       frontend:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added server Prometheus settings conditional configuration.

## Why?
Support to override server Prometheus settings.

For example, have the ability to change the framework:
```
framework: "opentelemetry"
```
Supported frameworks are: `tally` (the default) or `opentelemetry`.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
CICD

3. Any docs updates needed?
No