### PR TITLE
change mysql driver to mysql8 as mysql is no longer supported

### DIFF
--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -154,7 +154,7 @@ server:
               consistency: "local_quorum"
               serialConsistency: "local_serial"
         sql:
-          driver: "mysql"
+          driver: "mysql8"
           host: "mysql"
           port: 3306
           database: "temporal"
@@ -184,7 +184,7 @@ server:
               consistency: "local_quorum"
               serialConsistency: "local_serial"
         sql:
-          driver: "mysql"
+          driver: "mysql8"
           host: "mysql"
           port: 3306
           database: "temporal_visibility"

--- a/charts/temporal/values/values.aurora-mysql.yaml
+++ b/charts/temporal/values/values.aurora-mysql.yaml
@@ -5,7 +5,7 @@ server:
         driver: "sql"
 
         sql:
-          driver: "mysql"
+          driver: "mysql8"
           host: _HOST_
           port: 3306
           database: temporal
@@ -20,7 +20,7 @@ server:
         driver: "sql"
 
         sql:
-          driver: "mysql"
+          driver: "mysql8"
           host: _HOST_
           port: 3306
           database: temporal_visibility


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
change "mysql" driver in values.yaml and example values.aurora-mysql.yaml to "mysql8"

## Why?
"mysql" is no longer in the list of supported drivers (cassandra, mysql8, postgres12, postgres12_pgx, elasticsearch)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
This is a small change so I don't open an issue for it.

3. How was this tested:
I deployed the helm chart, using sql as default/visibility DB.

4. Any docs updates needed?
No, README doesn't contain this part.