### PR TITLE
fix: update obsolete transaction isolation level attribute for aurora…

### DIFF
--- a/charts/temporal/values/values.aurora-mysql.yaml
+++ b/charts/temporal/values/values.aurora-mysql.yaml
@@ -14,7 +14,7 @@ server:
           maxConns: 20
           maxConnLifetime: "1h"
           connectAttributes:
-            tx_isolation: 'READ-COMMITTED'
+            transaction_isolation: 'READ-COMMITTED'
 
       visibility:
         driver: "sql"
@@ -29,7 +29,7 @@ server:
           maxConns: 20
           maxConnLifetime: "1h"
           connectAttributes:
-            tx_isolation: 'READ-COMMITTED'          
+            transaction_isolation: 'READ-COMMITTED'
 
 cassandra:
   enabled: false


### PR DESCRIPTION
…/mysql

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

The tx_transaction is no longer available with the most recent aurora/mysql version.
That attribute is now replaced with transaction_isolation.
AWS documentation for reference https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.ParameterGroups.html
I've tested this change on the most recent aurora/mysql version 8.0.mysql_aurora.3.06.0

## Why?
<!-- Tell your future self why have you made these changes -->

Without this change the temporal servers won't start. Here is the error message from one of the pod crashing:

`Error 1193: Unknown system variable 'tx_isolation'`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

On latest Aurora/MySQL version version 8.0.mysql_aurora.3.06.0 with temporal version 1.30.0

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
