### PR TITLE
feat: add create default namespace job

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -419,4 +419,77 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+---
+{{- if .Values.schema.defaultNamespace.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "temporal.componentname" (list . "default-namespace") }}
+  labels:
+    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    helm.sh/chart: {{ include "temporal.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.defaultNamespace.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "temporal.componentname" (list . "default-namespace") }}
+      labels:
+        app.kubernetes.io/name: {{ include "temporal.name" . }}
+        helm.sh/chart: {{ include "temporal.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      {{ include "temporal.serviceAccount" . }}
+      restartPolicy: "OnFailure"
+      containers:
+        - name: create-default-namespace
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              temporal operator namespace describe {{ .Values.schema.defaultNamespace.namespace }} || temporal operator namespace create {{ .Values.schema.defaultNamespace.namespace }}
+          env:
+            - name: TEMPORAL_ADDRESS
+              value: "{{ include "temporal.fullname" . }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
+          {{- with .Values.schema.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.schema.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.schema.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default $.Values.admintools.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admintools.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -382,6 +382,10 @@ schema:
   update:
     enabled: true
     backoffLimit: 100
+  defaultNamespace:
+    enabled: true
+    backoffLimit: 100
+    namespace: default
   resources: {}
   containerSecurityContext: {}
   securityContext: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
add job to create default namespace
## Why?
<!-- Tell your future self why have you made these changes -->
feature request: https://github.com/temporalio/helm-charts/issues/420
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> #420

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
```bash
helm template abc charts/temporal/

# disable: helm template abc charts/temporal/ --set schema.defaultNamespace.enabled=false
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
| name | type | description |
|--------|--------|--------|
| schema.defaultNamespace.enabled | boolean | control create namespace. default is `true` |
| schema.defaultNamespace.backoffLimit | integer | job after fail max time to re-run. default is `100` |
| schema.defaultNamespace.namespace | string | which namespace need to create. default is `default` |
