### PR TITLE
added tls configuration for elasticsearch

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -52,13 +52,26 @@ data:
           elasticsearch:
             version: "{{ $elasticsearch.version }}"
             url:
-                scheme: "{{ $elasticsearch.scheme }}"
-                host: "{{ $elasticsearch.host }}:{{ $elasticsearch.port }}"
+              scheme: "{{ $elasticsearch.scheme }}"
+              host: "{{ $elasticsearch.host }}:{{ $elasticsearch.port }}"
             username: "{{ $elasticsearch.username }}"
             password: {{ `{{ .Env.TEMPORAL_VISIBILITY_STORE_PASSWORD  | quote }}` }}
             logLevel: "{{ $elasticsearch.logLevel }}"
+        {{- if $elasticsearch.tls.enabled }}
+            tls:
+              enabled: {{ $elasticsearch.tls.enabled }}
+              {{- if $elasticsearch.tls.cert }}
+              certFile: "/etc/temporal/elasticsearch-certs/{{ $elasticsearch.tls.cert }}"
+              {{- end }}
+              {{- if $elasticsearch.tls.key }}
+              keyFile: "/etc/temporal/elasticsearch-certs/{{ $elasticsearch.tls.key }}"
+              {{- end }}
+              {{- if $elasticsearch.tls.ca }}
+              caFile: "/etc/temporal/elasticsearch-certs/{{ $elasticsearch.tls.ca }}"
+              {{- end }}
+        {{- end }}
             indices:
-                visibility: "{{ $elasticsearch.visibilityIndex }}"
+              visibility: "{{ $elasticsearch.visibilityIndex }}"
         {{- else if eq (include "temporal.persistence.driver" (list $ "visibility")) "sql" }}
           sql:
             pluginName: "{{ include "temporal.persistence.sql.driver" (list $ "visibility") }}"

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if $.Values.server.enabled }}
 {{- range $service := (list "frontend" "history" "matching" "worker") }}
 {{ $serviceValues := index $.Values.server $service }}
+{{- $elasticsearch := $.Values.elasticsearch -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,7 +37,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
-      {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
+      {{- if or $.Values.cassandra.enabled (or $elasticsearch.enabled $elasticsearch.external)}}
       initContainers:
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service
@@ -51,11 +52,17 @@ spec:
           imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
           command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SELECT keyspace_name FROM system_schema.keyspaces" | grep {{ $.Values.server.config.persistence.default.cassandra.keyspace }}$; do echo waiting for default keyspace to become ready; sleep 1; done;']
         {{- end }}
-        {{- if or $.Values.elasticsearch.enabled $.Values.elasticsearch.external }}
+        {{- if or $elasticsearch.enabled $elasticsearch.external }}
         - name: check-elasticsearch-index
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'until curl --silent --fail {{- if and $.Values.elasticsearch.username $.Values.elasticsearch.password }} --user "{{ $.Values.elasticsearch.username }}:{{ $.Values.elasticsearch.password }}" {{- end }} {{ $.Values.elasticsearch.scheme }}://{{ $.Values.elasticsearch.host }}:{{ $.Values.elasticsearch.port }}/{{ $.Values.elasticsearch.visibilityIndex }} 2>&1 > /dev/null; do echo waiting for elasticsearch index to become ready; sleep 1; done;']
+          {{- if $elasticsearch.tls.enabled }}
+          volumeMounts:
+              - name: elasticsearch-certs
+                mountPath: /etc/temporal/elasticsearch-certs
+                readOnly: true
+          {{- end }}
+          command: ['sh', '-c', 'until curl {{- if and $elasticsearch.tls.enabled $elasticsearch.tls.ca }} --cacert /etc/temporal/elasticsearch-certs/{{ $elasticsearch.tls.ca }} {{- end }} --silent --fail {{- if and $elasticsearch.username $elasticsearch.password }} --user "{{ $elasticsearch.username }}:{{ $elasticsearch.password }}" {{- end }} {{ $elasticsearch.scheme }}://{{ $elasticsearch.host }}:{{ $elasticsearch.port }}/{{ $elasticsearch.visibilityIndex }} 2>&1 > /dev/null; do echo waiting for elasticsearch index to become ready; sleep 1; done;']
         {{- end }}
       {{- end }}
       containers:
@@ -112,6 +119,11 @@ spec:
               subPath: config_template.yaml
             - name: dynamic-config
               mountPath: /etc/temporal/dynamic_config
+            {{- if $elasticsearch.tls.secretName }}
+            - name: elasticsearch-certs
+              mountPath: /etc/temporal/elasticsearch-certs
+              readOnly: true
+            {{- end }}
             {{- if $.Values.server.additionalVolumeMounts }}
             {{- toYaml $.Values.server.additionalVolumeMounts | nindent 12}}
             {{- end }}
@@ -129,6 +141,11 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if and $elasticsearch.tls.enabled $elasticsearch.tls.secretName }}
+        - name: elasticsearch-certs
+          secret:
+            secretName: {{ $elasticsearch.tls.secretName | quote }}
+        {{- end }}
         - name: config
           configMap:
             name: "{{ include "temporal.fullname" $ }}-config"

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -1,4 +1,5 @@
 {{- if $.Values.server.enabled }}{{- if or $.Values.schema.createDatabase.enabled $.Values.schema.setup.enabled $.Values.schema.update.enabled }}
