### PR TITLE
feat: updated grafana and prometheus helm dependencies

### DIFF
--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.44.0
+version: 0.43.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.24.2

--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     condition: cassandra.enabled
   - name: prometheus
     repository: https://prometheus-community.github.io/helm-charts
-    version: 15.1.3
+    version: 25.22.0
     condition: prometheus.enabled
   - name: elasticsearch
     repository: https://helm.elastic.co
@@ -26,7 +26,7 @@ dependencies:
     condition: elasticsearch.enabled
   - name: grafana
     repository: https://grafana.github.io/helm-charts
-    version: 5.0.10
+    version: 8.0.2
     condition: grafana.enabled
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -39,7 +39,7 @@ dependencies:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.43.0
+version: 0.44.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.24.2


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Updated Temporal's Helm chart dependencies:
- Grafana from `5.0.10` to `8.0.2`.
- Prometheus from `15.1.3` to `25.22.0`.

While it's a huge bump, I've raised the temporal minor version as it shouldn't be a breaking change in most cases.
Let me know if you prefer to bump the chart's version differently.

## Why?
<!-- Tell your future self why have you made these changes -->

Take advantage of products updates while reducing security risks. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

```bash
helm template temporal . -n temporal | kubectl apply -f -
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

N/A