### PR TITLE
fix issue #588 [Feature Request] Add prefix for metrics exposed by Pr…

### DIFF
--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.54.0
+version: 0.55.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.26.2

--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.55.0
+version: 0.54.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.26.2

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -96,6 +96,9 @@ data:
         excludeTags:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if and (hasKey .Values.server.metrics "prefix") .Values.server.metrics.prefix }}
+        prefix: {{ $server.metrics.prefix }}
+        {{- end }}
         {{- with $server.config.prometheus }}
         prometheus:
           {{- toYaml . | nindent 10 }}

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -96,8 +96,8 @@ data:
         excludeTags:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if and (hasKey .Values.server.metrics "prefix") .Values.server.metrics.prefix }}
-        prefix: {{ $server.metrics.prefix }}
+        {{- with $server.metrics.prefix }}
+        prefix: "{{- . }}"
         {{- end }}
         {{- with $server.config.prometheus }}
         prometheus:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -34,7 +34,7 @@ server:
     tags: {}
     # Tags to be excluded in Prometheus metrics
     excludeTags: {}
-    prefix: 
+    prefix:
     # Enable Prometheus ServiceMonitor
     # Use this if you installed the Prometheus Operator (https://github.com/coreos/prometheus-operator).
     serviceMonitor:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -34,6 +34,7 @@ server:
     tags: {}
     # Tags to be excluded in Prometheus metrics
     excludeTags: {}
+    prefix: 
     # Enable Prometheus ServiceMonitor
     # Use this if you installed the Prometheus Operator (https://github.com/coreos/prometheus-operator).
     serviceMonitor:


### PR DESCRIPTION
fix Issue #588 add prefix for metrics exposed by Prometheus

## What was changed
added `server.metrics.prefix` to values.yaml

## Why?

per feature request, and the prefix is helpful for complex installations
1. closes 588
2. How was tis tested:
added configuration setting to values.yaml and ran `helm template` and ensured that the correct setting made its way to the proper section in the config map file.
3. Any docs updates needed?
I don't think so, as the other settings are not in the readme.
