### PR TITLE
Add AdditionalEnvs to Namespace Job

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -150,8 +150,8 @@ spec:
               {{- else }}
               value: "{{ include "temporal.fullname" $ }}-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
               {{- end }}
-              {{- if $.Values.admintools.additionalEnv }} 
-                {{- toYaml $.Values.admintools.additionalEnv | nindent 12 }}
+              {{- with $.Values.admintools.additionalEnv }}
+                {{- toYaml . | nindent 12 }}
               {{- end }} 
               {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -150,6 +150,9 @@ spec:
               {{- else }}
               value: "{{ include "temporal.fullname" $ }}-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
               {{- end }}
+              {{- if $.Values.admintools.additionalEnv }} 
+                {{- toYaml $.Values.admintools.additionalEnv | nindent 12 }}
+              {{- end }} 
               {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:
                 {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## What was changed
Added ability to specify additional environment variables for the namespace job in `server-job.yaml`

## Why?
Allows TLS arguments to be passed to commands used by Temporal CLI

## Checklist
1. Closes #640 

2. How was this tested:
 - set `server.config.namespaces.create` to true
 - add the following to `env` in the `create-{{ $namespace.name }}-namespace` job, at line 153
 ```yaml
{{- with $.Values.admintools.additionalEnv }} 
  {{- toYaml . | nindent 12 }}
{{- end }} 
```
 - add any envs under `admintools.additionalEnv`
 - run `helm template demo charts/temporal -s templates/server-job.yaml`
 - verify that the envs under the create namespace jobs reflect the envs added
 
3. Any docs updates needed?
None
