### PR TITLE
fix(elasticsearch): make auth parameters optional in health check

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - name: check-elasticsearch-index
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'until curl --silent --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1 > /dev/null; do echo waiting for elasticsearch index to become ready; sleep 1; done;']
+          command: ['sh', '-c', 'until curl --silent --fail $( [ -n "$ES_USER" ] && [ -n "$ES_PWD" ] && echo --user  "$ES_USER:$ES_PWD") $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1 > /dev/null; do echo waiting for elasticsearch index to become ready; sleep 1; done;']
           env:
             {{- include "temporal.admintools-env" (list $ "visibility") | nindent 12 }}
         {{- end }}

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -40,7 +40,7 @@ spec:
         - name: check-elasticsearch
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['sh', '-c', 'until curl --silent --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
+          command: ['sh', '-c', 'until curl --silent --fail $( [ -n "$ES_USER" ] && [ -n "$ES_PWD" ] && echo --user  "$ES_USER:$ES_PWD") $ES_SCHEME://$ES_HOST:$ES_PORT 2>&1 > /dev/null; do echo waiting for elasticsearch to start; sleep 1; done;']
           env:
             {{- include "temporal.admintools-env" (list $ "visibility") | nindent 12 }}
         {{- end }}
@@ -80,9 +80,9 @@ spec:
             {{- else if eq $driver "elasticsearch" }}
           command: ['sh', '-c']
           args:
-            - 'curl -X PUT --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_$ES_VERSION.json" 2>&1 &&
-              curl --head --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1 ||
-              curl -X PUT --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1'
+            - 'curl -X PUT --fail $( [ -n "$ES_USER" ] && [ -n "$ES_PWD" ] && echo --user  "$ES_USER:$ES_PWD") $ES_SCHEME://$ES_HOST:$ES_PORT/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_$ES_VERSION.json" 2>&1 &&
+              curl --head --fail $( [ -n "$ES_USER" ] && [ -n "$ES_PWD" ] && echo --user  "$ES_USER:$ES_PWD") $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1 ||
+              curl -X PUT --fail $( [ -n "$ES_USER" ] && [ -n "$ES_PWD" ] && echo --user  "$ES_USER:$ES_PWD") $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1'
             {{- end }}
           env:
             {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}


### PR DESCRIPTION
ix: Only add --user flag when both ES_USER and ES_PWD env vars are set. Previously the curl command always included auth headers even when not configured, causing Elasticsearch to reject the request.  Resolves issue where pods would hang in init state when Elasticsearch auth was not configured.


## What was changed
Makes the --user parameter conditional in the Elasticsearch health check command,
only including authentication when both ES_USER and ES_PWD environment variables
are set.

## Why?
When Elasticsearch is configured without authentication, the init container was sending empty auth credentials (--user ":") which caused 403 errors. This change makes the --user flag conditional on having both username and password set.  Bug: Init containers would hang when checking Elasticsearch readiness due to 403 responses from sending empty auth credentials.  


1. Closes  #621 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->


