### PR TITLE
Including an internal-frontend service with auth enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,36 @@ helm install \
   --wait
 ```
 
+### Configuring authorization
+
+See https://docs.temporal.io/self-hosted-guide/security#claim-mapper
+
+This chart enables you to configure Temporal's authorization support. The values within this Helm chart
+server.config.authorization section are included in the resulting Temporal configuration under the 
+global.authorization section.
+
+For instance, you could enable the JWT based default authorizer and claim mapper functionality by including the following:
+
+This configures Temporal to load the JSON Web Key Set from the provided keySourceURIs, and refresh it on an internal. 
+That is used to validate the JWTs that you provide to Temporal via the "authorization" meta data header. 
+
+```yaml
+server:
+  config:    
+    authorization:
+     jwtKeyProvider:
+       keySourceURIs:
+         - http://localhost:/jwks.json
+       refreshInterval: 1m
+     permissionsClaimName: permissions
+     authorizer: default
+     claimMapper: default
+```
+
+Note that if a non-default value is provided for server.config.authorization.authorizer, then we will automatically
+include the "internal-frontend" service that the other Temporal services use for internal communication that bypasses the 
+authorization process. 
+
 ## Play With It
 
 ### Exploring Your Cluster

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -119,6 +119,15 @@ data:
           membershipPort: {{ $server.frontend.service.membershipPort }}
           bindOnIP: "0.0.0.0"
 
+      {{- if and (hasKey .Values.server.config "authorization") (hasKey .Values.server.config.authorization "authorizer") }}
+      internal-frontend:
+        rpc:
+          grpcPort: {{ index $server "internal-frontend" "service" "port" }}
+          httpPort: {{ index $server "internal-frontend" "service" "httpPort" }}
+          membershipPort: {{ index $server "internal-frontend" "service" "membershipPort" }}
+          bindOnIP: "0.0.0.0"
+      {{- end }}
+
       history:
         rpc:
           grpcPort: {{ $server.history.service.port }}
@@ -173,8 +182,10 @@ data:
       {{- toYaml . | nindent 6 }}
     {{- end }}
 
+    {{- if not (and (hasKey .Values.server.config "authorization") (hasKey .Values.server.config.authorization "authorizer")) }}
     publicClient:
       hostPort: "{{ include "temporal.componentname" (list $ "frontend") }}:{{ $server.frontend.service.port }}"
+    {{- end }}
 
     dynamicConfigClient:
       filepath: "/etc/temporal/dynamic_config/dynamic_config.yaml"

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -1,5 +1,12 @@
 {{- if $.Values.server.enabled }}
-{{- range $service := (list "frontend" "history" "matching" "worker") }}
+
+{{- $serviceList := (list "frontend" "history" "matching" "worker") }}
+
+{{- if and (hasKey .Values.server.config "authorization") (hasKey .Values.server.config.authorization "authorizer") }}
+  {{- $serviceList = (list "frontend" "internal-frontend" "history" "matching" "worker") }}
+{{- end }}
+
+{{- range $service := $serviceList }}
 {{ $serviceValues := index $.Values.server $service }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -218,6 +218,49 @@ server:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+
+    metrics:
+      annotations:
+        enabled: true
+      serviceMonitor: {}
+      # enabled: false
+      prometheus: {}
+      # timerType: histogram
+    podAnnotations: {}
+    podLabels: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    additionalEnv: []
+    containerSecurityContext: {}
+    topologySpreadConstraints: []
+    podDisruptionBudget: {}
+
+  internal-frontend:
+    service:
+      # Evaluated as template
+      annotations: {}
+      type: ClusterIP
+      port: 7236
+      membershipPort: 6936
+      #httpPort: 7243
+    ingress:
+      enabled: false
+      # className:
+      annotations: {}
+      # kubernetes.io/ingress.class: traefik
+      # ingress.kubernetes.io/ssl-redirect: "false"
+      # traefik.frontend.rule.type: PathPrefix
+      hosts:
+        - "/"
+        # - "domain.com/xyz"
+        # - "domain.com"
+      tls: []
+      #  - secretName: chart-example-tls
+      #    hosts:
+      #      - chart-example.local
+
     metrics:
       annotations:
         enabled: true


### PR DESCRIPTION

NOTE: I have not tested this with mTLS.

## What was changed
This adds an internal-frontend portion to the config map when a non-default authorizer is enabled, and removes the publicClient section if it's present.

It starts the internal-frontend deployment using the same parameters as the normal frontend, but slightly different ports (7236, 6936).

This pretty much follows the instructions in the release notes for 1.20: https://github.com/temporalio/temporal/releases/tag/v1.20.0

## Why?
When one enables authorization using the recent jwt authorization support, the worker pod fails repeatedly with an authorization failure because it is not providing the JWT token.  By following the above instructions, we bring up a special "internal frontend" that it will use for internal communications instead, bypassing this requirement and allowing the worker to start up properly.

1. Closes issue #560 

2. How was this tested:

Added the requisite configuration, and ensure that the Temporal worker starts successfully.

3. Any docs updates needed?

Added a section to the readme.