### PR TITLE
Being able to disable prom annotations

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -45,10 +45,12 @@ metadata:
     app.kubernetes.io/component: {{ $service }}
     app.kubernetes.io/part-of: {{ $.Chart.Name }}
     app.kubernetes.io/headless: 'true'
+    {{- if $serviceValues.metrics.annotations.enabled }}
     prometheus.io/job: {{ $.Chart.Name }}-{{ $service }}
     prometheus.io/scrape: 'true'
     prometheus.io/scheme: http
-    prometheus.io/port: "9090"
+    prometheus.io/port: '9090'
+    {{- end }}
 
   annotations:
     # Use this annotation in addition to the actual field below because the

--- a/values.yaml
+++ b/values.yaml
@@ -171,7 +171,7 @@ server:
       port: 7233
     metrics:
       annotations:
-        enabled: true
+        enabled: false
       serviceMonitor: {}
       # enabled: false
       prometheus: {}
@@ -193,7 +193,7 @@ server:
       port: 7234
     metrics:
       annotations:
-        enabled: true
+        enabled: false
       serviceMonitor: {}
       # enabled: false
       prometheus: {}
@@ -237,7 +237,7 @@ server:
       port: 7239
     metrics:
       annotations:
-        enabled: true
+        enabled: false
       serviceMonitor: {}
       # enabled: false
       prometheus: {}


### PR DESCRIPTION
## What was changed
Default behavior should be to have the annotations disabled at the service level.
Note that it is already enabled at the global level by default:

```yaml
server:
  metrics:
    annotations:
      enabled: true
```

## Why?
That makes easier to configure if you use the prometheus operator for instance
