### PR TITLE
Set SQL-TLS when sql.tls.enabled is true

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -49,7 +49,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.32.0
+version: 0.33.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -95,6 +95,10 @@ spec:
               value: {{ include "temporal.persistence.sql.host" (list $ $store) }}
             - name: SQL_PORT
               value: {{ include "temporal.persistence.sql.port" (list $ $store) | quote }}
+            {{- if $storeConfig.sql.tls.enabled }}
+            - name: SQL_TLS
+              value: "true"
+            {{- end }}
             {{- if $storeConfig.sql.user }}
             - name: SQL_USER
               value: {{ $storeConfig.sql.user }}
@@ -154,6 +158,10 @@ spec:
               value: {{ include "temporal.persistence.sql.port" (list $ $store) | quote }}
             - name: SQL_DATABASE
               value: {{ include "temporal.persistence.sql.database" (list $ $store) }}
+            {{- if $storeConfig.sql.tls.enabled }}
+            - name: SQL_TLS
+              value: "true"
+            {{- end }}
             {{- if $storeConfig.sql.user }}
             - name: SQL_USER
               value: {{ $storeConfig.sql.user }}
@@ -301,6 +309,10 @@ spec:
               value: {{ include "temporal.persistence.sql.port" (list $ $store) | quote }}
             - name: SQL_DATABASE
               value: {{ include "temporal.persistence.sql.database" (list $ $store) }}
+            {{- if $storeConfig.sql.tls.enabled }}
+            - name: SQL_TLS
+              value: "true"
+            {{- end }}
             {{- if $storeConfig.sql.user }}
             - name: SQL_USER
               value: {{ $storeConfig.sql.user }}


### PR DESCRIPTION
## What was changed
This change adds `SQL_TLS` as an environment variable to the schema jobs, when you have TLS enabled for your SQL Driver.

## Why?
The Schema Jobs are unable to run against a PostgreSQL server that requires TLS, as it does not currently respect your TLS settings.

## Checklist
1. Closes
None

3. How was this tested:
Tested on a 1.28 Kubernetes cluster, with an AWS RDS Proxy being used as the PSQL host.

4. Any docs updates needed?
N/A
