### PR TITLE
Fix YAML parse error when specifying two or more resource labels

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -97,7 +97,7 @@ app.kubernetes.io/part-of: {{ $global.Chart.Name }}
 {{- else -}}
 {{- $resourceLabels = (index $global.Values $component $scope $resourceTypeKey) -}}
 {{- end -}}
-{{- range $label_name, $label_value := $resourceLabels -}}
+{{- range $label_name, $label_value := $resourceLabels }}
 {{ $label_name}}: {{ $label_value }}
 {{- end -}}
 {{- end -}}

--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -89,7 +89,7 @@ app.kubernetes.io/managed-by: {{ index $global "Release" "Service" }}
 app.kubernetes.io/instance: {{ index $global "Release" "Name" }}
 app.kubernetes.io/version: {{ include "temporal.appVersion" $global }}
 app.kubernetes.io/part-of: {{ $global.Chart.Name }}
-{{ with $resourceType -}}
+{{- with $resourceType -}}
 {{- $resourceTypeKey := printf "%sLabels" . -}}
 {{- $resourceLabels := dict -}}
 {{- if or (eq $scope "") (ne $component "server") -}}


### PR DESCRIPTION
## What was changed
This PR fixes a YAML parse error on temporal/templates/server-deployment.yaml (`error converting YAML to JSON: yaml: line 31: mapping values are not allowed in this context`).

## Why?
This error is introduced in PR #539 and occurs when two or more resource labels (e.g. podLabels) are specified. It works with 1 resource label, because the parse error is caused by missing newlines after each label in the `$resourceLabels` range. This starts to become a problem with at least 2 items.

## Checklist
1. How was this tested:
`helm install -f values.yaml --set additionalLabels.additionalLabel1="additionalTest1"  --set server.frontend.podLabels.label1="test1" --set server.frontend.podLabels.label2="test2" debug . --dry-run --debug`

2. Any docs updates needed?
No.