### PR TITLE
[frontend] define serviceName

### DIFF
--- a/charts/temporal/templates/frontend-ingress.yaml
+++ b/charts/temporal/templates/frontend-ingress.yaml
@@ -40,12 +40,12 @@ spec:
               pathType: Prefix
               backend:
                 service:
-                  name: {{ include "temporal.fullname" $ }}-frontend
+                  name: {{ default (printf "%s-frontend" (include "temporal.fullname" $)) $.Values.server.frontend.service.name }}
                   port:
                     number: {{ $.Values.server.frontend.service.port }}
               {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
               backend:
-                serviceName: {{ include "temporal.fullname" $ }}-frontend
+                serviceName: {{ default (printf "%s-frontend" (include "temporal.fullname" $)) $.Values.server.frontend.service.name }}
                 servicePort: {{ $.Values.server.frontend.service.port }}
               {{- end }}
     {{- end}}

--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "temporal.componentname" (list $ $service) }}
+  name: {{ default (include "temporal.componentname" (list $ $service)) $.Values.server.frontend.service.name  }}
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
   {{- if $serviceValues.service.annotations }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -140,7 +140,7 @@ server:
         driver: "cassandra"
         cassandra:
           hosts: []
-          # port: 9042
+          port: 9042
           keyspace: "temporal"
           user: "user"
           password: "password"
@@ -170,7 +170,7 @@ server:
         driver: "cassandra"
         cassandra:
           hosts: []
-          # port: 9042
+          port: 9042
           keyspace: "temporal_visibility"
           user: "user"
           password: "password"
@@ -204,6 +204,7 @@ server:
           retention: 3d
   frontend:
     service:
+      # name: temporal-frontend-name
       # Evaluated as template
       annotations: {}
       type: ClusterIP
@@ -211,7 +212,7 @@ server:
       membershipPort: 6933
       httpPort: 7243
     ingress:
-      enabled: false
+      enabled: true
       # className:
       annotations: {}
       # kubernetes.io/ingress.class: traefik

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -204,7 +204,7 @@ server:
           retention: 3d
   frontend:
     service:
-      # name: temporal-frontend-name
+      # name: temporal-frontend-serviceName
       # Evaluated as template
       annotations: {}
       type: ClusterIP

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -170,7 +170,7 @@ server:
         driver: "cassandra"
         cassandra:
           hosts: []
-          port: 9042
+          # port: 9042
           keyspace: "temporal_visibility"
           user: "user"
           password: "password"

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -140,7 +140,7 @@ server:
         driver: "cassandra"
         cassandra:
           hosts: []
-          port: 9042
+          # port: 9042
           keyspace: "temporal"
           user: "user"
           password: "password"

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -212,7 +212,7 @@ server:
       membershipPort: 6933
       httpPort: 7243
     ingress:
-      enabled: true
+      enabled: false
       # className:
       annotations: {}
       # kubernetes.io/ingress.class: traefik


### PR DESCRIPTION
## What was changed
[frontend] define serviceName

## Why?
I'm using [ingress-nginx controller](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/), to expose multiple temporal clusters frontend services in different [tcp](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml#L192) ports, using the same NLB. As such, I need to set the serviceName to a specific value.

e.g.
```yaml
tcp:
  7233: "temporal-test1/temporal-frontend-serviceName:7233"
  7234: "temporal-test2/temporal-frontend-serviceName:7233"
  7235: "temporal-test3/temporal-frontend-serviceName7233"
```

2. How was this tested:
```yaml
cd charts/temporal
helm template . --name-template temporal -n temporal -f values.yaml > test.yaml --debug
```

@robholland 