### PR TITLE
allow secretKey ref for external cassandra

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -203,7 +203,11 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- $store := index . 1 -}}
 {{- $storeConfig := index $global.Values.server.config.persistence $store -}}
 {{/* Cassandra password is optional, but we will create an empty secret for it */}}
+{{- if $storeConfig.cassandra.secretKey -}}
+{{- $storeConfig.cassandra.secretKey -}}
+{{- else -}}
 {{- print "password" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "temporal.persistence.sql.database" -}}


### PR DESCRIPTION

## What was changed
Allow for the specification of a secretKey.

## Why?
The bitnami Cassandra helm chart creates the password with the `cassandra-passsword` key.  This allows the user to split Cassandra out of the Temporal helm release.

## Checklist

1. Closes n/a

2. How was this tested:
`helm template .`

3. Any docs updates needed?
n/a
