### PR TITLE
fix: sidecarContainers should be an array, not a dict

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -49,7 +49,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.26.0
+version: 0.26.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,7 @@ serviceAccount:
 
 server:
   enabled: true
-  sidecarContainers: {}
+  sidecarContainers: []
   image:
     repository: temporalio/server
     tag: 1.21.3


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Very simple change: I changed the datatype of `sidecarContainers` to `[]` (from `{}`).

## Why?
<!-- Tell your future self why have you made these changes -->

When running Tanka, we've been getting this warning:

`coalesce.go:220: warning: cannot overwrite table with non table for temporal.server.sidecarContainers (map[])`

It was rendering the YAML fine, but when CI runs people kept thinking there was an actual issue.

