### PR TITLE
fix: Populate SQL_CONNECT_ATTRIBUTES in admintools and schema job

### DIFF
--- a/charts/temporal/templates/_admintools-env.yaml
+++ b/charts/temporal/templates/_admintools-env.yaml
@@ -37,6 +37,10 @@
     secretKeyRef:
       name: {{ include "temporal.persistence.secretName" (list $global $store) }}
       key: {{ include "temporal.persistence.secretKey" (list $global $store) }}
+  {{- with $driverConfig.connectAttributes }}
+- name: SQL_CONNECT_ATTRIBUTES
+  value: {{ include "temporal.persistence.sql.connectAttributes" (list $global $store) | quote }}
+  {{- end }}
   {{- with $driverConfig.tls }}
 - name: SQL_TLS
   value: {{ .enabled | quote }}

--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -337,6 +337,18 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- end -}}
 {{- end -}}
 
+{{- define "temporal.persistence.sql.connectAttributes" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- $driverConfig := $storeConfig.sql -}}
+{{- $result := list -}}
+{{- range $key, $value := $driverConfig.connectAttributes -}}
+  {{- $result = append $result (printf "%s=%s" $key $value) -}}
+{{- end -}}
+{{- join "&" $result -}}
+{{- end -}}
+
 {{- define "temporal.persistence.elasticsearch.secretName" -}}
 {{- $global := index . 0 -}}
 {{- $store := index . 1 -}}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
When `server.persistence.config.*.sql.connectAttributes` is set, also populate the `SQL_CONNECT_ATTRIBUTES` env var in the `temporal-schema` job. According to https://github.com/temporalio/temporal/blob/main/tools/sql/handler.go#L157, the `SQL_CONNECT_ATTRIBUTE` env var must be in this format: `key1=value1&key2=value`.

## Why?
<!-- Tell your future self why have you made these changes -->
If users want to use a different schema than `public`, they need to set the `connectAttribute` value to something like `search_path: temporal`. With this PR, the `temporal-schema` job will know about it and create tables in the right schema.

## Checklist
<!--- add/delete as needed --->

1. Closes #561 

2. How was this tested:
    1. `helm lint charts/temporal`
    2. Add `connectAttributes` to charts/temporal/values/values.postgresql.yaml:
    ```yaml
    connectAttributes:
      search_path: temporal
      foo_bar: baz
    ```
    3. `helm template my-release charts/temporal -f charts/temporal/values/values.postgresql.yaml`
    4. Check the resulting yaml contains the `SQL_CONNECT_ATTRIBUTES` env var:
        ```yaml
        - name: SQL_CONNECT_ATTRIBUTES
          value: "foo_bar=baz&search_path=temporal"
        ```
    5. Run step iii against `main` and against my branch, checking the resulting yamls are the same.