### PR TITLE
Configure SQL TLS environment variables in server-job

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -88,6 +88,10 @@ spec:
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['temporal-sql-tool', '--database', '{{ include "temporal.persistence.sql.database" (list $ $store) }}', 'create-database']
+          {{- if $.Values.server.additionalVolumeMounts }}
+          volumeMounts:
+            {{- toYaml $.Values.server.additionalVolumeMounts | nindent 12 }}
+          {{- end }}
           env:
             - name: SQL_PLUGIN
               value: {{ include "temporal.persistence.sql.driver" (list $ $store) }}
@@ -110,6 +114,28 @@ spec:
               value: {{ $storeConfig.sql.password }}
               {{- end }}
             {{- end }}
+            {{- with $storeConfig.sql.tls }}
+            - name: SQL_TLS
+              value: {{ .enabled | quote }}
+            {{- if .caFile }}
+            - name: SQL_TLS_CA_FILE
+              value: {{ .caFile }}
+            {{- end }}
+            {{- if and .certFile .keyFile }}
+            - name: SQL_TLS_CERT_FILE
+              value: {{ .certFile }}
+            - name: SQL_TLS_KEY_FILE
+              value: {{ .keyFile }}
+            {{- end }}
+            {{- if .serverName }}
+            - name: SQL_TLS_SERVER_NAME
+              value: {{ .serverName }}
+            {{- end }}
+            {{- if hasKey . "enableHostVerification" }}
+            - name: SQL_TLS_DISABLE_HOST_VERIFICATION
+              value: {{ not .enableHostVerification | quote }}
+            {{- end }}
+            {{- end }}
         {{- end }}
         {{- end }}
         {{- else }}
@@ -122,6 +148,10 @@ spec:
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'setup-schema', '-v', '0.0']
+          {{- if $.Values.server.additionalVolumeMounts }}
+          volumeMounts:
+            {{- toYaml $.Values.server.additionalVolumeMounts | nindent 12 }}
+          {{- end }}
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
@@ -169,6 +199,28 @@ spec:
               value: {{ $storeConfig.sql.password }}
               {{- end }}
             {{- end }}
+            {{- with $storeConfig.sql.tls }}
+            - name: SQL_TLS
+              value: {{ .enabled | quote }}
+            {{- if .caFile }}
+            - name: SQL_TLS_CA_FILE
+              value: {{ .caFile }}
+            {{- end }}
+            {{- if and .certFile .keyFile }}
+            - name: SQL_TLS_CERT_FILE
+              value: {{ .certFile }}
+            - name: SQL_TLS_KEY_FILE
+              value: {{ .keyFile }}
+            {{- end }}
+            {{- if .serverName }}
+            - name: SQL_TLS_SERVER_NAME
+              value: {{ .serverName }}
+            {{- end }}
+            {{- if hasKey . "enableHostVerification" }}
+            - name: SQL_TLS_DISABLE_HOST_VERIFICATION
+              value: {{ not .enableHostVerification | quote }}
+            {{- end }}
+            {{- end }}
             {{- end }}
         {{- end }}
           {{- with .Values.schema.resources }}
@@ -198,6 +250,10 @@ spec:
       {{- with .Values.server.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.server.additionalVolumes }}
+      volumes:
+        {{- toYaml $.Values.server.additionalVolumes | nindent 8 }}
       {{- end }}
 ---
 {{- end }}
@@ -266,6 +322,10 @@ spec:
           {{- else if eq (include "temporal.persistence.sql.driver" (list $ $store)) "postgres12" }}
           command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'update-schema', '--schema-dir', '/etc/temporal/schema/postgresql/v12/{{ include "temporal.persistence.schema" $store }}/versioned']
           {{- end }}
