### PR TITLE
Fix schema job not garbage collected

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "temporal.resourceLabels" (list . "database" "") | nindent 4 }}
 spec:
   backoffLimit: {{ $.Values.schema.setup.backoffLimit }}
+  {{- if $.Values.schema.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ $.Values.schema.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       name: {{ include "temporal.componentname" (list . "schema") }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -379,6 +379,8 @@ schema:
   resources: {}
   containerSecurityContext: {}
   securityContext: {}
+  # To delete the Job resource after it is finished. This can help with subsequent upgrades
+  # ttlSecondsAfterFinished: 10
 elasticsearch:
   enabled: true
   replicas: 3


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This PR fixes #554 by allowing users to specify a `ttlSecondsAfterFinished`. 

## Why?
If the job is not garbage collected, helm upgrades are not possible.

## Checklist
<!--- add/delete as needed --->

1. Closes #554

2. How was this tested: 
   Run helm install, check if job is deleted after completion

4. Any docs updates needed? 
   Don't know, is there documentation for the helm chart?
