### PR TITLE
Print annotation and label value as YAML to support array string values

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -91,11 +91,11 @@ Create the annotations for all resources
 {{- end -}}
 {{- $resourceAnnotations := merge $scopeAnnotations $componentAnnotations -}}
 {{- range $annotation_name, $annotation_value := $resourceAnnotations }}
-{{ $annotation_name }}: {{ $annotation_value }}
+{{ $annotation_name }}: {{ $annotation_value | toYaml }}
 {{- end -}}
 {{- end -}}
 {{- range $annotation_name, $annotation_value := $global.Values.additionalAnnotations }}
-{{ $annotation_name }}: {{ $annotation_value }}
+{{ $annotation_name }}: {{ $annotation_value | toYaml }}
 {{- end -}}
 {{- end -}}
 
@@ -128,11 +128,11 @@ app.kubernetes.io/part-of: {{ $global.Chart.Name }}
 {{- end -}}
 {{- $resourceLabels := merge $scopeLabels $componentLabels -}}
 {{- range $label_name, $label_value := $resourceLabels }}
-{{ $label_name}}: {{ $label_value }}
+{{ $label_name}}: {{ $label_value | toYaml }}
 {{- end -}}
 {{- end -}}
 {{- range $label_name, $label_value := $global.Values.additionalLabels }}
-{{ $label_name }}: {{ $label_value }}
+{{ $label_name }}: {{ $label_value | toYaml }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -91,11 +91,11 @@ Create the annotations for all resources
 {{- end -}}
 {{- $resourceAnnotations := merge $scopeAnnotations $componentAnnotations -}}
 {{- range $annotation_name, $annotation_value := $resourceAnnotations }}
-{{ $annotation_name }}: {{ $annotation_value | toYaml }}
+{{ $annotation_name }}: {{ $annotation_value | quote }}
 {{- end -}}
 {{- end -}}
 {{- range $annotation_name, $annotation_value := $global.Values.additionalAnnotations }}
-{{ $annotation_name }}: {{ $annotation_value | toYaml }}
+{{ $annotation_name }}: {{ $annotation_value | quote }}
 {{- end -}}
 {{- end -}}
 
@@ -128,11 +128,11 @@ app.kubernetes.io/part-of: {{ $global.Chart.Name }}
 {{- end -}}
 {{- $resourceLabels := merge $scopeLabels $componentLabels -}}
 {{- range $label_name, $label_value := $resourceLabels }}
-{{ $label_name}}: {{ $label_value | toYaml }}
+{{ $label_name}}: {{ $label_value | quote }}
 {{- end -}}
 {{- end -}}
 {{- range $label_name, $label_value := $global.Values.additionalLabels }}
-{{ $label_name }}: {{ $label_value | toYaml }}
+{{ $label_name }}: {{ $label_value | quote }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/temporal/tests/deployment_test.go
+++ b/charts/temporal/tests/deployment_test.go
@@ -120,6 +120,7 @@ func TestTemplateServerDeploymentAnnotations(t *testing.T) {
 		SetValues: map[string]string{
 			"server.frontend.deploymentAnnotations.one":  "three",
 			"server.frontend.deploymentAnnotations.four": "four",
+			"server.frontend.deploymentAnnotations.five": "[{\"test\":\"success\"}]",
 			"server.deploymentAnnotations.one":           "one",
 			"server.deploymentAnnotations.two":           "two",
 			"additionalAnnotations.zero":                 "zero",
@@ -135,6 +136,7 @@ func TestTemplateServerDeploymentAnnotations(t *testing.T) {
 	require.Equal(t, "three", deployment.ObjectMeta.Annotations["one"])
 	require.Equal(t, "two", deployment.ObjectMeta.Annotations["two"])
 	require.Equal(t, "four", deployment.ObjectMeta.Annotations["four"])
+	require.Equal(t, "[{\"test\":\"success\"}]", deployment.ObjectMeta.Annotations["five"])
 	require.Equal(t, "zero", deployment.ObjectMeta.Annotations["zero"])
 	require.Equal(t, "zero", deployment.Spec.Template.ObjectMeta.Annotations["zero"])
 }
@@ -154,6 +156,7 @@ func TestTemplateServerDeploymentLabels(t *testing.T) {
 		SetValues: map[string]string{
 			"server.frontend.deploymentLabels.one":  "three",
 			"server.frontend.deploymentLabels.four": "four",
+			"server.frontend.deploymentLabels.five": "[{\"test\":\"success\"}]",
 			"server.deploymentLabels.one":           "one",
 			"server.deploymentLabels.two":           "two",
 			"additionalLabels.zero":                 "zero",
@@ -169,6 +172,7 @@ func TestTemplateServerDeploymentLabels(t *testing.T) {
 	require.Equal(t, "three", deployment.ObjectMeta.Labels["one"])
 	require.Equal(t, "two", deployment.ObjectMeta.Labels["two"])
 	require.Equal(t, "four", deployment.ObjectMeta.Labels["four"])
+	require.Equal(t, "[{\"test\":\"success\"}]", deployment.ObjectMeta.Labels["five"])
 	require.Equal(t, "zero", deployment.ObjectMeta.Labels["zero"])
 	require.Equal(t, "zero", deployment.Spec.Template.ObjectMeta.Labels["zero"])
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This PR adds support for array strings as annotations and labels.

## Why?
Annotations and labels with array string as value (e.g. `ad.datadoghq.com/temporal-web.logs: '[{"source":"temporal","service":"temporal-web"}]'`) results in an error, both on installation and upgrade.

Error message: 
`Error: UPGRADE FAILED: cannot patch "temporal-admintools" with kind Deployment:  "" is invalid: patch: Invalid value: "{...}": json: cannot unmarshal array into Go struct field ObjectMeta.spec.template.metadata.annotations of type string`

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Automated.

Or manual via:
`helm install -f values.yaml --set web.podAnnotations.arrayannotation='[{"test":"true"}]' debug . --dry-run --debug`

2. Any docs updates needed?
No.