### PR TITLE
Added liveliness probe to the web deployment.

### DIFF
--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -42,13 +42,9 @@ spec:
                 name: {{ .Values.web.additionalEnvSecretName }}
           {{- end }}
           livenessProbe:
-            failureThreshold: 3
             initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
             tcpSocket:
               port: http
-            timeoutSeconds: 1
           ports:
             - name: http
               containerPort: 8080

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -41,6 +41,14 @@ spec:
             - secretRef:
                 name: {{ .Values.web.additionalEnvSecretName }}
           {{- end }}
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: http
+            timeoutSeconds: 1
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## What was changed
Modified the web-deployment.yml to specify a liveliness probe on the web component monitoring the http port.
Note: didn't add startup or readiness since the other components don't have these either.

## Why?
Improved monitoring of the web component.

## Checklist

1. Closes https://github.com/temporalio/helm-charts/issues/591
(only if you don't care about the readiness and startup probes)

2. How was this tested:
Used 'kubectl describe' on the web container to verify changes. 
Decreased initialDelaySeconds with a bad tcpSocket port to verify error condition.
Fixed the port to verify there's a Liveliness section in the description and no errors.

3. Any docs updates needed?
No