+          {{- if $.Values.server.additionalVolumeMounts }}
+          volumeMounts:
+            {{- toYaml $.Values.server.additionalVolumeMounts | nindent 12 }}
+          {{- end }}
           env:
             {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
@@ -313,6 +373,28 @@ spec:
               value: {{ $storeConfig.sql.password }}
               {{- end }}
             {{- end }}
+            {{- with $storeConfig.sql.tls }}
+            - name: SQL_TLS
+              value: {{ .enabled | quote }}
+            {{- if .caFile }}
+            - name: SQL_TLS_CA_FILE
+              value: {{ .caFile }}
+            {{- end }}
+            {{- if and .certFile .keyFile }}
+            - name: SQL_TLS_CERT_FILE
+              value: {{ .certFile }}
+            - name: SQL_TLS_KEY_FILE
+              value: {{ .keyFile }}
+            {{- end }}
+            {{- if .serverName }}
+            - name: SQL_TLS_SERVER_NAME
+              value: {{ .serverName }}
+            {{- end }}
+            {{- if hasKey . "enableHostVerification" }}
+            - name: SQL_TLS_DISABLE_HOST_VERIFICATION
+              value: {{ not .enableHostVerification | quote }}
+            {{- end }}
+            {{- end }}
             {{- end }}
         {{- end }}
         {{- end }}
@@ -339,6 +421,10 @@ spec:
       {{- with .Values.admintools.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.server.additionalVolumes }}
+      volumes:
+        {{- toYaml $.Values.server.additionalVolumes | nindent 8 }}
       {{- end }}
 ---
 {{- end }}

--- a/charts/temporal/values/values.postgresql.yaml
+++ b/charts/temporal/values/values.postgresql.yaml
@@ -20,6 +20,9 @@ server:
           #  enabled: true
           #  enableHostVerification: true
           #  serverName: _HOST_ # this is strictly required when using serverless CRDB offerings
+          #  caFile: /path/to/certs/<CA-file> # Here we assumed that caFile, certFile, keyFile are stored in one secret mounted as 'secret-with-certs' (see: server.additionalVolumes and server.additionalVolumeMounts sections).
+          #  certFile: /path/to/certs/<client-cert-file>
+          #  keyFile: /path/to/certs/<client-key-file>
 
       visibility:
         driver: "sql"
@@ -40,6 +43,17 @@ server:
           #  enabled: true
           #  enableHostVerification: true
           #  serverName: _HOST_ # this is strictly required when using serverless CRDB offerings
+          #  caFile: /path/to/certs/<CA-file> # Here we assumed that caFile, certFile, keyFile are stored in one secret mounted as 'secret-with-certs' (see: server.additionalVolumes and server.additionalVolumeMounts sections).
+          #  certFile: /path/to/certs/<client-cert-file>
+          #  keyFile: /path/to/certs/<client-key-file>
+
+# additionalVolumes:
+#   - name: secret-with-certs
+#     secret:
+#       secretName: secret-with-certs
+# additionalVolumeMounts:
+#   - name: secret-with-certs
+#     mountPath: /path/to/certs/
 
 cassandra:
   enabled: false

--- a/charts/temporal/values/values.postgresql.yaml
+++ b/charts/temporal/values/values.postgresql.yaml
@@ -47,13 +47,13 @@ server:
           #  certFile: /path/to/certs/<client-cert-file>
           #  keyFile: /path/to/certs/<client-key-file>
 
-# additionalVolumes:
-#   - name: secret-with-certs
-#     secret:
-#       secretName: secret-with-certs
-# additionalVolumeMounts:
-#   - name: secret-with-certs
-#     mountPath: /path/to/certs/
+  # additionalVolumes:
+  #   - name: secret-with-certs
+  #     secret:
+  #       secretName: secret-with-certs
+  # additionalVolumeMounts:
+  #   - name: secret-with-certs
+  #     mountPath: /path/to/certs/
 
 cassandra:
   enabled: false


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added support for `SQL_TLS*` properties in schema jobs (`server-job.yaml`).

## Why?
<!-- Tell your future self why have you made these changes -->
Currently, when PostgreSQL database is secured with TLS, schema jobs are not properly configured.

In the Pull Request we reuse `server.config.persistence.*.sql.tls`, `server.config.additionalVolumes` and `server.config.additionalVolumeMounts` properties..

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No related issues.

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No updates needed.