### PR TITLE
Turn off service annotations when requested.

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/server-configmap.yaml") $ | sha256sum }}
-        {{- if (default $.Values.server.metrics.annotations.enabled $serviceValues.metrics.annotations.enabled) }}
+        {{- if (dig "metrics" "annotations" "enabled" $.Values.server.metrics.annotations.enabled $serviceValues) }}
         prometheus.io/job: {{ $.Chart.Name }}-{{ $service }}
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9090'

--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -46,19 +46,19 @@ metadata:
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
     app.kubernetes.io/headless: 'true'
-    {{- if (default $.Values.server.metrics.annotations.enabled $serviceValues.metrics.annotations.enabled) }}
-    prometheus.io/job: {{ $.Chart.Name }}-{{ $service }}
-    prometheus.io/scrape: 'true'
-    prometheus.io/scheme: http
-    prometheus.io/port: "9090"
-    {{- end }}
-
   annotations:
     # Use this annotation in addition to the actual field below because the
     # annotation will stop being respected soon but the field is broken in
     # some versions of Kubernetes:
     # https://github.com/kubernetes/kubernetes/issues/58662
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    {{- if (dig "metrics" "annotations" "enabled" $.Values.server.metrics.annotations.enabled $serviceValues) }}
+    prometheus.io/job: {{ $.Chart.Name }}-{{ $service }}
+    prometheus.io/scrape: 'true'
+    prometheus.io/scheme: http
+    prometheus.io/port: "9090"
+    {{- end }}
+
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -46,10 +46,12 @@ metadata:
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
     app.kubernetes.io/headless: 'true'
+    {{- if (default $.Values.server.metrics.annotations.enabled $serviceValues.metrics.annotations.enabled) }}
     prometheus.io/job: {{ $.Chart.Name }}-{{ $service }}
     prometheus.io/scrape: 'true'
     prometheus.io/scheme: http
     prometheus.io/port: "9090"
+    {{- end }}
 
   annotations:
     # Use this annotation in addition to the actual field below because the

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -74,9 +74,6 @@ tests:
       matchMany: true
     set:
       server:
-        metrics:
-          annotations:
-            enabled: false
         frontend:
           metrics:
             annotations:

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -66,3 +66,25 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: my-init-container
+  - it: omits prometheus annotations when disabled
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        metrics:
+          annotations:
+            enabled: false
+        frontend:
+          metrics:
+            annotations:
+              enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/job"]
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/port"]

--- a/charts/temporal/tests/server_service_test.yaml
+++ b/charts/temporal/tests/server_service_test.yaml
@@ -16,22 +16,19 @@ tests:
   - it: omits prometheus annotations when disabled
     template: templates/server-service.yaml
     documentSelector:
-      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend-headless")].kind'
       value: Service
       matchMany: true
     set:
       server:
-        metrics:
-          annotations:
-            enabled: false
         frontend:
           metrics:
             annotations:
               enabled: false
     asserts:
       - notExists:
-          path: spec.template.metadata.annotations["prometheus.io/job"]
+          path: metadata.annotations["prometheus.io/job"]
       - notExists:
-          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          path: metadata.annotations["prometheus.io/scrape"]
       - notExists:
-          path: spec.template.metadata.annotations["prometheus.io/port"]
+          path: metadata.annotations["prometheus.io/port"]

--- a/charts/temporal/tests/server_service_test.yaml
+++ b/charts/temporal/tests/server_service_test.yaml
@@ -1,0 +1,37 @@
+suite: test server service
+templates:
+  - server-service.yaml
+set:
+  server:
+    replicaCount: 2
+    resources:
+      requests:
+        cpu: 100m
+    frontend:
+      replicaCount: 3
+      resources:
+        requests:
+          cpu: 200m
+tests:
+  - it: omits prometheus annotations when disabled
+    template: templates/server-service.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
+      value: Service
+      matchMany: true
+    set:
+      server:
+        metrics:
+          annotations:
+            enabled: false
+        frontend:
+          metrics:
+            annotations:
+              enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/job"]
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/port"]


### PR DESCRIPTION

## What was changed
Added exclusion for the service, as we have for the deployment.

## Why?
Prevents prometheus scraping services when it's not wanted, such as users using Datadog.

## Checklist

1. Closes https://github.com/temporalio/helm-charts/issues/647

2. How was this tested:
Added unit tests.

3. Any docs updates needed?
No.