### PR TITLE
Provide option to create default namespace

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -125,8 +125,8 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
-        {{- if $.Values.server.config.defaultNamespaces.enabled }}
-          {{- range $namespace := $.Values.server.config.defaultNamespaces.namespace }}
+        {{- if $.Values.server.config.namespaces.create }}
+          {{- range $namespace := $.Values.server.config.namespaces.namespace }}
         - name: create-{{ $namespace.name }}-namespace
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -125,15 +125,16 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
-        {{- if $.Values.server.config.defaultNamespace.enabled }}
-        - name: create-default-namespace
+        {{- if $.Values.server.config.defaultNamespaces.enabled }}
+          {{- range $namespace := $.Values.server.config.defaultNamespaces.namespace }}
+        - name: create-{{ $namespace.name }}-namespace
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['/bin/sh','-c']
-          args: ['temporal operator namespace describe -n {{ $.Values.server.config.defaultNamespace.namespace }} || temporal operator namespace create -n {{ $.Values.server.config.defaultNamespace.namespace }} --retention {{ $.Values.server.config.defaultNamespace.retention }}']
+          args: ['temporal operator namespace describe -n {{ $namespace.name }} || temporal operator namespace create -n {{ $namespace.name }}{{- if hasKey $namespace "retention" }} --retention {{ $namespace.retention }}{{- end }}']
           env:
             - name: TEMPORAL_ADDRESS
-              value: "{{ include "temporal.fullname" . }}-frontend.{{ .Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
+              value: "{{ include "temporal.fullname" $ }}-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
               {{- with $.Values.server.additionalVolumeMounts }}
           volumeMounts:
                 {{- toYaml . | nindent 12 }}
@@ -146,6 +147,7 @@ spec:
           securityContext:
                 {{- toYaml . | nindent 12 }}
               {{- end }}
+          {{- end }}
         {{- end }}
       containers:
         - name: done

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -125,6 +125,28 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
+        {{- if $.Values.server.config.defaultNamespace.enabled }}
+        - name: create-default-namespace
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['/bin/sh','-c']
+          args: ['temporal operator namespace describe -n {{ $.Values.server.config.defaultNamespace.namespace }} || temporal operator namespace create -n {{ $.Values.server.config.defaultNamespace.namespace }} --retention {{ $.Values.server.config.defaultNamespace.retention }}']
+          env:
+            - name: TEMPORAL_ADDRESS
+              value: "{{ include "temporal.fullname" . }}-frontend.{{ .Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
+              {{- with $.Values.server.additionalVolumeMounts }}
+          volumeMounts:
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
+              {{- with $.Values.schema.resources }}
+          resources:
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
+              {{- with $.Values.schema.containerSecurityContext }}
+          securityContext:
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
+        {{- end }}
       containers:
         - name: done
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -178,11 +178,12 @@ server:
           maxConnLifetime: "1h"
           # connectAttributes:
           #   tx_isolation: 'READ-COMMITTED'
-    defaultNamespace:
-      # Enable this to create default namespace
+    defaultNamespaces:
+      # Enable this to create namespaces
       enabled: false
-      namespace: default
-      retention: 3d
+      namespace:
+        - name: default
+          retention: 3d
   frontend:
     service:
       # Evaluated as template

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -178,9 +178,9 @@ server:
           maxConnLifetime: "1h"
           # connectAttributes:
           #   tx_isolation: 'READ-COMMITTED'
-    defaultNamespaces:
+    namespaces:
       # Enable this to create namespaces
-      enabled: false
+      create: false
       namespace:
         - name: default
           retention: 3d

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -178,6 +178,11 @@ server:
           maxConnLifetime: "1h"
           # connectAttributes:
           #   tx_isolation: 'READ-COMMITTED'
+    defaultNamespace:
+      # Enable this to create default namespace
+      enabled: false
+      namespace: default
+      retention: 3d
   frontend:
     service:
       # Evaluated as template


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR addresses the Feature Request #420 
Update the server setup Kubernetes job to create a default namespace.
Create configuration to enable this feature, by default its disabled.
Also, provides option to configure retention period, by default its 3 days.

## Why?
<!-- Tell your future self why have you made these changes -->
Creates a default namespace on the server to avoid manual effort.

## Checklist
<!--- add/delete as needed --->

1. Closes #420 

2. How was this tested: <!--- Please describe how you tested your changes/how we can test them --> Manual installation of the helm chart and running the updated job on a Kubernetes cluster to validate creation of new namespace.
`helm lint charts/temporal/.`
`helm install --dry-run temporal charts/temporal/.`
`helm install temporal charts/temporal/.`

4. Any docs updates needed? N/A
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
