### PR TITLE
Use admintools-env and secret for ES password consistent with e.g. jobs

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -70,7 +70,9 @@ spec:
         - name: check-elasticsearch-index
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'until curl --silent --fail {{- if and $.Values.elasticsearch.username $.Values.elasticsearch.password }} --user "{{ $.Values.elasticsearch.username }}:{{ $.Values.elasticsearch.password }}" {{- end }} {{ $.Values.elasticsearch.scheme }}://{{ $.Values.elasticsearch.host }}:{{ $.Values.elasticsearch.port }}/{{ $.Values.elasticsearch.visibilityIndex }} 2>&1 > /dev/null; do echo waiting for elasticsearch index to become ready; sleep 1; done;']
+          command: ['sh', '-c', 'until curl --silent --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1 > /dev/null; do echo waiting for elasticsearch index to become ready; sleep 1; done;']
+          env:
+            {{- include "temporal.admintools-env" (list $ "visibility") | nindent 12 }}
         {{- end }}
       {{- end }}
       containers:


### PR DESCRIPTION
## What was changed
The ES check init container on the main deployment of temporal server is made consistent with the Job templates' similar containers.

## Why?
Problem encountered with setting up Temporal deployment with external Elasticsearch using authentication.
Issue created:
https://github.com/temporalio/helm-charts/issues/529

## Why draft
We need to work a bit to test this chart version with our deployment