### PR TITLE
feat: Add support for `additionalVolumes` and `additionalVolumeMounts` for web

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -41,6 +41,9 @@ spec:
         - name: {{ .Chart.Name }}-web-config
           configMap:
             name: {{ include "temporal.componentname" (list . "web") }}-config
+      {{- if .Values.web.additionalVolumes }}
+      {{- toYaml .Values.web.additionalVolumes | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-web
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
@@ -59,6 +62,10 @@ spec:
             {{- toYaml .Values.web.resources | nindent 12 }}
           {{- with .Values.web.containerSecurityContext }}
           securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.additionalVolumeMounts }}
+          volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.web.securityContext }}

--- a/values.yaml
+++ b/values.yaml
@@ -337,6 +337,9 @@ web:
 
   affinity: {}
 
+  additionalVolumes: []
+  additionalVolumeMounts: []
+
   additionalEnv: []
 
   containerSecurityContext: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds the ability to set `additionalVolumes` and `additionalVolumeMounts` to the `web` Deployment.

## Why?
<!-- Tell your future self why have you made these changes -->
This was one of many changes needed to support injecting TLS certificates for full mTLS support. Specifically the `web` process needs certificates to talk to the backend services when you enable mTLS.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

We have this chart forked internally and are using it. These changes were applied to it and confirmed it deploys successfully and mounts my volumes:

```yaml
# file: values.yaml
web:
  additionalVolumeMounts:
    - name: certs
      mountPath: /etc/temporal/certs
  additionalVolumes:
    - name: certs
      secret:
        secretName: temporal-certs
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
