### PR TITLE
Switch job to use admintools settings, not server

### DIFF
--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{ include "temporal.serviceAccount" $ }}
       {{- if $.Values.admintools.additionalInitContainers }}
       initContainers:
-        {{- toYaml $.Values.admintools.additionalInitContainers | nindent 8}}
+        {{- toYaml $.Values.admintools.additionalInitContainers | nindent 8 }}
       {{- end }}
       containers:
         - name: admin-tools

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -24,6 +24,9 @@ spec:
       {{ include "temporal.serviceAccount" $ }}
       restartPolicy: OnFailure
       initContainers:
+        {{- if $.Values.admintools.additionalInitContainers }}
+          {{- toYaml $.Values.admintools.additionalInitContainers | nindent 8 }}
+        {{- end }}
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service
           image: busybox
@@ -56,7 +59,7 @@ spec:
               {{- end }}
           env:
               {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}
-              {{- with $.Values.server.additionalVolumeMounts }}
+              {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:
                 {{- toYaml . | nindent 12 }}
               {{- end }}
@@ -83,7 +86,7 @@ spec:
             {{- end }}
           env:
             {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}
-            {{- with $.Values.server.additionalVolumeMounts }}
+            {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -118,7 +121,7 @@ spec:
               {{- end }}
           env:
               {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}
-              {{- with $.Values.server.additionalVolumeMounts }}
+              {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:
                 {{- toYaml . | nindent 12 }}
               {{- end }}
@@ -143,7 +146,7 @@ spec:
           env:
             - name: TEMPORAL_ADDRESS
               value: "{{ include "temporal.fullname" $ }}-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
-              {{- with $.Values.server.additionalVolumeMounts }}
+              {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:
                 {{- toYaml . | nindent 12 }}
               {{- end }}
@@ -178,19 +181,15 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.server.nodeSelector }}
+      {{- with $.Values.admintools.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.server.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with $.Values.server.tolerations }}
+      {{- with $.Values.admintools.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.server.additionalVolumes }}
+      {{- with $.Values.admintools.additionalVolumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -1,0 +1,31 @@
+suite: test server job
+templates:
+  - server-job.yaml
+tests:
+  - it: includes additional init containers
+    set:
+      admintools:
+        additionalInitContainers:
+          - name: my-init-container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: my-init-container
+  - it: includes additional volumes
+    set:
+      admintools:
+        additionalVolumes:
+          - name: my-volume
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: my-volume
+  - it: includes additional volume mounts
+    set:
+      admintools:
+        additionalVolumeMounts:
+          - name: my-volume
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[*].volumeMounts[0].name
+          value: my-volume


### PR DESCRIPTION

## What was changed
Added the admintools.additionalInitContainers to the schema jobs. Swapped some server settings for admintools variants. Removed affinity.

## Why?
The job runs the admintools container and so those settings seem more appropriate than server. Affinity shouldn't be relevant to a short lived job.

