### PR TITLE
Add auth and database features

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.server.enabled }}
-{{- range $service := (list "frontend" "history" "matching" "worker") }}
+{{- range $service := (list "frontend" "internal-frontend" "history" "matching" "worker") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -34,8 +34,9 @@ data:
           cassandra:
             hosts: "{{ include "temporal.persistence.cassandra.hosts" (list $ "default") }}"
             port: {{ include "temporal.persistence.cassandra.port" (list $ "default") }}
+            user: "{{ `{{ .Env.TEMPORAL_STORE_USER }}` }}"
             password: "{{ `{{ .Env.TEMPORAL_STORE_PASSWORD }}` }}"
-            {{- with (omit $.Values.server.config.persistence.default.cassandra "hosts" "port" "password" "existingSecret") }}
+            {{- with (omit $.Values.server.config.persistence.default.cassandra "hosts" "port" "user" "password" "existingSecret") }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
@@ -50,7 +51,7 @@ data:
             databaseName: "{{ $.Values.server.config.persistence.default.sql.database }}"
             connectAddr: "{{ include "temporal.persistence.sql.host" (list $ "default") }}:{{ include "temporal.persistence.sql.port" (list $ "default") }}"
             connectProtocol: "tcp"
-            user: {{ include "temporal.persistence.sql.user" (list $ "default") }}
+            user: "{{ `{{ .Env.TEMPORAL_STORE_USER }}` }}"
             password: "{{ `{{ .Env.TEMPORAL_STORE_PASSWORD }}` }}"
             {{- with (omit $.Values.server.config.persistence.default.sql "driver" "driverName" "host" "port" "connectAddr" "connectProtocol" "database" "databaseName" "user" "password" "existingSecret") }}
             {{- toYaml . | nindent 12 }}
@@ -64,7 +65,7 @@ data:
             databaseName: "{{ $.Values.server.config.persistence.visibility.sql.database }}"
             connectAddr: "{{ include "temporal.persistence.sql.host" (list $ "visibility") }}:{{ include "temporal.persistence.sql.port" (list $ "visibility") }}"
             connectProtocol: "tcp"
-            user: "{{ include "temporal.persistence.sql.user" (list $ "visibility") }}"
+            user: "{{ `{{ .Env.TEMPORAL_VISIBILITY_STORE_USER }}` }}"
             password: "{{ `{{ .Env.TEMPORAL_VISIBILITY_STORE_PASSWORD }}` }}"
             {{- with (omit $.Values.server.config.persistence.visibility.sql "driver" "driverName" "host" "port" "connectAddr" "connectProtocol" "database" "databaseName" "user" "password" "existingSecret") }}
             {{- toYaml . | nindent 12 }}
@@ -111,6 +112,21 @@ data:
           listenAddress: "0.0.0.0:9090"
         {{- end }}
 
+      {{- if $.Values.server.config.auth.enabled }}
+      authorization:
+        authorizer: "{{ $.Values.server.config.auth.authorizer }}"
+        claimMapper: "{{ $.Values.server.config.auth.claimMapper }}"
+        permissionsClaimName: "{{ $.Values.server.config.auth.permissionsClaimName }}"
+        jwtKeyProvider:
+          keySourceURIs:
+          {{- with $.Values.server.config.auth.jwtKeyProvider.keySourceURIs }}
+          {{- range . }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- end }}
+          refreshInterval: "{{ $.Values.server.config.auth.jwtKeyProvider.refreshInterval }}"
+      {{- end }}
+
       {{- if $.Values.server.config.tls }}
       tls:
         {{- with $.Values.server.config.tls }}
@@ -124,6 +140,14 @@ data:
           grpcPort: {{ include "temporal.frontend.grpcPort" $ }}
           membershipPort: {{ include "temporal.frontend.membershipPort" $ }}
           bindOnIP: "0.0.0.0"
+
+      {{- if index $.Values.server "internal-frontend" "enabled" }}
+      internal-frontend:
+        rpc:
+          grpcPort: {{ include "temporal.internal-frontend.grpcPort" $ }}
+          membershipPort: {{ include "temporal.internal-frontend.membershipPort" $ }}
+          bindOnIP: "0.0.0.0"
+      {{- end }}
 
       history:
         rpc:
@@ -192,8 +216,10 @@ data:
 
     {{- end }}
 
+    {{- if not (index $.Values.server "internal-frontend" "enabled") }}
     publicClient:
       hostPort: "{{ include "temporal.componentname" (list $ "frontend") }}:{{ $.Values.server.frontend.service.port }}"
+    {{- end }}
 
     dynamicConfigClient:
       filepath: "/etc/temporal/dynamic_config/dynamic_config.yaml"

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.server.enabled }}
-{{- range $service := (list "frontend" "history" "matching" "worker") }}
+{{- range $service := (list "frontend" "internal-frontend" "history" "matching" "worker") }}
 {{- $serviceValues := index $.Values.server $service -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -100,16 +100,30 @@ spec:
               value: "{{ $.Values.elasticsearch.password }}"
             - name: SERVICES
               value: {{ $service }}
+            - name: TEMPORAL_STORE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ "default") }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ "default") }}
             - name: TEMPORAL_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "default") }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ "default") }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ "default") }}
