### PR TITLE
fix: Using config as alertmanager yml

### DIFF
--- a/charts/temporal/values/values.prometheus.external.yaml
+++ b/charts/temporal/values/values.prometheus.external.yaml
@@ -1,8 +1,8 @@
 prometheus: 
   alertmanager:
     enabled: false
-  alertmanagerFiles:
-    alertmanager.yml: {}
+  config:
+  # mounted as alertmanager.yml:
   kubeStateMetrics:
     enabled: false
   nodeExporter:


### PR DESCRIPTION
This change clarifies that the config key should be used to define the alertmanager.yml file.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I basically changed the yml example to explicitly show that the `alertmanager.config` is responsible for defining the `alertmanager.yml` instead of this:
```
alertmanagerFiles:
    alertmanager.yml: {}
```

As you can see in the `alertmanager` chart this is the expected use:
- https://github.com/prometheus-community/helm-charts/blob/main/charts/alertmanager/values.yaml#L288
- https://github.com/prometheus-community/helm-charts/blob/main/charts/alertmanager/templates/configmap.yaml#L15

## Why?
I initially attempted to use alertmanagerFiles but, after some trial and error and reverse engineering, I realized that a config object was the correct approach instead. I think people will make good use of a clear documentation.

2. How was this tested:
I am running a self-hosted version of this, right now I have it working and serving clients with the changes I proposed.

3. Any docs updates needed?
No
