### PR TITLE
Allow to skip database creation

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -49,6 +49,7 @@ spec:
           imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
           command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ .Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
         {{- end }}
+        {{- if .Values.schema.createDatabase.enabled }}
         {{- range $store := (list "default" "visibility") }}
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
@@ -110,6 +111,7 @@ spec:
               value: {{ $storeConfig.sql.password }}
               {{- end }}
             {{- end }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- else }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -376,6 +376,8 @@ web:
   securityContext: {}
 
 schema:
+  createDatabase:
+    enabled: true
   setup:
     enabled: true
     backoffLimit: 100

--- a/charts/temporal/values/values.aurora-mysql.yaml
+++ b/charts/temporal/values/values.aurora-mysql.yaml
@@ -41,6 +41,8 @@ postgresql:
   enabled: false
 
 schema:
+  createDatabase:
+    enabled: true
   setup:
     enabled: false
   update:

--- a/charts/temporal/values/values.cassandra.yaml
+++ b/charts/temporal/values/values.cassandra.yaml
@@ -49,6 +49,8 @@ postgresql:
   enabled: false
 
 schema:
+  createDatabase:
+    enabled: true
   setup:
     enabled: false
   update:

--- a/charts/temporal/values/values.mysql.yaml
+++ b/charts/temporal/values/values.mysql.yaml
@@ -37,6 +37,8 @@ postgresql:
   enabled: false
 
 schema:
+  createDatabase:
+    enabled: true
   setup:
     enabled: false
   update:

--- a/charts/temporal/values/values.postgresql.yaml
+++ b/charts/temporal/values/values.postgresql.yaml
@@ -60,6 +60,8 @@ elasticsearch:
   enabled: true
 
 schema:
+  createDatabase:
+    enabled: true
   setup:
     enabled: false
   update:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR adds an ability to skip database creation. The default values ensures that the change will be backwards compatible with an existing installations.
## Why?
<!-- Tell your future self why have you made these changes -->

Currently it's not possible to use already existing database when deploying Temporal using this Helm chart
## Checklist
<!--- add/delete as needed --->

1. Closes #440


2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I've performed a fresh install with:
```
schema:
  createDatabase:
    enabled: false
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
