### PR TITLE
Set maxIdleConns in values

### DIFF
--- a/charts/temporal/ci/postgres-es-values.yaml
+++ b/charts/temporal/ci/postgres-es-values.yaml
@@ -13,6 +13,7 @@ server:
           user: "temporal"
           password: "temporal"
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
 elasticsearch:
   enabled: true

--- a/charts/temporal/ci/postgres-values.yaml
+++ b/charts/temporal/ci/postgres-values.yaml
@@ -13,6 +13,7 @@ server:
           user: "temporal"
           password: "temporal"
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
       visibility:
         driver: "sql"
@@ -24,6 +25,7 @@ server:
           user: "temporal"
           password: "temporal"
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
 cassandra:
   enabled: false

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -163,6 +163,7 @@ server:
           existingSecret: ""
           secretName: ""
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
           # connectAttributes:
           # tx_isolation: 'READ-COMMITTED'
@@ -193,6 +194,7 @@ server:
           existingSecret: ""
           secretName: ""
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
           # connectAttributes:
           #   tx_isolation: 'READ-COMMITTED'

--- a/charts/temporal/values/values.aurora-mysql.yaml
+++ b/charts/temporal/values/values.aurora-mysql.yaml
@@ -12,6 +12,7 @@ server:
           user: _USERNAME_
           password: _PASSWORD_
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
           connectAttributes:
             tx_isolation: 'READ-COMMITTED'
@@ -27,6 +28,7 @@ server:
           user: _USERNAME_
           password: _PASSWORD_
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
           connectAttributes:
             tx_isolation: 'READ-COMMITTED'          

--- a/charts/temporal/values/values.mysql.yaml
+++ b/charts/temporal/values/values.mysql.yaml
@@ -12,6 +12,7 @@ server:
           user: _USERNAME_
           password: _PASSWORD_
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
 
       visibility:
@@ -25,6 +26,7 @@ server:
           user: _USERNAME_
           password: _PASSWORD_
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
 
 cassandra:

--- a/charts/temporal/values/values.postgresql.yaml
+++ b/charts/temporal/values/values.postgresql.yaml
@@ -15,6 +15,7 @@ server:
           # it has a single key called `password`
           # existingSecret: temporal-default-store
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
           # tls:
           #  enabled: true
@@ -38,6 +39,7 @@ server:
           # it has a single key called `password`
           # existingSecret: temporal-visibility-store
           maxConns: 20
+          maxIdleConns: 20
           maxConnLifetime: "1h"
           # tls:
           #  enabled: true


### PR DESCRIPTION
## What was changed
Set maxIdleConns in sql values.

## Why?
We noticed that sql performance will improve significantly if we set maxIdleConns.
If this value is not set, it will be taken as 0 and database connections will be deleted as soon as it becomes idle.

