### PR TITLE
Add support for annotations on job resource

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Create the annotations for all resources
 {{- $scope := index . 1 -}}
 {{- $resourceType := index . 2 -}}
 {{- $component := "server" -}}
-{{- if (or (eq $scope "admintools") (eq $scope "web")) -}}
+{{- if (or (eq $scope "admintools") (eq $scope "web") (eq $scope "schema")) -}}
 {{- $component = $scope -}}
 {{- end -}}
 {{- with $resourceType -}}

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
+  annotations:
+    {{- include "temporal.resourceAnnotations" (list $ "schema" "job") | nindent 4 }}
 spec:
   backoffLimit: {{ $.Values.schema.setup.backoffLimit }}
   ttlSecondsAfterFinished: 86400

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -442,6 +442,7 @@ schema:
   update:
     enabled: true
     backoffLimit: 100
+  jobAnnotations: {}
   podAnnotations: {}
   podLabels: {}
   resources: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added support for adding annotations to the schema Job resource. I have leveraged the `temporal.resourceAnnotations` template for consistency. If preferred, we could use the 'direct' approach as used with the annotations in the Job's pod specification, .e.g:

```
  {{- with $.Values.schema.jobAnnotations }}
  annotations:
    {{- toYaml . | nindent 4 }}
  {{- end }}
```

## Why?
We deploy our manifests using ArgoCD and it fails when we make a change to the Job's pod specification (e.g. the secrets being mounted or the environment variables set) as by default ArgoCD uses `apply`. However this behaviour can be reconfigured via [resource annotations](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#replace-resource-instead-of-applying-changes). This PR allows us to set that annotation. 

## Checklist
<!--- add/delete as needed --->

1. Closes  n/a

2. How was this tested: I ran `helm template` locally 

3. Any docs updates needed? n/a
