### PR TITLE
add new options for TEMPORAL_CORS_ORIGINS and TEMPORAL_CSRF_COOKIE_INSECURE

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -48,6 +48,14 @@ spec:
           env:
             - name: TEMPORAL_ADDRESS
               value: "{{ include "temporal.fullname" . }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
+            {{- if .Values.web.corsOrigins }}
+            - name: TEMPORAL_CORS_ORIGINS
+              value: "{{ .Values.web.corsOrigins }}"
+            {{- end }}
+            {{- if .Values.web.corsOrigins }}
+            - name: TEMPORAL_CSRF_COOKIE_INSECURE
+              value: "{{ .Values.web.csrfCookieInsecure }}"
+            {{- end }}
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: TEMPORAL_CORS_ORIGINS
               value: "{{ .Values.web.corsOrigins }}"
             {{- end }}
-            {{- if .Values.web.corsOrigins }}
+            {{- if .Values.web.csrfCookieInsecure }}
             - name: TEMPORAL_CSRF_COOKIE_INSECURE
               value: "{{ .Values.web.csrfCookieInsecure }}"
             {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -343,6 +343,12 @@ web:
   
   securityContext: {}
 
+  # comma-separated string
+  corsOrigins: ""
+
+  # disables csrf secure cookies
+  csrfCookieInsecure: false
+
 schema:
   setup:
     enabled: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds options for `TEMPORAL_CORS_ORIGINS` and `TEMPORAL_CSRF_COOKIE_INSECURE`

## Why?
<!-- Tell your future self why have you made these changes -->

So they can be configured more explicitly than through the `additionalEnvs`, lacking documentation on them so surfacing to dedicated options makes it easier to find the functionality. Also this usage is quite common for privately-networked deployments.

## Checklist
<!--- add/delete as needed --->

1. Closes  #401 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

`helm template`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No
