### PR TITLE
Quote sql password for default store

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -35,7 +35,7 @@ data:
             connectAddr: "{{ include "temporal.persistence.sql.host" (list $ "default") }}:{{ include "temporal.persistence.sql.port" (list $ "default") }}"
             connectProtocol: "tcp"
             user: {{ include "temporal.persistence.sql.user" (list $ "default") }}
-            password: "{{ `{{ .Env.TEMPORAL_STORE_PASSWORD }}` }}"
+            password: {{ `{{ .Env.TEMPORAL_STORE_PASSWORD | quote }}` }}
             {{- with (omit $server.config.persistence.default.sql "driver" "driverName" "host" "port" "connectAddr" "connectProtocol" "database" "databaseName" "user" "password" "existingSecret") }}
               {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## What was changed
The Env.TEMPORAL_STORE_PASSWORD under sql persistance is quoted in the same way as Env.TEMPORAL_VISIBILITY_STORE_PASSWORD 

## Why?
Same reasons discussed in https://github.com/temporalio/helm-charts/issues/521, to allow for special characters in the password. 