### PR TITLE
Add support for "custom" persistence driver

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -18,6 +18,7 @@ data:
       visibilityStore: visibility
       numHistoryShards: {{ $server.config.numHistoryShards }}
       datastores:
+        {{- if ne (include "temporal.persistence.driver" (list $ "default")) "custom" }}
         default:
           {{- if eq (include "temporal.persistence.driver" (list $ "default")) "cassandra" }}
           cassandra:
@@ -44,6 +45,7 @@ data:
           faultInjection:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
         {{- with $server.config.persistence.additionalStores }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -76,16 +76,20 @@ spec:
                   fieldPath: status.podIP
             - name: SERVICES
               value: {{ $service }}
+            {{- if ne (include "temporal.persistence.driver" (list $ "default")) "custom" }}
             - name: TEMPORAL_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "default") }}
                   key: {{ include "temporal.persistence.secretKey" (list $ "default") }}
+            {{- end }}
+            {{- if ne (include "temporal.persistence.driver" (list $ "visibility")) "custom" }}
             - name: TEMPORAL_VISIBILITY_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "visibility") }}
                   key: {{ include "temporal.persistence.secretKey" (list $ "visibility") }}
+            {{- end }}
           {{- if and (hasKey $.Values.server "internalFrontend") $.Values.server.internalFrontend.enabled }}
             - name: USE_INTERNAL_FRONTEND
               value: "1"

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -48,7 +48,7 @@ spec:
           {{- range $store := (list "default" "visibility") }}
             {{- $storeConfig := index $.Values.server.config.persistence $store }}
             {{- $driver := include "temporal.persistence.driver" (list $ $store) }}
-            {{- if ne $driver "elasticsearch" }}
+            {{- if and (ne $driver "elasticsearch") (ne $driver "custom") }}
         - name: create-{{ $store }}-store
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
@@ -70,33 +70,35 @@ spec:
           {{- range $store := (list "default" "visibility") }}
             {{- $storeConfig := index $.Values.server.config.persistence $store }}
             {{- $driver := include "temporal.persistence.driver" (list $ $store) }}
+            {{- if ne $driver "custom" }}
         - name: setup-{{ $store }}-store
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-            {{- if eq $driver "cassandra" }}
+              {{- if eq $driver "cassandra" }}
           command: ['temporal-cassandra-tool', 'setup-schema', '-v', '0.0']
-            {{- else if eq $driver "sql" }}
+              {{- else if eq $driver "sql" }}
           command: ['temporal-sql-tool', 'setup-schema', '-v', '0.0']
-            {{- else if eq $driver "elasticsearch" }}
+              {{- else if eq $driver "elasticsearch" }}
           command: ['sh', '-c']
           args:
             - 'curl -X PUT --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/_template/temporal_visibility_v1_template -H "Content-Type: application/json" --data-binary "@schema/elasticsearch/visibility/index_template_$ES_VERSION.json" 2>&1 &&
               curl --head --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1 ||
               curl -X PUT --fail --user "$ES_USER:$ES_PWD" $ES_SCHEME://$ES_HOST:$ES_PORT/$ES_VISIBILITY_INDEX 2>&1'
-            {{- end }}
+              {{- end }}
           env:
-            {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}
-            {{- with $.Values.admintools.additionalVolumeMounts }}
+              {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}
+              {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with $.Values.schema.resources }}
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
+              {{- with $.Values.schema.resources }}
           resources:
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with $.Values.schema.containerSecurityContext }}
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
+              {{- with $.Values.schema.containerSecurityContext }}
           securityContext:
-              {{- toYaml . | nindent 12 }}
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
             {{- end }}
           {{- end }}
         {{- end }}
@@ -105,7 +107,7 @@ spec:
             {{- $storeConfig := index $.Values.server.config.persistence $store }}
             {{- $driver := include "temporal.persistence.driver" (list $ $store) }}
             {{- $schema := include "temporal.persistence.schema" $store }}
-            {{- if ne $driver "elasticsearch" }}
+            {{- if and (ne $driver "elasticsearch") (ne $driver "custom") }}
         - name: update-{{ $store }}-store
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
@@ -152,7 +154,7 @@ spec:
               {{- end }}
               {{- with $.Values.admintools.additionalEnv }}
                 {{- toYaml . | nindent 12 }}
-              {{- end }} 
+              {{- end }}
               {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:
                 {{- toYaml . | nindent 12 }}

--- a/charts/temporal/templates/server-secret.yaml
+++ b/charts/temporal/templates/server-secret.yaml
@@ -7,7 +7,7 @@
   {{- $driverConfig = $.Values.elasticsearch -}}
   {{- end -}}
   {{- $secretName := include "temporal.componentname" (list $ (printf "%s-store" $store)) }}
-  {{- if and (not $driverConfig.existingSecret) (eq (include "temporal.persistence.secretName" (list $ $store)) $secretName) }}
+  {{- if and (ne $driver "custom") (not $driverConfig.existingSecret) (eq (include "temporal.persistence.secretName" (list $ $store)) $secretName) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## What was changed

We add a new first-class persistence driver "custom" to support CustomDataStores

## Why?

Temporal core allows for the registration and configuration of custom data stores. However, there is a disparity in how the helm chart translates persistence configuration between helm values and the resulting configmap.

As an example, the temporal config for a custom driver for the default store may look as so:

```
persistence:
  defaultStore: my-custom-store
  visibilityStore: es-visibility
  numHistoryShards: 4
  datastores:
    my-custom-store:
      customDatastore:
        name: "my-custom"
        options:
          hosts: "mycustom.example.com"
          keyspace: "temporal"
```

Translating to helm values would look like

```
server:
  config:
    persistence:
      defaultStore: my-custom-store
      additionalStores:
        my-custom-store:
          customDatastore:
            name: "my-custom"
            options:
              hosts: "mycustom.example.com"
              keyspace: "temporal"
```

This gets us most of the way there, but there are a few problems:

1. The charts always assume defaultStore = "default" and thus have opinions about subordinate structures such as default.driver.  This results in objects such as Secrets and Jobs being incorrectly emitted for default.driver = "cassandra" even though we are trying to specify an alternate store.  This logic should probably be $defaultStore.driver and $visibilityStore.driver instead.
2. The additionalStores configuration does not lend itself to first-class representation in conditional statements, even though it can be used to emit the resulting configmap correctly.

One could argue that we should clean up the helm representation to more closely align with the temporal-server yaml, but this is a bigger task (and a breaking change).  Instead, this patch ties into the existing model of using $store.driver = {cassandra, sql, elasticsearch} and adds a 4th first-class type "custom."

The user may configure this as so:

```
server:
  config:
    persistence:
      default:
        driver: custom
      visibility:
        driver: custom
```

And in doing so, we instruct the various templates to elide the objects (Jobs, Secrets, etc.) related to that store, leaving it to the user to supply the rest of the required configuration using a combination of additionalStores, additionalEnv, additionalVolumeMounts, etc., to inject configuration and secrets.  They would also, of course, be responsible for any DDL setup or migration.

## Checklist

1. How was this tested:

Used `helm-template` with various additionalStore configurations present and removed and carefully inspected output to ensure adherence to stated goals.  Deployed to k8s to verify.

2. Any docs updates needed?
 
 No