### PR TITLE
Fix init containers restart policy

### DIFF
--- a/charts/temporal/values/values.cloudsqlproxy.yaml
+++ b/charts/temporal/values/values.cloudsqlproxy.yaml
@@ -7,7 +7,7 @@ admintools:
         - "-ip_address_types=PRIVATE"
         - "-instances=_PROJECTNAME_:_REGION_:_INSTANCENAME_=tcp:5432"
         - "-credential_file=/etc/google-cloud-key/key.json"
-      restart: Always
+      restartPolicy: Always
       securityContext:
         runAsNonRoot: true
       volumeMounts:
@@ -29,7 +29,7 @@ server:
         - "-ip_address_types=PRIVATE"
         - "-instances=_PROJECTNAME_:_REGION_:_INSTANCENAME_=tcp:5432"
         - "-credential_file=/etc/google-cloud-key/key.json"
-      restart: Always
+      restartPolicy: Always
       securityContext:
         runAsNonRoot: true
       volumeMounts:


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
Changing the the gcp proxy example to restartPolicy to be working the way it was intended

## Why?
Ran into this issue when trying to get our temporal installation to work with gcp sql proxy and postgres.

## Checklist
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Use this values file to deploy a temporal instance using sql proxy with a gcp postgres instance
