### PR TITLE
Ensure we use global for includes.

### DIFF
--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -2,26 +2,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "temporal.componentname" (list . "admintools") }}
+  name: {{ include "temporal.componentname" (list $ "admintools") }}
   labels:
-    {{- include "temporal.resourceLabels" (list . "admintools" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "admintools" "") | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "temporal.name" . }}
+      app.kubernetes.io/name: {{ include "temporal.name" $ }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: admintools
   template:
     metadata:
       labels:
-        {{- include "temporal.resourceLabels" (list . "admintools" "pod") | nindent 8 }}
+        {{- include "temporal.resourceLabels" (list $ "admintools" "pod") | nindent 8 }}
       {{- with $.Values.admintools.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{ include "temporal.serviceAccount" . }}
+      {{ include "temporal.serviceAccount" $ }}
       containers:
         - name: admin-tools
           image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
@@ -33,9 +33,9 @@ spec:
           env:
             # TEMPORAL_CLI_ADDRESS is deprecated, use TEMPORAL_ADDRESS instead
             - name: TEMPORAL_CLI_ADDRESS
-              value: {{ include "temporal.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }}
+              value: {{ include "temporal.fullname" $ }}-frontend:{{ .Values.server.frontend.service.port }}
             - name: TEMPORAL_ADDRESS
-              value: {{ include "temporal.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }}
+              value: {{ include "temporal.fullname" $ }}-frontend:{{ .Values.server.frontend.service.port }}
           {{- if .Values.admintools.additionalEnv }}
           {{- toYaml .Values.admintools.additionalEnv | nindent 12 }}
           {{- end }}

--- a/charts/temporal/templates/admintools-service.yaml
+++ b/charts/temporal/templates/admintools-service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "temporal.componentname" (list . "admintools") }}
+  name: {{ include "temporal.componentname" (list $ "admintools") }}
   labels:
-    {{- include "temporal.resourceLabels" (list . "admintools" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "admintools" "") | nindent 4 }}
 spec:
   type: ClusterIP 
   ports:
@@ -14,7 +14,7 @@ spec:
       name: ssh
 
   selector:
-    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    app.kubernetes.io/name: {{ include "temporal.name" $ }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: admintools
 {{- end }}

--- a/charts/temporal/templates/frontend-ingress.yaml
+++ b/charts/temporal/templates/frontend-ingress.yaml
@@ -8,9 +8,9 @@ apiVersion: extensions/v1beta1
   {{- end }}
 kind: Ingress
 metadata:
-  name: {{ include "temporal.componentname" (list . "frontend") }}
+  name: {{ include "temporal.componentname" (list $ "frontend") }}
   labels:
-    {{- include "temporal.resourceLabels" (list . "frontend" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "frontend" "") | nindent 4 }}
 {{- with .Values.server.frontend.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -6,7 +6,7 @@ kind: ConfigMap
 metadata:
   name: "{{ include "temporal.fullname" $ }}-config"
   labels:
-    {{- include "temporal.resourceLabels" (list . "" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}
 data:
   config_template.yaml: |-
     log:

--- a/charts/temporal/templates/server-dynamicconfigmap.yaml
+++ b/charts/temporal/templates/server-dynamicconfigmap.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ include "temporal.fullname" . }}-dynamic-config"
+  name: "{{ include "temporal.fullname" $ }}-dynamic-config"
   labels:
-    {{- include "temporal.resourceLabels" (list . "" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}
 data:
   dynamic_config.yaml: |-
   {{- if $.Values.server.dynamicConfig }}

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -2,16 +2,16 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "temporal.componentname" (list . "schema") }}
+  name: {{ include "temporal.componentname" (list $ "schema") }}
   labels:
-    {{- include "temporal.resourceLabels" (list . "database" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
 spec:
   backoffLimit: {{ $.Values.schema.setup.backoffLimit }}
   template:
     metadata:
-      name: {{ include "temporal.componentname" (list . "schema") }}
+      name: {{ include "temporal.componentname" (list $ "schema") }}
       labels:
-        {{- include "temporal.resourceLabels" (list . "database" "") | nindent 8 }}
+        {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 8 }}
         {{- with $.Values.schema.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -20,7 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "temporal.serviceAccount" . }}
+      {{- include "temporal.serviceAccount" $ }}
       restartPolicy: OnFailure
       initContainers:
         {{- if $.Values.cassandra.enabled }}

--- a/charts/temporal/templates/server-pdb.yaml
+++ b/charts/temporal/templates/server-pdb.yaml
@@ -7,7 +7,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "temporal.componentname" (list $ $service) }}-pdb
   labels:
-    {{- include "temporal.resourceLabels" (list . $service "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
 spec:
   {{ toYaml $serviceValues.podDisruptionBudget }}
   selector:

--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "temporal.componentname" (list . "frontend") }}
+  name: {{ include "temporal.componentname" (list $ "frontend") }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "frontend" "") | nindent 4 }}
   {{- if .Values.server.frontend.service.annotations }}
@@ -24,7 +24,7 @@ spec:
       name: http
       # TODO: Allow customizing the node HTTP port
   selector:
-    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    app.kubernetes.io/name: {{ include "temporal.name" $ }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: frontend
 

--- a/charts/temporal/templates/serviceaccount.yaml
+++ b/charts/temporal/templates/serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "temporal.serviceAccountName" . }}
+  name: {{ include "temporal.serviceAccountName" $ }}
   labels:
-    {{- include "temporal.resourceLabels" (list . "" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install, pre-upgrade
     helm.sh/hook-weight: "-10"

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -2,14 +2,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "temporal.componentname" (list . "web") }}
+  name: {{ include "temporal.componentname" (list $ "web") }}
   labels:
-    {{- include "temporal.resourceLabels" (list . "web" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
 spec:
   replicas: {{ .Values.web.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "temporal.name" . }}
+      app.kubernetes.io/name: {{ include "temporal.name" $ }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: web
   template:
@@ -21,7 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{ include "temporal.serviceAccount" . }}
+      {{ include "temporal.serviceAccount" $ }}
       {{- if .Values.web.additionalVolumes }}
       volumes:
       {{- toYaml .Values.web.additionalVolumes | nindent 8 }}
@@ -32,7 +32,7 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: TEMPORAL_ADDRESS
-              value: "{{ include "temporal.fullname" . }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
+              value: "{{ include "temporal.fullname" $ }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}

--- a/charts/temporal/templates/web-ingress.yaml
+++ b/charts/temporal/templates/web-ingress.yaml
@@ -8,9 +8,9 @@ apiVersion: extensions/v1beta1
   {{- end }}
 kind: Ingress
 metadata:
-  name: {{ include "temporal.componentname" (list . "web") }}
+  name: {{ include "temporal.componentname" (list $ "web") }}
   labels:
-    {{- include "temporal.resourceLabels" (list . "web" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
 {{- with .Values.web.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/temporal/templates/web-pdb.yaml
+++ b/charts/temporal/templates/web-pdb.yaml
@@ -3,9 +3,9 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "temporal.componentname" (list . "web") }}-pdb
+  name: {{ include "temporal.componentname" (list $ "web") }}-pdb
   labels:
-    {{- include "temporal.resourceLabels" (list . "web" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
 spec:
   {{ toYaml $.Values.web.podDisruptionBudget }}
   selector:

--- a/charts/temporal/templates/web-service.yaml
+++ b/charts/temporal/templates/web-service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "temporal.componentname" (list . "web") }}
+  name: {{ include "temporal.componentname" (list $ "web") }}
   labels:
-    {{- include "temporal.resourceLabels" (list . "web" "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
   {{- if .Values.web.service.annotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.web.service.annotations "context" $) | nindent 4 }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
       nodePort: {{ .Values.web.service.nodePort }}
       {{- end }}
   selector:
-    app.kubernetes.io/name: {{ include "temporal.name" . }}
+    app.kubernetes.io/name: {{ include "temporal.name" $ }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: web
   {{- end }}


### PR DESCRIPTION
Some call sites used . which was sometimes not the global context.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changed include calls to use `$` instead of `.` to ensure they pass the global scope.

## Why?
In some cases `.` wasn't the global scope, causing helpers to fail. In either case it's better to be more explicit about what is being passed.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
