### PR TITLE
Add support for deployment labels and annotations

### DIFF
--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -11,6 +11,13 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: admintools
     app.kubernetes.io/part-of: {{ .Chart.Name }}
+    {{- with $.Values.admintools.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $.Values.admintools.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -13,6 +13,13 @@ metadata:
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: {{ $service }}
     app.kubernetes.io/part-of: {{ $.Chart.Name }}
+    {{- with (default $.Values.server.deploymentLabels $serviceValues.deploymentLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with (default $.Values.server.deploymentAnnotations $serviceValues.deploymentAnnotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ default $.Values.server.replicaCount $serviceValues.replicaCount }}
   selector:

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -11,6 +11,13 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: web
     app.kubernetes.io/part-of: {{ .Chart.Name }}
+    {{- with $.Values.web.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $.Values.web.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.web.replicaCount }}
   selector:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -58,6 +58,8 @@ server:
       #   targetLabel: __name__
     prometheus:
       timerType: histogram
+  deploymentAnnotations: {}
+  deploymentLabels: {}
   podAnnotations: {}
   podLabels: {}
   secretLabels: {}
@@ -207,6 +209,8 @@ server:
       # enabled: false
       prometheus: {}
       # timerType: histogram
+    deploymentAnnotations: {}
+    deploymentLabels: {}
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -229,6 +233,8 @@ server:
       # enabled: false
       prometheus: {}
       # timerType: histogram
+    deploymentAnnotations: {}
+    deploymentLabels: {}
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -251,6 +257,8 @@ server:
       # enabled: false
       prometheus: {}
       # timerType: histogram
+    deploymentAnnotations: {}
+    deploymentLabels: {}
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -273,6 +281,8 @@ server:
       # enabled: false
       prometheus: {}
       # timerType: histogram
+    deploymentAnnotations: {}
+    deploymentLabels: {}
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -293,6 +303,8 @@ admintools:
     type: ClusterIP
     port: 22
     annotations: {}
+  deploymentAnnotations: {}
+  deploymentLabels: {}
   podLabels: {}
   podAnnotations: {}
   nodeSelector: {}
@@ -332,6 +344,8 @@ web:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+  deploymentAnnotations: {}
+  deploymentLabels: {}
   podAnnotations: {}
   podLabels: {}
   resources: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This PR adds support for configuring custom labels and annotations in the main metadata of all `Deployment` workloads:
- `server`
- `server.frontend`
- `server.history`
- `server.matching`
- `server.worker`
- `admintools`
- `web`

## Why?
<!-- Tell your future self why have you made these changes -->

These changes were added specifically to allow for custom `server` `Deployment` annotations so that a tool like [stakater/Reloader](https://github.com/stakater/Reloader) may be used to auto-restart the `server` when persistence auth keys are rotated.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Local `helm template` rendering.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
