### PR TITLE
Move additionalInitContainers to bottom in server-job.yaml

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -24,9 +24,6 @@ spec:
       {{ include "temporal.serviceAccount" $ }}
       restartPolicy: OnFailure
       initContainers:
-        {{- if $.Values.admintools.additionalInitContainers }}
-          {{- toYaml $.Values.admintools.additionalInitContainers | nindent 8 }}
-        {{- end }}
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service
           image: busybox
@@ -163,6 +160,9 @@ spec:
                 {{- toYaml . | nindent 12 }}
               {{- end }}
           {{- end }}
+        {{- end }}
+        {{- if $.Values.admintools.additionalInitContainers }}
+          {{- toYaml $.Values.admintools.additionalInitContainers | nindent 8 }}
         {{- end }}
       containers:
         - name: done

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -9,7 +9,7 @@ tests:
           - name: my-init-container
     asserts:
       - equal:
-          path: spec.template.spec.initContainers[0].name
+          path: spec.template.spec.initContainers[-1].name
           value: my-init-container
   - it: includes additional volumes
     set:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Moved `admintools.additionalInitContainers` to the bottom in server-job.

## Why?
<!-- Tell your future self why have you made these changes -->
Since additional init containers run first there isn't a way to add additional steps to server job after schema setup/update (for instance, add search attributes).

## Checklist
<!--- add/delete as needed --->

1. Closes - <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- add value:
```
admintools:
  additionalInitContainers:
    - name: create-search-attributes
      image: temporalio/admin-tools:1.26.2
      imagePullPolicy: IfNotPresent
      command: ['/bin/sh','-c']
      args: ['temporal operator search-attribute create --namespace "my-namespace" --name="CustomId" --type="Keyword"']
```
- run command `helm template demo charts/temporal -s templates/server-job.yaml`
- check that added container is at the end

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No