### PR TITLE
Allow username to be specified in persistence secrets

### DIFF
--- a/charts/temporal/templates/_admintools-env.yaml
+++ b/charts/temporal/templates/_admintools-env.yaml
@@ -15,12 +15,15 @@
 - name: CASSANDRA_KEYSPACE
   value: {{ $driverConfig.keyspace }}
 - name: CASSANDRA_USER
-  value: {{ $driverConfig.user }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "temporal.persistence.secretName" (list $global $store) }}
+      key: {{ include "temporal.persistence.secretKeyUser" (list $global $store) }}
 - name: CASSANDRA_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "temporal.persistence.secretName" (list $global $store) }}
-      key: {{ include "temporal.persistence.secretKey" (list $global $store) }}
+      key: {{ include "temporal.persistence.secretKeyPassword" (list $global $store) }}
 {{- else if eq $driver "sql" -}}
 - name: SQL_PLUGIN
   value: {{ include "temporal.persistence.sql.driver" (list $global $store) }}
@@ -31,12 +34,15 @@
 - name: SQL_DATABASE
   value: {{ include "temporal.persistence.sql.database" (list $global $store) }}
 - name: SQL_USER
-  value: {{ $driverConfig.user }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "temporal.persistence.secretName" (list $global $store) }}
+      key: {{ include "temporal.persistence.secretKeyUser" (list $global $store) }}
 - name: SQL_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "temporal.persistence.secretName" (list $global $store) }}
-      key: {{ include "temporal.persistence.secretKey" (list $global $store) }}
+      key: {{ include "temporal.persistence.secretKeyPassword" (list $global $store) }}
   {{- with $driverConfig.tls }}
 - name: SQL_TLS
   value: {{ .enabled | quote }}
@@ -67,12 +73,15 @@
 - name: ES_PORT
   value: {{ $driverConfig.port | quote }}
 - name: ES_USER
-  value: {{ $driverConfig.username | quote }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "temporal.persistence.secretName" (list $global $store) }}
+      key: {{ include "temporal.persistence.secretKeyUser" (list $global $store) }}
 - name: ES_PWD
   valueFrom:
     secretKeyRef:
       name: {{ include "temporal.persistence.secretName" (list $global $store) }}
-      key: {{ include "temporal.persistence.secretKey" (list $global $store) }}
+      key: {{ include "temporal.persistence.secretKeyPassword" (list $global $store) }}
 - name: ES_VERSION
   value: {{ $driverConfig.version }}
 - name: ES_VISIBILITY_INDEX

--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -224,7 +224,7 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- print . -}}
 {{- else -}}
 {{/* Cassandra user is optional, but we will create an empty secret for it */}}
-{{- print "user" -}}
+{{- print "username" -}}
 {{- end -}}
 {{- end -}}
 
@@ -411,7 +411,7 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- if $driverConfig.secretKeyUser -}}
 {{- print $driverConfig.secretKeyUser -}}
 {{- else -}}