+{{- $elasticsearch := $.Values.elasticsearch -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -30,7 +31,7 @@ spec:
         - name: check-elasticsearch
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'until curl --silent --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
+          command: ['sh', '-c', 'until curl --silent --fail {{- if and $elasticsearch.tls.enabled $elasticsearch.tls.ca }} --cacert /etc/temporal/elasticsearch-certs/{{ $elasticsearch.tls.ca }} {{- end }} --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
           env:
             {{- include "temporal.admintools-env" (list $ "visibility") | nindent 12 }}
         {{- end }}
@@ -70,14 +71,19 @@ spec:
             {{- else if eq $driver "elasticsearch" }}
           command: ['sh', '-c']
           args:
-            - 'curl -X PUT --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_$ES_VERSION.json" 2>&1 &&
-              curl -X PUT --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1'
+            - 'curl -X PUT --fail {{- if and $elasticsearch.tls.enabled $elasticsearch.tls.ca }} --cacert /etc/temporal/elasticsearch-certs/{{ $elasticsearch.tls.ca }} {{- end }} --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_$ES_VERSION.json" 2>&1 &&
+              curl -X PUT --fail {{- if and $elasticsearch.tls.enabled $elasticsearch.tls.ca }} --cacert /etc/temporal/elasticsearch-certs/{{ $elasticsearch.tls.ca }} {{- end }} --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1'
             {{- end }}
           env:
             {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}
-            {{- with $.Values.server.additionalVolumeMounts }}
           volumeMounts:
+            {{- with $.Values.server.additionalVolumeMounts }}
               {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if and $elasticsearch.tls.enabled $elasticsearch.tls.secretName }}
+            - name: elasticsearch-certs
+              mountPath: /etc/temporal/elasticsearch-certs
+              readOnly: true
             {{- end }}
             {{- with $.Values.schema.resources }}
           resources:
@@ -158,8 +164,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.server.additionalVolumes }}
       volumes:
+      {{- if $elasticsearch.tls.secretName }}
+      - name: elasticsearch-certs
+        secret:
+          secretName: {{ $elasticsearch.tls.secretName | quote }}
+      {{- end }}
+      {{- with $.Values.server.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end -}}{{- end -}}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -384,6 +384,12 @@ elasticsearch:
   username: ""
   password: ""
   visibilityIndex: "temporal_visibility_v1_dev"
+  tls:
+    enabled: false
+    secretName: ""
+    cert: ""
+    key: ""
+    ca: ""
 prometheus:
   enabled: true
   nodeExporter:

--- a/charts/temporal/values/values.elasticsearch.yaml
+++ b/charts/temporal/values/values.elasticsearch.yaml
@@ -6,3 +6,5 @@ elasticsearch:
   version: "v7"
   scheme: "http"
   logLevel: "error"
+  tls:
+    enabled: false


### PR DESCRIPTION
## What was changed
Added TLS Configuration for external elasticsearch

## Why?
If we have external elasticsearch then we should able to connect to elasticsearch

## Checklist
- [ ] Setup external elasticsearch using elastic operator example
- [ ] Setup 

1. Closes #447 

2. How was this tested:

- Setup of elasticsearch 
- Install helm chart with this values

```yaml
elasticsearch:
  enabled: false
  external: true
  host: "elasticsearch-es-http"
  port: "9200"
  version: "v7"
  scheme: "https"
  logLevel: "error"
  username: "#USER#"
  password: "#PASSWORD#"
  tls:
    enabled: true
    secretName: "elasticsearch-es-remote-ca"
    ca: "ca.crt"
```
