### PR TITLE
Being able to disable the es schema setup job

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -256,7 +256,7 @@ spec:
       {{- end }}
 ---
 {{- end }}
-{{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
+{{- if and (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external) .Values.schema.setup.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Do not run the hook that setups the ES schema if not necessary.

## Why?
Sometimes you don't need to setup the schema if this is done through another process