### PR TITLE
Closes #675: Enable persistence to the default Cassandra and ES

### DIFF
--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -451,7 +451,7 @@ elasticsearch:
   enabled: true
   replicas: 3
   persistence:
-    enabled: false
+    enabled: true
   imageTag: 7.17.3
   host: elasticsearch-master-headless
   scheme: http
@@ -524,7 +524,7 @@ grafana:
 cassandra:
   enabled: true
   persistence:
-    enabled: false
+    enabled: true
   image:
     repo: cassandra
     tag: 3.11.3

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -452,6 +452,10 @@ elasticsearch:
   replicas: 3
   persistence:
     enabled: true
+  volumeClaimTemplate:
+    resources:
+      requests:
+        storage: 5Gi
   imageTag: 7.17.3
   host: elasticsearch-master-headless
   scheme: http
@@ -525,6 +529,7 @@ cassandra:
   enabled: true
   persistence:
     enabled: true
+    size: 5Gi
   image:
     repo: cassandra
     tag: 3.11.3


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Enable persistence to the default Cassandra and ES

## Why?
The current default chart are using transient storage for ES and Cassandra.
This results in the cluster being down each time the ES/Cassandra instances are killed. The reason is that schema migration is only run once at the time of initialization, so new ES/Cassandra instances don't have the needed schemas.
There is no way to recover from this except starting a new deployment.

## Checklist
<!--- add/delete as needed --->

1. Closes #675 

2. How was this tested:
I deployed a Temporal cluster with the new configs, and then killed the Cassandra/ES instance. After that, I checked whether the cluster still worked properly.

3. Any docs updates needed?
N/A
