### PR TITLE
Use tplvalues.render for templating inside values

### DIFF
--- a/charts/temporal/templates/web-service.yaml
+++ b/charts/temporal/templates/web-service.yaml
@@ -11,10 +11,9 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: web
     app.kubernetes.io/part-of: {{ .Chart.Name }}
-{{- with .Values.web.service.annotations }}
-  annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+  {{- if .Values.web.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.web.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.web.service.loadBalancerIP }}
   loadBalancerIP: {{.}}


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->


<!--- For ALL Contributors 👇 -->

## What was changed
Use templating for `web.service` annotations in the same way as `server.service` is defined https://github.com/temporalio/helm-charts/blob/bad8c74311717f2121579f64e2e6b1670fc19818/charts/temporal/templates/server-service.yaml#L15.

## Why?
A very cool trick to allow passing templated values inside the values.yaml file instead of relying on an outside templating engine

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added a template in `values.yaml` and ran `helm template`.

3. Any docs updates needed?
No
