### PR TITLE
Use visibilityStore config key instead of advancedVisibilityStore

### DIFF
--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -20,7 +20,7 @@ data:
     persistence:
       defaultStore: {{ $.Values.server.config.persistence.defaultStore }}
     {{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
-      advancedVisibilityStore: es-visibility
+      visibilityStore: es-visibility
     {{- else }}
       visibilityStore: visibility
     {{- end }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Use `visibilityStore` config key instead of `advancedVisibilityStore`

## Why?
<!-- Tell your future self why have you made these changes -->
`advancedVisibilityStore` is deprecated.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
