### PR TITLE
Apply security context regardless of persistence engine.

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -45,13 +45,13 @@ spec:
         {{- end }}
     spec:
       {{ include "temporal.serviceAccount" $ }}
-      {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       {{- if semverCompare ">=1.13.0" $.Chart.AppVersion}}
       {{- with $.Values.server.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
+      {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       initContainers:
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service


### PR DESCRIPTION
Replaces #308.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Always apply the security context if set rather than only doing so if using cassandra or elasticsearch.
<!-- Describe what has changed in this PR -->

## Why?
security context is unrelated to persistence engine.

Updated version of #308 which is outdated.
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
