### PR TITLE
Automatically configure Postgres and MySQL databases on startup

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -206,6 +206,17 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- print "password" -}}
 {{- end -}}
 
+{{- define "temporal.persistence.sql.database" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.database -}}
+{{- $storeConfig.sql.database -}}
+{{- else -}}
+{{- required (printf "Please specify database for %s store" $store) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "temporal.persistence.sql.driver" -}}
 {{- $global := index . 0 -}}
 {{- $store := index . 1 -}}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -80,6 +80,38 @@ spec:
             {{- end }}
         {{- end }}
         {{- end }}
+        {{- else if or (eq (include "temporal.persistence.driver" (list $ "default")) "sql") (eq (include "temporal.persistence.driver" (list $ "visibility")) "sql") }}
+        {{- range $store := (list "default" "visibility") }}
+        {{- $storeConfig := index $.Values.server.config.persistence $store }}
+        {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+        - name: create-{{ $store }}-store
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'temporal-sql-tool create-database -database {{ include "temporal.persistence.sql.database" (list $ $store) }}']
+          env:
+            - name: SQL_PLUGIN
+              value: {{ include "temporal.persistence.sql.driver" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "temporal.persistence.sql.host" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "temporal.persistence.sql.port" (list $ $store) | quote }}
+            {{- if $storeConfig.sql.user }}
+            - name: SQL_USER
+              value: {{ $storeConfig.sql.user }}
+            {{- end }}
+            {{- if (or $storeConfig.sql.password $storeConfig.sql.existingSecret) }}
+            - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ $storeConfig.sql.password }}
+              {{- end }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
         {{- else }}
           []
         {{- end }}
@@ -111,6 +143,30 @@ spec:
                   key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
               {{- else }}
               value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
+            {{- end }}
+            {{- else if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ include "temporal.persistence.sql.driver" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "temporal.persistence.sql.host" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "temporal.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_DATABASE
+              value: {{ include "temporal.persistence.sql.database" (list $ $store) }}
+            {{- if $storeConfig.sql.user }}
+            - name: SQL_USER
+              value: {{ $storeConfig.sql.user }}
+            {{- end }}
+            {{- if (or $storeConfig.sql.password $storeConfig.sql.existingSecret) }}
+            - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ $storeConfig.sql.password }}
               {{- end }}
             {{- end }}
             {{- end }}
@@ -204,6 +260,10 @@ spec:
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
           command: ['sh', '-c', 'temporal-cassandra-tool update-schema -d /etc/temporal/schema/cassandra/{{ include "temporal.persistence.schema" $store }}/versioned']
+          {{- else if eq (include "temporal.persistence.sql.driver" (list $ $store)) "mysql" }}
+          command: ["temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool", "update", "-schema-dir", "/etc/temporal/schema/mysql/v57/{{ include "temporal.persistence.schema" $store }}/versioned"]
+          {{- else if eq (include "temporal.persistence.sql.driver" (list $ $store)) "postgres" }}
+          command: ["temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool", "update", "-schema-dir", "/etc/temporal/schema/postgresql/v96/{{ include "temporal.persistence.schema" $store }}/versioned"]
           {{- end }}
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
@@ -226,6 +286,30 @@ spec:
                   key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
               {{- else }}
               value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
+            {{- end }}
+            {{- else if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ include "temporal.persistence.sql.driver" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "temporal.persistence.sql.host" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "temporal.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_DATABASE
+              value: {{ include "temporal.persistence.sql.database" (list $ $store) }}
+            {{- if $storeConfig.sql.user }}
+            - name: SQL_USER
+              value: {{ $storeConfig.sql.user }}
+            {{- end }}
+            {{- if (or $storeConfig.sql.password $storeConfig.sql.existingSecret) }}
+            - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ $storeConfig.sql.password }}
               {{- end }}
             {{- end }}
             {{- end }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -55,7 +55,7 @@ spec:
         - name: create-{{ $store }}-store
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'temporal-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }} --replication-factor {{ $storeConfig.cassandra.replicationFactor }}']
+          command: ['temporal-cassandra-tool', 'create', '-k', '{{ $storeConfig.cassandra.keyspace }}', '--replication-factor', '{{ $storeConfig.cassandra.replicationFactor }}']
           env:
             - name: CASSANDRA_HOST
               value: {{ first (splitList "," (include "temporal.persistence.cassandra.hosts" (list $ $store))) }}
@@ -87,7 +87,7 @@ spec:
         - name: create-{{ $store }}-store
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'temporal-sql-tool create-database -database {{ include "temporal.persistence.sql.database" (list $ $store) }}']
+          command: ['temporal-sql-tool', '--database', '{{ include "temporal.persistence.sql.database" (list $ $store) }}', 'create-database']
           env:
             - name: SQL_PLUGIN
               value: {{ include "temporal.persistence.sql.driver" (list $ $store) }}
@@ -121,7 +121,7 @@ spec:
         - name: {{ $store }}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ["temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool", "setup-schema", "-v", "0.0"]
+          command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'setup-schema', '-v', '0.0']
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
@@ -259,11 +259,11 @@ spec:
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
-          command: ['sh', '-c', 'temporal-cassandra-tool update-schema -d /etc/temporal/schema/cassandra/{{ include "temporal.persistence.schema" $store }}/versioned']
+          command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'update-schema', '--schema-dir', '/etc/temporal/schema/cassandra/{{ include "temporal.persistence.schema" $store }}/versioned']
           {{- else if eq (include "temporal.persistence.sql.driver" (list $ $store)) "mysql" }}
-          command: ["temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool", "update", "-schema-dir", "/etc/temporal/schema/mysql/v57/{{ include "temporal.persistence.schema" $store }}/versioned"]
+          command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'update-schema', '--schema-dir', '/etc/temporal/schema/mysql/v57/{{ include "temporal.persistence.schema" $store }}/versioned']
           {{- else if eq (include "temporal.persistence.sql.driver" (list $ $store)) "postgres" }}
-          command: ["temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool", "update", "-schema-dir", "/etc/temporal/schema/postgresql/v96/{{ include "temporal.persistence.schema" $store }}/versioned"]
+          command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'update-schema', '--schema-dir', '/etc/temporal/schema/postgresql/v96/{{ include "temporal.persistence.schema" $store }}/versioned']
           {{- end }}
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Automatically create databases and apply the schemas to them for Postgres and MySQL.
Original PR: #281

## Why?
Allow automatically configuring databases and their schemas.

## Checklist
<!--- add/delete as needed --->

1. Closes #349

2. How was this tested:
CICD
Tested with MySql & Cassandra environments

3. Any docs updates needed?
No