+            - name: TEMPORAL_VISIBILITY_STORE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ "visibility") }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ "visibility") }}
             - name: TEMPORAL_VISIBILITY_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "visibility") }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ "visibility") }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ "visibility") }}
+          {{- if index $.Values.server "internal-frontend" "enabled" }}
+            - name: USE_INTERNAL_FRONTEND
+              value: "1"
+          {{- end }}
           {{- if $.Values.server.versionCheckDisabled }}
             - name: TEMPORAL_VERSION_CHECK_DISABLED
               value: "1"

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -65,7 +65,14 @@ spec:
               value: {{ $storeConfig.cassandra.keyspace }}
             {{- if $storeConfig.cassandra.user }}
             - name: CASSANDRA_USER
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.cassandra.user }}
+              {{- end }}
             {{- end }}
             {{- if (or $storeConfig.cassandra.password $storeConfig.cassandra.existingSecret) }}
             - name: CASSANDRA_PASSWORD
@@ -73,7 +80,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ $store) }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ $store) }}
               {{- else }}
               value: {{ $storeConfig.cassandra.password }}
               {{- end }}
@@ -97,7 +104,14 @@ spec:
               value: {{ include "temporal.persistence.sql.port" (list $ $store) | quote }}
             {{- if $storeConfig.sql.user }}
             - name: SQL_USER
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.sql.user }}
+              {{- end }}
             {{- end }}
             {{- if (or $storeConfig.sql.password $storeConfig.sql.existingSecret) }}
             - name: SQL_PASSWORD
@@ -105,7 +119,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ $store) }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ $store) }}
               {{- else }}
               value: {{ $storeConfig.sql.password }}
               {{- end }}
@@ -132,7 +146,14 @@ spec:
               value: {{ $storeConfig.cassandra.keyspace }}
             {{- if $storeConfig.cassandra.user }}
             - name: CASSANDRA_USER
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.cassandra.user }}
+              {{- end }}
             {{- end }}
             {{- if (or $storeConfig.cassandra.password $storeConfig.cassandra.existingSecret) }}
             - name: CASSANDRA_PASSWORD
@@ -140,7 +161,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ $store) }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ $store) }}
               {{- else }}
               value: {{ $storeConfig.cassandra.password }}
               {{- end }}
@@ -156,7 +177,14 @@ spec:
               value: {{ include "temporal.persistence.sql.database" (list $ $store) }}
             {{- if $storeConfig.sql.user }}
             - name: SQL_USER
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.sql.user }}
+              {{- end }}
             {{- end }}
             {{- if (or $storeConfig.sql.password $storeConfig.sql.existingSecret) }}
             - name: SQL_PASSWORD
