### PR TITLE
Being able to set environment variables using 'envFrom'

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -121,6 +121,17 @@ spec:
           {{- if or $.Values.server.additionalEnv $serviceValues.additionalEnv }}
           {{- toYaml (default $.Values.server.additionalEnv $serviceValues.additionalEnv) | nindent 12 }}
           {{- end }}
+          {{- if or $serviceValues.additionalEnvCM $serviceValues.additionalEnvSecret }}
+          envFrom:
+            {{- if $serviceValues.additionalEnvCM }}
+            - configMapRef:
+                name: {{ $serviceValues.additionalEnvCM }}
+            {{- end }}
+            {{- if $serviceValues.additionalEnvSecret }}
+            - secretRef:
+                name: {{ $serviceValues.additionalEnvSecret }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: rpc
               containerPort: {{ include (printf "temporal.%s.grpcPort" $service) $ }}

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -121,15 +121,33 @@ spec:
           {{- if or $.Values.server.additionalEnv $serviceValues.additionalEnv }}
           {{- toYaml (default $.Values.server.additionalEnv $serviceValues.additionalEnv) | nindent 12 }}
           {{- end }}
-          {{- if or $serviceValues.additionalEnvCM $serviceValues.additionalEnvSecret }}
+          {{- if or $.Values.server.additionalEnvCM $.Values.server.additionalEnvSecret }}
+          envFrom:
+            {{- if $.Values.server.additionalEnvCM }}
+            {{- range $.Values.server.additionalEnvCM }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
+            {{- end }}
+            {{- if $.Values.server.additionalEnvSecret }}
+            {{- range $.Values.server.additionalEnvSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- end }}
+          {{- else if or $serviceValues.additionalEnvCM $serviceValues.additionalEnvSecret }}
           envFrom:
             {{- if $serviceValues.additionalEnvCM }}
+            {{- range $serviceValues.additionalEnvCM }}
             - configMapRef:
-                name: {{ $serviceValues.additionalEnvCM }}
+                name: {{ . }}
+            {{- end }}
             {{- end }}
             {{- if $serviceValues.additionalEnvSecret }}
+            {{- range $serviceValues.additionalEnvSecret }}
             - secretRef:
-                name: {{ $serviceValues.additionalEnvSecret }}
+                name: {{ . }}
+            {{- end }}
             {{- end }}
           {{- end }}
           ports:

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -51,6 +51,17 @@ spec:
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}
+          {{- if or .Values.web.additionalEnvCM .Values.web.additionalEnvSecret }}
+          envFrom:
+            {{- if .Values.web.additionalEnvCM }}
+            - configMapRef:
+                name: {{ .Values.web.additionalEnvCM }}
+            {{- end }}
+            {{- if .Values.web.additionalEnvSecret }}
+            - secretRef:
+                name: {{ .Values.web.additionalEnvSecret }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -54,12 +54,16 @@ spec:
           {{- if or .Values.web.additionalEnvCM .Values.web.additionalEnvSecret }}
           envFrom:
             {{- if .Values.web.additionalEnvCM }}
+            {{- range .Values.web.additionalEnvCM }}
             - configMapRef:
-                name: {{ .Values.web.additionalEnvCM }}
+                name: {{ . }}
+            {{- end }}
             {{- end }}
             {{- if .Values.web.additionalEnvSecret }}
+            {{- range .Values.web.additionalEnvSecret }}
             - secretRef:
-                name: {{ .Values.web.additionalEnvSecret }}
+                name: {{ . }}
+            {{- end }}
             {{- end }}
           {{- end }}
           ports:

--- a/values.yaml
+++ b/values.yaml
@@ -84,6 +84,8 @@ server:
   additionalVolumes: []
   additionalVolumeMounts: []
   additionalEnv: []
+  additionalEnvCM: ""
+  additionalEnvSecret: ""
   securityContext:
     fsGroup: 1000
     runAsUser: 1000
@@ -183,6 +185,8 @@ server:
     tolerations: []
     affinity: {}
     additionalEnv: []
+    additionalEnvCM: ""
+    additionalEnvSecret: ""
     containerSecurityContext: {}
     topologySpreadConstraints: {}
     podDisruptionBudget: {}
@@ -205,6 +209,8 @@ server:
     tolerations: []
     affinity: {}
     additionalEnv: []
+    additionalEnvCM: ""
+    additionalEnvSecret: ""
     containerSecurityContext: {}
     topologySpreadConstraints: {}
     podDisruptionBudget: {}
@@ -227,6 +233,8 @@ server:
     tolerations: []
     affinity: {}
     additionalEnv: []
+    additionalEnvCM: ""
+    additionalEnvSecret: ""
     containerSecurityContext: {}
     topologySpreadConstraints: {}
     podDisruptionBudget: {}
@@ -249,6 +257,8 @@ server:
     tolerations: []
     affinity: {}
     additionalEnv: []
+    additionalEnvCM: ""
+    additionalEnvSecret: ""
     containerSecurityContext: {}
     topologySpreadConstraints: {}
     podDisruptionBudget: {}
@@ -270,6 +280,8 @@ admintools:
   tolerations: []
   affinity: {}
   additionalEnv: []
+  additionalEnvCM: ""
+  additionalEnvSecret: ""
   resources: {}
   containerSecurityContext: {}
   securityContext: {}

--- a/values.yaml
+++ b/values.yaml
@@ -84,8 +84,8 @@ server:
   additionalVolumes: []
   additionalVolumeMounts: []
   additionalEnv: []
-  additionalEnvCM: ""
-  additionalEnvSecret: ""
+  additionalEnvCM: []
+  additionalEnvSecret: []
   securityContext:
     fsGroup: 1000
     runAsUser: 1000
@@ -185,8 +185,8 @@ server:
     tolerations: []
     affinity: {}
     additionalEnv: []
-    additionalEnvCM: ""
-    additionalEnvSecret: ""
+    additionalEnvCM: []
+    additionalEnvSecret: []
     containerSecurityContext: {}
     topologySpreadConstraints: {}
     podDisruptionBudget: {}
@@ -209,8 +209,8 @@ server:
     tolerations: []
     affinity: {}
     additionalEnv: []
-    additionalEnvCM: ""
-    additionalEnvSecret: ""
+    additionalEnvCM: []
+    additionalEnvSecret: []
     containerSecurityContext: {}
     topologySpreadConstraints: {}
     podDisruptionBudget: {}
@@ -233,8 +233,8 @@ server:
     tolerations: []
     affinity: {}
     additionalEnv: []
-    additionalEnvCM: ""
-    additionalEnvSecret: ""
+    additionalEnvCM: []
+    additionalEnvSecret: []
     containerSecurityContext: {}
     topologySpreadConstraints: {}
     podDisruptionBudget: {}
@@ -257,8 +257,8 @@ server:
     tolerations: []
     affinity: {}
     additionalEnv: []
-    additionalEnvCM: ""
-    additionalEnvSecret: ""
+    additionalEnvCM: []
+    additionalEnvSecret: []
     containerSecurityContext: {}
     topologySpreadConstraints: {}
     podDisruptionBudget: {}
@@ -280,8 +280,8 @@ admintools:
   tolerations: []
   affinity: {}
   additionalEnv: []
-  additionalEnvCM: ""
-  additionalEnvSecret: ""
+  additionalEnvCM: []
+  additionalEnvSecret: []
   resources: {}
   containerSecurityContext: {}
   securityContext: {}
@@ -350,9 +350,11 @@ web:
   affinity: {}
 
   additionalEnv: []
+  additionalEnvCM: []
+  additionalEnvSecret: []
 
   containerSecurityContext: {}
-  
+
   securityContext: {}
 
 schema:


### PR DESCRIPTION
## What was changed
Add the ability to define environment variables that come from configmaps or secrets

## Why?
Make use of envFrom is pretty handy when, for instance you have all the environment variables defined in Secrets or Configmaps.
That way we only need to have this bit of code if we have all the config env vars in a secret

```yaml
web:
  additionalEnvSecret: 
    - "temporal-web-envvars"
```
