### PR TITLE
FIX Add name value to pdb template

### DIFF
--- a/templates/server-pdb.yaml
+++ b/templates/server-pdb.yaml
@@ -5,7 +5,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: 
+  name: {{ include "temporal.componentname" (list $ $service) }}-pdb
   labels:
     app.kubernetes.io/name: {{ include "temporal.name" $ }}
     helm.sh/chart: {{ include "temporal.chart" $ }}


### PR DESCRIPTION
## What was changed
* Added value to name field in PodDisruptionBudget template

## Why?
PodDisruptionBudget resources require a name field to be present, when utilizing pdb templates, helm upgrade throws the following error.
```
Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. Unable to continue with update: could not get information about the resource: resource name may not be empty
``` 
When running `helm template . --name-template temporal --values  values.yaml --dry-run` with PDB configured the generated resource does not contain a value for name: and when manually apply the resource (kubectl apply -f pdb.yaml) k8s server throws the following error

```
error: error when retrieving current configuration of:
Resource: "policy/v1, Resource=poddisruptionbudgets", GroupVersionKind: "policy/v1, Kind=PodDisruptionBudget"
Name: "", Namespace: "temporal"
from server for: "pdb.yaml": resource name may not be empty
```

After adding value to name PDBs are created successfully 

## Checklist

2. How was this tested:
Manually using helm template + helm upgrade

4. Any docs updates needed?
No