@@ -164,7 +192,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ $store) }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ $store) }}
               {{- else }}
               value: {{ $storeConfig.sql.password }}
               {{- end }}
@@ -276,7 +304,14 @@ spec:
               value: {{ $storeConfig.cassandra.keyspace }}
             {{- if $storeConfig.cassandra.user }}
             - name: CASSANDRA_USER
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.cassandra.user }}
+              {{- end }}
             {{- end }}
             {{- if (or $storeConfig.cassandra.password $storeConfig.cassandra.existingSecret) }}
             - name: CASSANDRA_PASSWORD
@@ -284,7 +319,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ $store) }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ $store) }}
               {{- else }}
               value: {{ $storeConfig.cassandra.password }}
               {{- end }}
@@ -300,7 +335,14 @@ spec:
               value: {{ include "temporal.persistence.sql.database" (list $ $store) }}
             {{- if $storeConfig.sql.user }}
             - name: SQL_USER
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.sql.user }}
+              {{- end }}
             {{- end }}
             {{- if (or $storeConfig.sql.password $storeConfig.sql.existingSecret) }}
             - name: SQL_PASSWORD
@@ -308,7 +350,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ $store) }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ $store) }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ $store) }}
               {{- else }}
               value: {{ $storeConfig.sql.password }}
               {{- end }}

--- a/charts/temporal/templates/server-pdb.yaml
+++ b/charts/temporal/templates/server-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.server.enabled }}
-{{- range $service := (list "frontend" "history" "matching" "worker") }}
+{{- range $service := (list "frontend" "internal-frontend" "history" "matching" "worker") }}
 {{- $serviceValues := index $.Values.server $service -}}
 {{- if and (gt ($serviceValues.replicaCount | int) 1) ($serviceValues.podDisruptionBudget) }}
 apiVersion: policy/v1

--- a/charts/temporal/templates/server-secret.yaml
+++ b/charts/temporal/templates/server-secret.yaml
@@ -26,8 +26,10 @@ metadata:
 type: Opaque
 data:
   {{- if eq (include "temporal.persistence.driver" (list $ $store)) "cassandra" }}
+  username: {{ $storeConfig.cassandra.user | b64enc | quote }}
   password: {{ $storeConfig.cassandra.password | b64enc | quote }}
   {{- else if eq (include "temporal.persistence.driver" (list $ $store)) "sql" }}
+  username: {{ include "temporal.persistence.sql.user" (list $ $store) | b64enc | quote }}
   password: {{ include "temporal.persistence.sql.password" (list $ $store) | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/temporal/templates/server-service-monitor.yaml
+++ b/charts/temporal/templates/server-service-monitor.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.server.enabled }}
-{{- range $service := (list "frontend" "matching" "history" "worker") }}
+{{- range $service := (list "frontend" "internal-frontend" "matching" "history" "worker") }}
 {{- $serviceValues := index $.Values.server $service -}}
 {{- if (default $.Values.server.metrics.serviceMonitor.enabled $serviceValues.metrics.serviceMonitor.enabled) }}
 apiVersion: monitoring.coreos.com/v1

--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -30,7 +30,7 @@ spec:
     app.kubernetes.io/component: frontend
 
 ---
-{{- range $service := (list "frontend" "matching" "history" "worker") }}
+{{- range $service := (list "frontend" "internal-frontend" "matching" "history" "worker") }}
 {{- $serviceValues := index $.Values.server $service -}}
 apiVersion: v1
 kind: Service

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -51,6 +51,28 @@ spec:
           env:
             - name: TEMPORAL_ADDRESS
               value: "{{ include "temporal.fullname" . }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
