### PR TITLE
Restrict CIDR ip addresses for a LoadBalancer type service

### DIFF
--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.server.frontend.service.type }}
+  {{- if .Values.server.frontend.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- include "common.tplvalues.render" ( dict "value" .Values.server.frontend.service.loadBalancerSourceRanges "context" $) | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.server.frontend.service.port }}
       targetPort: rpc

--- a/charts/temporal/tests/server_service_test.yaml
+++ b/charts/temporal/tests/server_service_test.yaml
@@ -1,0 +1,30 @@
+suite: test server service
+templates:
+  - server-service.yaml
+set:
+  server:
+    frontend:
+      service:
+        port: 7233
+        loadBalancerSourceRanges:
+          - "10.0.0.0/8"
+tests:
+  - it: defaults to service wide replica count
+    template: templates/server-service.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 7233
+  - it: includes load balancer source ranges
+    template: templates/server-service.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: spec.loadBalancerSourceRanges
+          value:
+          - "10.0.0.0/8"

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -209,6 +209,8 @@ server:
       port: 7233
       membershipPort: 6933
       httpPort: 7243
+      # loadBalancerSourceRanges:
+      # - "10.0.0.0/8"
     ingress:
       enabled: false
       # className:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Restrict IP addresses for load balancers created for the frontend service by adding the `spec.loadBalancerSourceRanges` for the LoadBalancer type. 

## Why?

I am self-hosting temporal on a Google Kubernetes Engine (GKE) cluster running temporal workflows. I have exposed the frontend service as an internal load balancer to my Cloud Run service (which initiates the temporal workflows) but, by default, the firewall rule created by the GKE service sets a source as "0.0.0.0/0". I am required to further restrict the allowed source ip range to specific subnets.

[GCP guide](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters#fw_ip_address) about restricting ip addresses based on CIDRs in `spec.loadBalancerSourceRanges[]`. Additionally, [AWS documentation](https://repost.aws/knowledge-center/eks-cidr-ip-address-loadbalancer) states that `spec.loadBalancerSourceRanges[]` is used to restrict IP addresses. 

## Checklist

1. How was this tested:
  ```sh
  cd charts/temporal

  helm template render \
  -f values.yaml \
  --set "server.frontend.service.loadBalancerSourceRanges={1.1.1.1/8,2.2.2.2/8}" ./ \
  | grep loadBalancerSourceRanges -A 3 -B 3
  ```

output is
```
    app.kubernetes.io/part-of: temporal
spec:
  type: ClusterIP
  loadBalancerSourceRanges:
    - 1.1.1.1/8
    - 2.2.2.2/8
  ports:
```

* Rendered the template locally.
* Deployed the changes to my development google kubernetes engine cluster. 
* Verified that the firewall rules concerning this frontend service changed the sourceIP from 0.0.0.0/0 to the ip range I specified in the `server.frontend.service.loadBalancerSourceRanges` from my helm values.yaml file.

1. Any docs updates needed? 
No