-{{- "password" -}}
+{{- "username" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -55,7 +55,7 @@ data:
             url:
                 scheme: "{{ $elasticsearch.scheme }}"
                 host: "{{ $elasticsearch.host }}:{{ $elasticsearch.port }}"
-            username: "{{ $elasticsearch.username }}"
+            user: {{ `{{ .Env.TEMPORAL_VISIBILITY_STORE_USER  | quote }}` }}
             password: {{ `{{ .Env.TEMPORAL_VISIBILITY_STORE_PASSWORD  | quote }}` }}
             logLevel: "{{ $elasticsearch.logLevel }}"
             indices:

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -23,8 +23,9 @@ data:
           cassandra:
             hosts: "{{ include "temporal.persistence.cassandra.hosts" (list $ "default") }}"
             port: {{ include "temporal.persistence.cassandra.port" (list $ "default") }}
+            user: {{ `{{ .Env.TEMPORAL_STORE_USER | quote }}` }}
             password: {{ `{{ .Env.TEMPORAL_STORE_PASSWORD | quote }}` }}
-            {{- with (omit $server.config.persistence.default.cassandra "hosts" "port" "password" "existingSecret") }}
+            {{- with (omit $server.config.persistence.default.cassandra "hosts" "port" "user" "password" "existingSecret") }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- else if eq (include "temporal.persistence.driver" (list $ "default")) "sql" }}
@@ -34,7 +35,7 @@ data:
             databaseName: "{{ $server.config.persistence.default.sql.database }}"
             connectAddr: "{{ include "temporal.persistence.sql.host" (list $ "default") }}:{{ include "temporal.persistence.sql.port" (list $ "default") }}"
             connectProtocol: "tcp"
-            user: {{ include "temporal.persistence.sql.user" (list $ "default") }}
+            user: {{ `{{ .Env.TEMPORAL_STORE_USER | quote }}` }}
             password: {{ `{{ .Env.TEMPORAL_STORE_PASSWORD | quote }}` }}
             {{- with (omit $server.config.persistence.default.sql "driver" "driverName" "host" "port" "connectAddr" "connectProtocol" "database" "databaseName" "user" "password" "existingSecret") }}
               {{- toYaml . | nindent 12 }}
@@ -66,7 +67,7 @@ data:
             databaseName: "{{ $server.config.persistence.visibility.sql.database }}"
             connectAddr: "{{ include "temporal.persistence.sql.host" (list $ "visibility") }}:{{ include "temporal.persistence.sql.port" (list $ "visibility") }}"
             connectProtocol: "tcp"
-            user: "{{ include "temporal.persistence.sql.user" (list $ "visibility") }}"
+            user: {{ `{{ .Env.TEMPORAL_VISIBILITY_STORE_USER  | quote }}` }}
             password: {{ `{{ .Env.TEMPORAL_VISIBILITY_STORE_PASSWORD  | quote }}` }}
             {{- with (omit $server.config.persistence.visibility.sql "driver" "driverName" "host" "port" "connectAddr" "connectProtocol" "database" "databaseName" "user" "password" "existingSecret") }}
               {{- toYaml . | nindent 12 }}

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -71,16 +71,26 @@ spec:
                   fieldPath: status.podIP
             - name: SERVICES
               value: {{ $service }}
+            - name: TEMPORAL_STORE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ "default") }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ "default") }}
             - name: TEMPORAL_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "default") }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ "default") }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ "default") }}
+            - name: TEMPORAL_VISIBILITY_STORE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "temporal.persistence.secretName" (list $ "visibility") }}
+                  key: {{ include "temporal.persistence.secretKeyUser" (list $ "visibility") }}
             - name: TEMPORAL_VISIBILITY_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "visibility") }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ "visibility") }}
+                  key: {{ include "temporal.persistence.secretKeyPassword" (list $ "visibility") }}
           {{- if $.Values.server.versionCheckDisabled }}
             - name: TEMPORAL_VERSION_CHECK_DISABLED
               value: "1"

--- a/charts/temporal/templates/server-secret.yaml
+++ b/charts/temporal/templates/server-secret.yaml
@@ -27,7 +27,7 @@ data:
   username: {{ include "temporal.persistence.sql.user" (list $ $store) | b64enc | quote }}
   password: {{ include "temporal.persistence.sql.password" (list $ $store) | b64enc | quote }}
   {{- else if eq $driver "elasticsearch" }}
-  username: {{ $driverConfig.user | b64enc | quote }}
+  username: {{ $driverConfig.username | b64enc | quote }}
   password: {{ $driverConfig.password | b64enc | quote }}
   {{- end }}
 ---

--- a/charts/temporal/templates/server-secret.yaml
+++ b/charts/temporal/templates/server-secret.yaml
@@ -21,10 +21,13 @@ metadata:
 type: Opaque
 data:
   {{- if eq $driver "cassandra" }}
+  username: {{ $driverConfig.user | b64enc | quote }}
   password: {{ $driverConfig.password | b64enc | quote }}
   {{- else if eq $driver "sql" }}
+  username: {{ include "temporal.persistence.sql.user" (list $ $store) | b64enc | quote }}
   password: {{ include "temporal.persistence.sql.password" (list $ $store) | b64enc | quote }}
   {{- else if eq $driver "elasticsearch" }}
+  username: {{ $driverConfig.user | b64enc | quote }}
   password: {{ $driverConfig.password | b64enc | quote }}
   {{- end }}
 ---


### PR DESCRIPTION
## What was changed
This commit allows the username to be specified alongside the password in persistence credentials secrets.

## Why?
Many dynamic database creds generation / rotation systems (such as Hashicorp Vault) generate both the username and password dynamically, which is more secure than just generating / rotating passwords. The functionality has been updated to allow either or both of these to be optionally set via a secret with any or both of username and password keys.
