### PR TITLE
Remove hard coded cluster.local references.

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -350,7 +350,7 @@ All Cassandra hosts.
 {{- define "cassandra.hosts" -}}
 {{- range $i := (until (int .Values.cassandra.config.cluster_size)) }}
 {{- $cassandraName := include "call-nested" (list $ "cassandra" "cassandra.fullname") -}}
-{{- printf "%s.%s.svc.cluster.local," $cassandraName $.Release.Namespace -}}
+{{- printf "%s.%s," $cassandraName $.Release.Namespace -}}
 {{- end }}
 {{- end -}}
 
@@ -359,7 +359,7 @@ The first Cassandra host in the stateful set.
 */}}
 {{- define "cassandra.host" -}}
 {{- $cassandraName := include "call-nested" (list . "cassandra" "cassandra.fullname") -}}
-{{- printf "%s.%s.svc.cluster.local" $cassandraName .Release.Namespace -}}
+{{- printf "%s.%s" $cassandraName .Release.Namespace -}}
 {{- end -}}
 
 {{/*

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -56,7 +56,7 @@ spec:
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service
           image: busybox
-          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+          command: ['sh', '-c', 'until nc -z {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }}; do echo waiting for cassandra service; sleep 1; done;']
         - name: check-cassandra
           image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
           imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -43,7 +43,7 @@ spec:
         {{- if .Values.cassandra.enabled }}
         - name: check-cassandra-service
           image: busybox
-          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+          command: ['sh', '-c', 'until nc -z {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }}; do echo waiting for cassandra service; sleep 1; done;']
         - name: check-cassandra
           image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
           imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
@@ -302,7 +302,7 @@ spec:
         {{- if .Values.cassandra.enabled }}
         - name: check-cassandra-service
           image: busybox
-          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+          command: ['sh', '-c', 'until nc -z {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }}; do echo waiting for cassandra service; sleep 1; done;']
         - name: check-cassandra
           image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
           imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}


### PR DESCRIPTION
Switch check-cassandra-service init container to use nc. nslookup in recent busybox images is broken and doesn't obey resolv.conf, meaning it won't check k8s search domains.

Alternative fix for #485 