### PR TITLE
Ensure appVersion is used by default as the server image tag.

### DIFF
--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -49,7 +49,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.37.0
+version: 0.38.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       {{ include "temporal.serviceAccount" . }}
       containers:
         - name: admin-tools
-          image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
+          image: "{{ .Values.admintools.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.admintools.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       {{ include "temporal.serviceAccount" . }}
       containers:
         - name: admin-tools
-          image: "{{ .Values.admintools.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.admintools.image.repository }}:{{ default .Chart.AppVersion .Values.admintools.image.tag }}"
           imagePullPolicy: {{ .Values.admintools.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -68,14 +68,14 @@ spec:
         {{- end }}
         {{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
         - name: check-elasticsearch-index
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'until curl --silent --fail {{- if and $.Values.elasticsearch.username $.Values.elasticsearch.password }} --user {{ $.Values.elasticsearch.username }}:{{ $.Values.elasticsearch.password }} {{- end }} {{ $.Values.elasticsearch.scheme }}://{{ $.Values.elasticsearch.host }}:{{ $.Values.elasticsearch.port }}/{{ $.Values.elasticsearch.visibilityIndex }} 2>&1 > /dev/null; do echo waiting for elasticsearch index to become ready; sleep 1; done;']
         {{- end }}
       {{- end }}
       containers:
         - name: {{ $.Chart.Name }}-{{ $service }}
-          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          image: "{{ $.Values.server.image.repository }}:{{ $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           env:
             - name: POD_IP

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -68,14 +68,14 @@ spec:
         {{- end }}
         {{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
         - name: check-elasticsearch-index
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ default $.Chart.AppVersion $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'until curl --silent --fail {{- if and $.Values.elasticsearch.username $.Values.elasticsearch.password }} --user {{ $.Values.elasticsearch.username }}:{{ $.Values.elasticsearch.password }} {{- end }} {{ $.Values.elasticsearch.scheme }}://{{ $.Values.elasticsearch.host }}:{{ $.Values.elasticsearch.port }}/{{ $.Values.elasticsearch.visibilityIndex }} 2>&1 > /dev/null; do echo waiting for elasticsearch index to become ready; sleep 1; done;']
         {{- end }}
       {{- end }}
       containers:
         - name: {{ $.Chart.Name }}-{{ $service }}
-          image: "{{ $.Values.server.image.repository }}:{{ $.Chart.AppVersion }}"
+          image: "{{ $.Values.server.image.repository }}:{{ default $.Chart.AppVersion $.Values.server.image.tag }}"
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           env:
             - name: POD_IP

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -53,7 +53,7 @@ spec:
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
         - name: create-{{ $store }}-store
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['temporal-cassandra-tool', 'create', '-k', '{{ $storeConfig.cassandra.keyspace }}', '--replication-factor', '{{ $storeConfig.cassandra.replicationFactor }}']
           env:
@@ -85,7 +85,7 @@ spec:
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
         - name: create-{{ $store }}-store
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['temporal-sql-tool', '--database', '{{ include "temporal.persistence.sql.database" (list $ $store) }}', 'create-database']
           env:
@@ -119,7 +119,7 @@ spec:
         {{- range $store := (list "default" "visibility") }}
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         - name: {{ $store }}-schema
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'setup-schema', '-v', '0.0']
           env:
@@ -257,7 +257,7 @@ spec:
         {{- if or (eq $store "default") (eq (include "temporal.persistence.driver" (list $ $store)) "sql") }}
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         - name: {{ $store }}-schema
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
           command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'update-schema', '--schema-dir', '/etc/temporal/schema/cassandra/{{ include "temporal.persistence.schema" $store }}/versioned']
@@ -383,12 +383,12 @@ spec:
       restartPolicy: "OnFailure"
       initContainers:
         - name: check-elasticsearch
-          image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
+          image: "{{ .Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'until curl --silent --fail {{- if and .Values.elasticsearch.username .Values.elasticsearch.password }} --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{- end }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
       containers:
         - name: create-elasticsearch-index
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c']
           args:

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -53,7 +53,7 @@ spec:
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
         - name: create-{{ $store }}-store
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ default $.Chart.AppVersion $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['temporal-cassandra-tool', 'create', '-k', '{{ $storeConfig.cassandra.keyspace }}', '--replication-factor', '{{ $storeConfig.cassandra.replicationFactor }}']
           env:
@@ -85,7 +85,7 @@ spec:
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         {{- if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
         - name: create-{{ $store }}-store
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ default $.Chart.AppVersion $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['temporal-sql-tool', '--database', '{{ include "temporal.persistence.sql.database" (list $ $store) }}', 'create-database']
           env:
@@ -119,7 +119,7 @@ spec:
         {{- range $store := (list "default" "visibility") }}
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         - name: {{ $store }}-schema
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ default $.Chart.AppVersion $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'setup-schema', '-v', '0.0']
           env:
@@ -257,7 +257,7 @@ spec:
         {{- if or (eq $store "default") (eq (include "temporal.persistence.driver" (list $ $store)) "sql") }}
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
         - name: {{ $store }}-schema
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ default $.Chart.AppVersion $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
           command: ['temporal-{{ include "temporal.persistence.driver" (list $ $store) }}-tool', 'update-schema', '--schema-dir', '/etc/temporal/schema/cassandra/{{ include "temporal.persistence.schema" $store }}/versioned']
@@ -383,12 +383,12 @@ spec:
       restartPolicy: "OnFailure"
       initContainers:
         - name: check-elasticsearch
-          image: "{{ .Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
+          image: "{{ .Values.admintools.image.repository }}:{{ default $.Chart.AppVersion $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'until curl --silent --fail {{- if and .Values.elasticsearch.username .Values.elasticsearch.password }} --user {{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }} {{- end }} {{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }} 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
       containers:
         - name: create-elasticsearch-index
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Chart.AppVersion }}"
+          image: "{{ $.Values.admintools.image.repository }}:{{ default $.Chart.AppVersion $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c']
           args:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -21,7 +21,7 @@ server:
   sidecarContainers: {}
   image:
     repository: temporalio/server
-    tag: 1.22.4
+    tag: 1.23.1
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -286,7 +286,7 @@ admintools:
   enabled: true
   image:
     repository: temporalio/admin-tools
-    tag: 1.22.4
+    tag: 1.23.1
     pullPolicy: IfNotPresent
 
   service:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -21,7 +21,7 @@ server:
   sidecarContainers: {}
   image:
     repository: temporalio/server
-    tag: 1.23.1
+    tag: {}
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -286,7 +286,7 @@ admintools:
   enabled: true
   image:
     repository: temporalio/admin-tools
-    tag: 1.23.1
+    tag: {}
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated image versions for frontend/matching/worker/history/admintools to 1.23.1

## Why?
Chart.yaml and values.yaml were out of sync

## Checklist
<!--- add/delete as needed --->

2. How was this tested:
Not tested 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
