### PR TITLE
Add support of pod annotations for service job

### DIFF
--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -35,6 +35,10 @@ spec:
         app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
+      annotations:
+        {{- with .Values.serviceJob.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
@@ -237,6 +241,10 @@ spec:
         app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
+      annotations:
+        {{- with .Values.serviceJob.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"
@@ -380,6 +388,10 @@ spec:
         app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: {{ .Chart.Name }}
+      annotations:
+        {{- with .Values.serviceJob.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{ include "temporal.serviceAccount" . }}
       restartPolicy: "OnFailure"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add support for pod annotations

<!-- Describe what has changed in this PR -->

Istio run with each pod due to which one time job/pod are not successfully terminal, istio is not required here as db schema setup and update are one time job, hence skipping istio by adding addition skip parameter.

## Why?
<!-- Tell your future self why have you made these changes -->


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
https://github.com/temporalio/helm-charts/issues/353
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I have deployed this on eks with istio enabled namespace, and it is working fine.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
