### PR TITLE
Config to specify tags to be excluded in prometheus metrics

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -88,10 +88,10 @@ data:
           {{- with $server.metrics.tags }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+        {{- with $server.metrics.excludeTags }}
         excludeTags:
-          {{- with $server.metrics.excludeTags }}
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with $server.config.prometheus }}
         prometheus:
           {{- toYaml . | nindent 10 }}

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -88,6 +88,10 @@ data:
           {{- with $server.metrics.tags }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+        excludeTags:
+          {{- with $server.metrics.excludeTags }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- with $server.config.prometheus }}
         prometheus:
           {{- toYaml . | nindent 10 }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -29,6 +29,8 @@ server:
       enabled: true
     # Additional tags to be added to Prometheus metrics
     tags: {}
+    # Tags to be excluded in Prometheus metrics
+    excludeTags: {}
     # Enable Prometheus ServiceMonitor
     # Use this if you installed the Prometheus Operator (https://github.com/coreos/prometheus-operator).
     serviceMonitor:


### PR DESCRIPTION
## Why?
Config to exclude metrics tags from prometheus.

## Checklist

1. Closes

2. How was this tested:

3. Any docs updates needed?
