### PR TITLE
Adds a PodDisruptionBudget and topologySpreadConstraints to web

### DIFF
--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -85,4 +85,8 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.web.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
   {{- end }}

--- a/charts/temporal/templates/web-pdb.yaml
+++ b/charts/temporal/templates/web-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.web.enabled }}
-{{- if and (gt ($.Values.web.replicaCount | int) 1) ($.Values.web.podDisruptionBudget) }}
+{{- if $.Values.web.podDisruptionBudget }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/temporal/templates/web-pdb.yaml
+++ b/charts/temporal/templates/web-pdb.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "temporal.componentname" web }}-pdb
+  name: {{ include "temporal.componentname" (list . "web") }}-pdb
   labels:
     app.kubernetes.io/name: {{ include "temporal.name" $ }}
     helm.sh/chart: {{ include "temporal.chart" $ }}

--- a/charts/temporal/templates/web-pdb.yaml
+++ b/charts/temporal/templates/web-pdb.yaml
@@ -1,0 +1,23 @@
+{{- if $.Values.web.enabled }}
+{{- if and (gt ($.Values.web.replicaCount | int) 1) ($.Values.web.podDisruptionBudget) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "temporal.componentname" web }}-pdb
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" $ }}
+    helm.sh/chart: {{ include "temporal.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
+spec:
+  {{ toYaml $.Values.web.podDisruptionBudget }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "temporal.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/component: web
+{{- end }}
+{{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -197,7 +197,7 @@ server:
     affinity: {}
     additionalEnv: []
     containerSecurityContext: {}
-    topologySpreadConstraints: {}
+    topologySpreadConstraints: []
     podDisruptionBudget: {}
   history:
     service:
@@ -218,7 +218,7 @@ server:
     affinity: {}
     additionalEnv: []
     containerSecurityContext: {}
-    topologySpreadConstraints: {}
+    topologySpreadConstraints: []
     podDisruptionBudget: {}
   matching:
     service:
@@ -239,7 +239,7 @@ server:
     affinity: {}
     additionalEnv: []
     containerSecurityContext: {}
-    topologySpreadConstraints: {}
+    topologySpreadConstraints: []
     podDisruptionBudget: {}
   worker:
     service:
@@ -260,7 +260,7 @@ server:
     affinity: {}
     additionalEnv: []
     containerSecurityContext: {}
-    topologySpreadConstraints: {}
+    topologySpreadConstraints: []
     podDisruptionBudget: {}
 admintools:
   enabled: true
@@ -335,7 +335,7 @@ web:
   additionalEnv: []
   containerSecurityContext: {}
   securityContext: {}
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   podDisruptionBudget: {}
 schema:
   createDatabase:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -335,6 +335,8 @@ web:
   additionalEnv: []
   containerSecurityContext: {}
   securityContext: {}
+  topologySpreadConstraints: {}
+  podDisruptionBudget: {}
 schema:
   createDatabase:
     enabled: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- added configurable podDisruptionBudget to web component
- added configurable topologySpreadConstraints to web component
- bugfix: topologySpreadConstraints should be of type list instead of map

## Why?
<!-- Tell your future self why have you made these changes -->

To enable the web component to have a PodDisruptionBudget created and topologySpreadContraints configured due to the requirement of these configurations being enforced by policy.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

`helm template .`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
