### PR TITLE
Revert "Update Cassandra host URLs to remove the ".cluster.local" suffix (#485)"

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -350,7 +350,7 @@ All Cassandra hosts.
 {{- define "cassandra.hosts" -}}
 {{- range $i := (until (int .Values.cassandra.config.cluster_size)) }}
 {{- $cassandraName := include "call-nested" (list $ "cassandra" "cassandra.fullname") -}}
-{{- printf "%s.%s.svc," $cassandraName $.Release.Namespace -}}
+{{- printf "%s.%s.svc.cluster.local," $cassandraName $.Release.Namespace -}}
 {{- end }}
 {{- end -}}
 
@@ -359,7 +359,7 @@ The first Cassandra host in the stateful set.
 */}}
 {{- define "cassandra.host" -}}
 {{- $cassandraName := include "call-nested" (list . "cassandra" "cassandra.fullname") -}}
-{{- printf "%s.%s.svc" $cassandraName .Release.Namespace -}}
+{{- printf "%s.%s.svc.cluster.local" $cassandraName .Release.Namespace -}}
 {{- end -}}
 
 {{/*

--- a/charts/temporal/values/values.cassandra.yaml
+++ b/charts/temporal/values/values.cassandra.yaml
@@ -27,7 +27,7 @@ server:
 #                      ResourceExhausted: 0.15
 
         cassandra:
-          hosts: ["cassandra.default.svc"]
+          hosts: ["cassandra.default.svc.cluster.local"]
           port: 9042
           keyspace: temporal
           user: "user"


### PR DESCRIPTION
This reverts commit b25c4fcd0e2661d1b18e3bc018ac957d4193448c.

## What was changed
Revert the change to remove the ".cluster.local" suffix.

## Why?
Just noticed that some of our test cells could not come up after this change.
Our busybox container was not able to resolve cassandra pods without .cluster.local

## Checklist
