### PR TITLE
Fix default image tag type in values 

### DIFF
--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -21,7 +21,7 @@ server:
   sidecarContainers: {}
   image:
     repository: temporalio/server
-    tag: {}
+    tag: ""
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -286,7 +286,7 @@ admintools:
   enabled: true
   image:
     repository: temporalio/admin-tools
-    tag: {}
+    tag: ""
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fix the default type of the image tag from map `{}` to string `""` in the values file.
Issue introduced in https://github.com/temporalio/helm-charts/pull/488

## Why?
<!-- Tell your future self why have you made these changes -->

It's causing these errors when rendering the chart
```
coalesce.go:286: warning: cannot overwrite table with non table for temporal.temporal.server.image.tag (map[])
``` 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
   None

2. How was this tested:
   By rendering helm templates locally

3. Any docs updates needed?
   No
