### PR TITLE
fix: add support for pre upgrade.

### DIFF
--- a/charts/temporal/templates/serviceaccount.yaml
+++ b/charts/temporal/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/part-of: {{ .Chart.Name }}
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install, pre-upgrade
     helm.sh/hook-weight: "-10"
     {{- with .Values.serviceAccount.extraAnnotations }}
       {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added support for pre-upgrade hook for creation of service account.

## Why?
<!-- Tell your future self why have you made these changes -->
- While trying to change the service account from default, post install. Service account is not created.
- This is because service account only has pre-install hook, and pre-upgrade is triggered when updating an existing release.

## Checklist
<!--- add/delete as needed --->

1. Closes #432 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Changes were tested by running a local chart with the existing changes.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No
