### PR TITLE
Setting busybox repository and tag via values.yaml

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -45,7 +45,9 @@ spec:
         {{- end }}
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service
-          image: busybox
+          image: {{ $.Values.busybox.image.repository }}
+          tag: {{ $.Values.busybox.image.tag }}
+          imagePullPolicy: {{ $.Values.busybox.image.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }}; do echo waiting for cassandra service; sleep 1; done;']
         - name: check-cassandra
           image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -29,7 +29,9 @@ spec:
         {{- end }}
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service
-          image: busybox
+          image: {{ $.Values.busybox.image.repository }}
+          tag: {{ $.Values.busybox.image.tag }}
+          imagePullPolicy: {{ $.Values.busybox.image.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }}; do echo waiting for cassandra service; sleep 1; done;']
         - name: check-cassandra
           image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -16,6 +16,12 @@ serviceAccount:
   extraAnnotations:
 additionalAnnotations: {}
 additionalLabels: {}
+
+busybox:
+  image:
+    repository: busybox
+    tag: 1.37.0
+
 server:
   enabled: true
   image:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -21,6 +21,7 @@ busybox:
   image:
     repository: busybox
     tag: 1.37.0
+    pullPolicy: IfNotPresent
 
 server:
   enabled: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I've updated the helmchart such that the busybox repository and tag are set via values set in values.yaml

## Why?
When working in isolated networks, having this image always set to `busybox:latest` as it is currently will cause the cluster to always try and check for what the latest version is, causing an ImagePullBackoff error. 
Similarly, I've needed to pull this image from a custom registry rather than the public one, too, so having the public repo hard-coded is inconvenient.

It's easy enough to patch yourself, but I thought other users in similar situations would appreciate not needing to do so.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
I ran the cluster locally using values.yaml and checked that all pods were healthy.

3. Any docs updates needed?
I don't believe so, but please correct me if I am wrong!
