### PR TITLE
Fix internalFrontend service selector labels

### DIFF
--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -29,7 +29,7 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "temporal.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
-    app.kubernetes.io/component: frontend
+    app.kubernetes.io/component: {{ $service }}
 
 ---
 {{- end }}


### PR DESCRIPTION

## What was changed
The frontend-internal service will point to the corresponding internal-frontend pods 

## Why?
When the internalFrontend is enabled its corresponding service points to the frontend pods instead of the internal-Frontend pods.

## Checklist
Tested locally