### PR TITLE
Fix YAML parse error when specifying service account name

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -20,7 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "temporal.serviceAccount" $ }}
+      {{ include "temporal.serviceAccount" $ }}
       restartPolicy: OnFailure
       initContainers:
         {{- if $.Values.cassandra.enabled }}


### PR DESCRIPTION
## What was changed
This PR fixes a YAML parse error on temporal/templates/server-job.yaml (`error converting YAML to JSON: yaml: line 29: mapping values are not allowed in this context`).

This error is introduced in release [temporal-0.46.0](https://github.com/temporalio/helm-charts/releases/tag/temporal-0.46.0) and occurs when any `serviceAccount.name` is set.

## Why?
After upgrading to release 0.46.0 or higher our installation failed, because we are using a custom service account name.

## Checklist
1. How was this tested:
`helm install -f values.yaml --set serviceAccount.name=default debug . --dry-run --debug`

2. Any docs updates needed?
No.