### PR TITLE
Update _helpers.tpl to avoid nested custom resource label

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -89,7 +89,7 @@ app.kubernetes.io/managed-by: {{ index $global "Release" "Service" }}
 app.kubernetes.io/instance: {{ index $global "Release" "Name" }}
 app.kubernetes.io/version: {{ include "temporal.appVersion" $global }}
 app.kubernetes.io/part-of: {{ $global.Chart.Name }}
-{{- with $resourceType -}}
+{{ with $resourceType -}}
 {{- $resourceTypeKey := printf "%sLabels" . -}}
 {{- $resourceLabels := dict -}}
 {{- if or (eq $scope "") (ne $component "server") -}}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Remove space trim for set of labels

## Why?
See #575 

## Checklist
<!--- add/delete as needed --->

1. Closes  #575 

2. How was this tested: 

The issue is no longer reproduced using `helm template` command

Before:
```
      labels:
        app.kubernetes.io/component: admintools
        app.kubernetes.io/name: temporal
        helm.sh/chart: temporal-0.45.0
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "1.25.0"
        app.kubernetes.io/part-of: temporaltest: infra <------------ ISSUE
```

After:
```
      labels:
        app.kubernetes.io/component: admintools
        app.kubernetes.io/name: temporal
        helm.sh/chart: temporal-0.45.0
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "1.25.0"
        app.kubernetes.io/part-of: temporal
        test: infra <-------- SOLVED
```