### PR TITLE
Fix rendering for elasticsearch visibility storage

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -109,11 +109,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "default") }}
                   key: {{ include "temporal.persistence.secretKey" (list $ "default") }}
+          {{- if ne (include "temporal.persistence.driver" (list $ "visibility")) "elasticsearch" }}
             - name: TEMPORAL_VISIBILITY_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "visibility") }}
                   key: {{ include "temporal.persistence.secretKey" (list $ "visibility") }}
+          {{- end }}
           {{- if $.Values.server.versionCheckDisabled }}
             - name: TEMPORAL_VERSION_CHECK_DISABLED
               value: "1"

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -117,6 +117,7 @@ spec:
         {{- end }}
       containers:
         {{- range $store := (list "default" "visibility") }}
+        {{- if ne (include "temporal.persistence.driver" (list $ $store)) "elasticsearch" }}
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         - name: {{ $store }}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
@@ -170,6 +171,7 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
+        {{- end }}
         {{- end }}
           {{- with .Values.schema.resources }}
           resources:
@@ -254,6 +256,7 @@ spec:
         {{- end }}
       containers:
         {{- range $store := (list "default" "visibility") }}
+        {{- if ne (include "temporal.persistence.driver" (list $ $store)) "elasticsearch" }}
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         - name: {{ $store }}-schema
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
@@ -317,6 +320,7 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
+        {{- end }}
         {{- end }}
           {{- with .Values.schema.resources }}
           resources:

--- a/templates/server-secret.yaml
+++ b/templates/server-secret.yaml
@@ -1,5 +1,6 @@
 {{- if $.Values.server.enabled }}
 {{- range $store := (list "default" "visibility") }}
+{{- if ne (include "temporal.persistence.driver" (list $ $store)) "elasticsearch" }}
 {{- $storeConfig := index $.Values.server.config.persistence $store }}
 {{- $driverConfig := index $storeConfig (include "temporal.persistence.driver" (list $ $store)) }}
 {{- $secretName := include "temporal.componentname" (list $ (printf "%s-store" $store)) }}
@@ -30,6 +31,7 @@ data:
   {{- else if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
   password: {{ include "temporal.persistence.sql.password" (list $ $store) | b64enc | quote }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -162,6 +162,7 @@ server:
 
       visibility:
         driver: "cassandra"
+        # driver: "elasticsearch"
 
         cassandra:
           hosts: []


### PR DESCRIPTION
## What was changed
To specify Elasticsearch as only visibility storage, the value `server.config.persistence.visibility.driver` should be set to `elasticsearch`.
This omits configuring Cassandra as visibility storage coming from default values.

## Why?
When Cassandra was disabled and external Postgres was used as default storage and external Elasticsearch for visibility storage, helm failed to install because created inconsistent resources and configuration.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->