### PR TITLE
Ability to specify a loadBalancerIP for the frontend service

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -16,6 +16,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.server.frontend.service.type }}
+  {{- with .Values.server.frontend.service.loadBalancerIP }}
+  loadBalancerIP: {{.}}
+  {{- end }}
   ports:
     - port: {{ .Values.server.frontend.service.port }}
       targetPort: rpc

--- a/values.yaml
+++ b/values.yaml
@@ -198,6 +198,7 @@ server:
       annotations: {} # Evaluated as template
       type: ClusterIP
       port: 7233
+      loadBalancerIP: ""
     metrics:
       annotations:
         enabled: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adds the ability to specify a loadBalancerIP for the frontend service.

## Why?
Allow static IP for load balancer.

## Checklist
<!--- add/delete as needed --->

1. Closes: None 

2. How was this tested: `helm template`

3. Any docs updates needed? No
