### PR TITLE
feat: add support for additionalEnv to schema jobs

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -78,6 +78,9 @@ spec:
               value: {{ $storeConfig.cassandra.password }}
               {{- end }}
             {{- end }}
+            {{- if $.Values.schema.additionalEnv }}
+              {{- toYaml $.Values.schema.additionalEnv | nindent 12 }}
+            {{- end }}
         {{- end }}
         {{- end }}
         {{- else if or (eq (include "temporal.persistence.driver" (list $ "default")) "sql") (eq (include "temporal.persistence.driver" (list $ "visibility")) "sql") }}
@@ -109,6 +112,9 @@ spec:
               {{- else }}
               value: {{ $storeConfig.sql.password }}
               {{- end }}
+            {{- end }}
+            {{- if $.Values.schema.additionalEnv }}
+              {{- toYaml $.Values.schema.additionalEnv | nindent 12 }}
             {{- end }}
         {{- end }}
         {{- end }}
@@ -169,6 +175,9 @@ spec:
               value: {{ $storeConfig.sql.password }}
               {{- end }}
             {{- end }}
+            {{- end }}
+            {{- if $.Values.schema.additionalEnv }}
+              {{- toYaml $.Values.schema.additionalEnv | nindent 12 }}
             {{- end }}
         {{- end }}
           {{- with .Values.schema.resources }}
@@ -316,6 +325,9 @@ spec:
               value: {{ $storeConfig.sql.password }}
               {{- end }}
             {{- end }}
+            {{- end }}
+            {{- if $.Values.schema.additionalEnv }}
+              {{- toYaml $.Values.schema.additionalEnv | nindent 12 }}
             {{- end }}
         {{- end }}
           {{- with .Values.schema.resources }}

--- a/values.yaml
+++ b/values.yaml
@@ -340,7 +340,7 @@ web:
   additionalEnv: []
 
   containerSecurityContext: {}
-  
+
   securityContext: {}
 
 schema:
@@ -353,6 +353,7 @@ schema:
   resources: {}
   containerSecurityContext: {}
   securityContext: {}
+  additionalEnv: []
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
## What was changed

Added support for `additionalEnv` to schema jobs (`server-job.yaml`).

## Why?

Currently, the chart doesn't have a way to tune PostgreSQL TLS settings in the jobs that create/update schema. One of the ways to implement that support is through custom environment variables. E.g. for "required" mode, I need to pass:

```yaml
        - name: SQL_TLS
           value: "true"
         - name: SQL_TLS_DISABLE_HOST_VERIFICATION
           value: "true"
```  

## Checklist

**2. How was this tested:**

Saved the values below to `custom-values.yaml`

```yaml
schema:
  additionalEnv:
    - name: SQL_TLS
      value: "true"
    - name: SQL_TLS_DISABLE_HOST_VERIFICATION
      value: "true"
```

Then ran:
```shell
helm dependencies update
helm template . -f custom-values.yaml --show-only templates/server-job.yaml
```

The envs should appear in specs of the containers.

**NOTE:** It was added only to containers that already had section with environment variables. There's probably not much need for that for `check-elasticsearch`, `create-elasticsearch-index`, etc.
