### PR TITLE
Adds HorizontalPodAutoscaler to web and server components

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -49,7 +49,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.31.0
+version: 0.32.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -375,3 +375,35 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Based on Bitnami charts method
+Return the target Kubernetes version
+*/}}
+{{- define "common.capabilities.kubeVersion" -}}
+{{- if .Values.global }}
+    {{- if .Values.global.kubeVersion }}
+    {{- .Values.global.kubeVersion -}}
+    {{- else }}
+    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+    {{- end -}}
+{{- else }}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Based on Bitnami charts method
+Return the appropriate apiVersion for Horizontal Pod Autoscaler.
+*/}}
+{{- define "common.capabilities.hpa.apiVersion" -}}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .context) -}}
+{{- if .beta2 -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- else -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -14,7 +14,9 @@ metadata:
     app.kubernetes.io/component: {{ $service }}
     app.kubernetes.io/part-of: {{ $.Chart.Name }}
 spec:
+  {{- if not $serviceValues.autoscaling.enabled }}
   replicas: {{ default $.Values.server.replicaCount $serviceValues.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "temporal.name" $ }}

--- a/templates/server-hpa.yaml
+++ b/templates/server-hpa.yaml
@@ -1,0 +1,52 @@
+{{- if $.Values.server.enabled }}
+{{- range $service := (list "frontend" "history" "matching" "worker") }}
+{{- $serviceValues := index $.Values.server $service -}}
+{{- if $serviceValues.autoscaling.enabled }}
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "temporal.componentname" (list $ $service) }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" $ }}
+    helm.sh/chart: {{ include "temporal.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: {{ $service }}
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "temporal.componentname" (list $ $service) }}
+  minReplicas: {{ $serviceValues.autoscaling.minReplicas }}
+  maxReplicas: {{ $serviceValues.autoscaling.maxReplicas }}
+  metrics:
+    {{- if $serviceValues.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" $) }}
+        targetAverageUtilization: {{ $serviceValues.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ $serviceValues.autoscaling.targetCPU }}
+        {{- end }}
+    {{- end }}
+    {{- if $serviceValues.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" $) }}
+        targetAverageUtilization: {{ $serviceValues.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ $serviceValues.autoscaling.targetMemory }}
+        {{- end }}
+    {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -12,7 +12,9 @@ metadata:
     app.kubernetes.io/component: web
     app.kubernetes.io/part-of: {{ .Chart.Name }}
 spec:
+  {{- if not .Values.web.autoscaling.enabled }}
   replicas: {{ .Values.web.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "temporal.name" . }}

--- a/templates/web-hpa.yaml
+++ b/templates/web-hpa.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.web.enabled -}}
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" . ) }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "temporal.componentname" (list . "web") }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "temporal.componentname" (list . "web") }}
+  minReplicas: {{ .Values.web.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.web.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.web.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.web.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.web.autoscaling.targetCPU }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.web.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.web.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.web.autoscaling.targetMemory }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -205,6 +205,12 @@ server:
       # enabled: false
       prometheus: {}
       # timerType: histogram
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 3
+      targetCPU: 90
+      targetMemory: 90
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -227,6 +233,12 @@ server:
       # enabled: false
       prometheus: {}
       # timerType: histogram
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 3
+      targetCPU: 90
+      targetMemory: 90
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -249,6 +261,12 @@ server:
       # enabled: false
       prometheus: {}
       # timerType: histogram
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 3
+      targetCPU: 90
+      targetMemory: 90
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -271,6 +289,12 @@ server:
       # enabled: false
       prometheus: {}
       # timerType: histogram
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 3
+      targetCPU: 90
+      targetMemory: 90
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -315,6 +339,12 @@ web:
       issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums
 
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 3
+    targetCPU: 90
+    targetMemory: 90
 
   image:
     repository: temporalio/ui
@@ -372,7 +402,7 @@ web:
   additionalEnv: []
 
   containerSecurityContext: {}
-  
+
   securityContext: {}
 
 schema:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adds HorizontalPodAutoscaler to web and server components. Also added two helpers from Bitnami's Chart, because didn't find useful adding the entire dependency https://github.com/bitnami/charts/tree/main/bitnami/common (I can change this btw).

## Why?
Improves reliability and scalability 

## Checklist
<!--- add/delete as needed --->

1. Closes - didn't find any related issue 

2. How was this tested:
- Helm template + kubectl apply --dry-run -f -
- Implemented on a staging environment
```shell
temporal-frontend             Deployment/temporal-frontend             26%/90%, 10%/90%   2         3         2          2m48s
temporal-history              Deployment/temporal-history              70%/90%, 13%/90%   2         3         2          2m48s
temporal-matching             Deployment/temporal-matching             26%/90%, 13%/90%   2         3         2          2m48s
temporal-web                  Deployment/temporal-web                  5%/90%, 2%/90%     2         3         2          2m48s
temporal-worker               Deployment/temporal-worker               24%/90%, 8%/90%    2         3         2          2m48s
```

3. Any docs updates needed?
No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
