### PR TITLE
Fixing the reference to a global Helm value within a local scope

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -145,8 +145,8 @@ spec:
           args: ['temporal operator namespace describe -n {{ $namespace.name }} || temporal operator namespace create -n {{ $namespace.name }}{{- if hasKey $namespace "retention" }} --retention {{ $namespace.retention }}{{- end }}']
           env:
             - name: TEMPORAL_ADDRESS
-              {{- if and (hasKey .Values.server "internalFrontend") .Values.server.internalFrontend.enabled }}
-              value: {{ include "temporal.fullname" $ }}-internal-frontend.{{ $.Release.Namespace }}.svc:{{ .Values.server.internalFrontend.service.port }}
+              {{- if and (hasKey $.Values.server "internalFrontend") $.Values.server.internalFrontend.enabled }}
+              value: {{ include "temporal.fullname" $ }}-internal-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.internalFrontend.service.port }}
               {{- else }}
               value: "{{ include "temporal.fullname" $ }}-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
 			  {{- end }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixing the reference to a global Helm value within a local scope

## Why?
This change would fix an error that occurred in version `0.53.0` of the Helm chart :

```
Error: template: temporal/templates/server-job.yaml:148:40: executing "temporal/templates/server-job.yaml" at <.Values.server>: nil pointer evaluating interface {}.server
```

## Checklist
<!--- add/delete as needed --->

1. Closes [616](https://github.com/temporalio/helm-charts/issues/616)

2. How was this tested:

Run this helm command and see that the error no longer appears: 
```bash
cd charts/temporal

helm template ./ --set server.config.namespaces.create=true
```
