### PR TITLE
Add support of clusterIP in server service

### DIFF
--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -13,6 +13,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ $serviceValues.service.type }}
+  {{- if hasKey $serviceValues.service "clusterIP" }}
+  clusterIP: {{ $serviceValues.service.clusterIP }}
+  {{- end }}
   ports:
     - port: {{ $serviceValues.service.port }}
       targetPort: rpc

--- a/charts/temporal/tests/service_test.go
+++ b/charts/temporal/tests/service_test.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestTemplateServerServiceDefault(t *testing.T) {
+	// t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../")
+	releaseName := "temporal"
+	require.NoError(t, err)
+
+	namespaceName := "temporal-" + strings.ToLower(random.UniqueId())
+
+	var deployment appsv1.Deployment
+
+	options := &helm.Options{
+		KubectlOptions:    k8s.NewKubectlOptions("", "", namespaceName),
+		BuildDependencies: true,
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/server-service.yaml"})
+
+	helm.UnmarshalK8SYaml(t, output, &deployment)
+}
+
+func TestTemplateServerServiceFrontendClusterIP(t *testing.T) {
+	// t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../")
+	releaseName := "temporal"
+	require.NoError(t, err)
+
+	namespaceName := "temporal-" + strings.ToLower(random.UniqueId())
+
+	var deployment appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"frontend.service.clusterIP": "None",
+		},
+		KubectlOptions:    k8s.NewKubectlOptions("", "", namespaceName),
+		BuildDependencies: true,
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/server-service.yaml"})
+
+	helm.UnmarshalK8SYaml(t, output, &deployment)
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added support of passing `clusterIP` value for `temporal-chart-frontend` and `temporal-chart-internal-frontend` services.
## Why?
<!-- Tell your future self why have you made these changes -->
There is no options to pass `clusterIP` reserved value or `None` for `temporal-chart-frontend`.
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested: Unit tests
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
