### PR TITLE
Fix condition for rendering visibility config

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -57,7 +57,7 @@ data:
             {{- end }}
           {{- end }}
         visibility:
-          {{- if eq (include "temporal.persistence.driver" (list $ "default")) "sql" }}
+          {{- if eq (include "temporal.persistence.driver" (list $ "visibility")) "sql" }}
           sql:
             pluginName: "{{ include "temporal.persistence.sql.driver" (list $ "visibility") }}"
             driverName: "{{ include "temporal.persistence.sql.driver" (list $ "visibility") }}"


### PR DESCRIPTION
While rendering visibility store config, instead of checking for .visibility key, it was checking for .default. Works when both your default and visibility store are same. Otherwise, doesn't.

<!--- For ALL Contributors 👇 -->

## What was changed
The condition for rendering visibility config in the server configmap was fixed.

## Why?
This was a typo-like bug that was fixed.

## Checklist

1. Closes #466 .

2. How was this tested:
By rendering using helm template.

3. Any docs updates needed?
No.
