### PR TITLE
Fix schema job cleanup by adding optional hook annotation

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "temporal.componentname" (list . "schema") }}
   labels:
     {{- include "temporal.resourceLabels" (list . "database" "") | nindent 4 }}
+  {{- if $.Values.schema.isHook }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+  {{- end }}
 spec:
   backoffLimit: {{ $.Values.schema.setup.backoffLimit }}
   template:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -368,6 +368,7 @@ web:
   topologySpreadConstraints: []
   podDisruptionBudget: {}
 schema:
+  isHook: false
   createDatabase:
     enabled: true
   setup:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR adds optional chart hook annotations to schema job. This `pre-install` hook will make sure the job gets run before any other deployment, and will automatically cleans up the job after it's finished with a `hook-delete-policy`.

## Why?
<!-- Tell your future self why have you made these changes -->
If the schema job is not garbage collected helm upgrades are not possible.
Also if the job doesn't get run first, other deployments can fail (at least initially) until the job is finished.

## Checklist
<!--- add/delete as needed --->

1. Closes #554 

2. How was this tested:
  Run helm install, check the job runs first before any other deployment, and check the job gets deleted after completion.

3. Any docs updates needed?
  I don't think there is any doc for this.