+            {{- if .Values.web.auth.enabled }}
+            - name: TEMPORAL_AUTH_ENABLED
+              value: "{{ .Values.web.auth.enabled }}"
+            {{- if .Values.web.auth.providers }}
+            - name: TEMPORAL_AUTH_LABEL
+              value: "{{ (index .Values.web.auth.providers 0).label }}"
+            - name: TEMPORAL_AUTH_TYPE
+              value: "{{ (index .Values.web.auth.providers 0).type }}"
+            - name: TEMPORAL_AUTH_PROVIDER_URL
+              value: "{{ (index .Values.web.auth.providers 0).providerUrl }}"
+            - name: TEMPORAL_AUTH_ISSUER_URL
+              value: "{{ (index .Values.web.auth.providers 0).issuerUrl }}"
+            - name: TEMPORAL_AUTH_CLIENT_ID
+              value: "{{ (index .Values.web.auth.providers 0).clientId }}"
+            - name: TEMPORAL_AUTH_CLIENT_SECRET
+              value: "{{ (index .Values.web.auth.providers 0).clientSecret }}"
+            - name: TEMPORAL_AUTH_CALLBACK_URL
+              value: "{{ (index .Values.web.auth.providers 0).callbackUrl }}"
+            - name: TEMPORAL_AUTH_SCOPES
+              value: "{{ (index .Values.web.auth.providers 0).scopes }}"
+          {{- end }}
+          {{- end }}
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -192,12 +192,46 @@ server:
           maxConnLifetime: "1h"
           # connectAttributes:
           #   tx_isolation: 'READ-COMMITTED'
+    auth:
+      enabled: false
+      # authorizer: default
+      # claimMapper: default
+      # permissionsClaimName: roles
+      # jwtKeyProvider:
+      #   keySourceURIs:
+      #   - "https://login.microsoftonline.com/<tenant id>/discovery/v2.0/keys"
+      #   refreshInterval: 30m
+
 
   frontend:
     service:
       annotations: {} # Evaluated as template
       type: ClusterIP
       port: 7233
+    metrics:
+      annotations:
+        enabled: true
+      serviceMonitor: {}
+      # enabled: false
+      prometheus: {}
+      # timerType: histogram
+    podAnnotations: {}
+    podLabels: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    additionalEnv: []
+    containerSecurityContext: {}
+    topologySpreadConstraints: {}
+    podDisruptionBudget: {}
+
+  internal-frontend:
+    enabled: false
+    service:
+      annotations: {} # Evaluated as template
+      type: ClusterIP
+      port: 7236
     metrics:
       annotations:
         enabled: true
@@ -310,6 +344,18 @@ web:
     # server/config.yml file content
     auth:
       enabled: false
+      # Use below settings for azure ad oidc
+      # enabled: true
+      # providers:
+      # - label: "Azure AD OIDC"
+      #   type: oidc
+      #   providerUrl: "https://login.microsoftonline.com/<tenant id>/v2.0"
+      #   issuerUrl: "https://login.microsoftonline.com/<tenant id>/v2.0"
+      #   clientId: "<service principal client id>"
+      #   clientSecret: "<service principal client secret>"
+      #   callbackUrl: "https://<temporal url>/auth/sso/callback"
+      #   scopes: "openid,profile,email,api://<app uri>/default"
+
     routing:
       default_to_namespace: # internal use only
       issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR includes two primary functionality enhancements to the helm chart:

- Addition of Auth settings to both server and web
- Allowing database username to optionally be specified in a secret alongside the password

## Why?
<!-- Tell your future self why have you made these changes -->
I'll address each area separately:

**Auth** - production environments need some form of authentication.  To use authentication, it was required to be enabled in both the server and web components.  Additionally, an `internal-frontend` service was added (per the v1.20.0 release) to allow the workflow service to function.  This also addresses an open issue (#304).

**Database Creds** - many dynamic database creds generation systems (such as hashicorp vault) generate both the username and password dynamically, which is more secure than just rotating the password.  The functionality has been updated to allow either or both of these to be optionally set via a secret with any or both of `username` and `password` keys.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> #304

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Tested a number of times using various alternatives of the configurations.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Included documentation via commented out items in values.yaml
