### PR TITLE
Add Values.web.service.clusterIP to provide headless temporal-web service toggle

### DIFF
--- a/charts/temporal/templates/web-service.yaml
+++ b/charts/temporal/templates/web-service.yaml
@@ -13,6 +13,9 @@ spec:
   loadBalancerIP: {{.}}
     {{- end }}
   type: {{ .Values.web.service.type }}
+  {{- with .Values.web.service.clusterIP }}
+  clusterIP: {{.}}
+  {{- end }}
   ports:
     - port: {{ .Values.web.service.port }}
       targetPort: http

--- a/charts/temporal/tests/web_service_test.yaml
+++ b/charts/temporal/tests/web_service_test.yaml
@@ -1,0 +1,31 @@
+suite: test server service
+templates:
+  - web-service.yaml
+tests:
+  - it: includes the provided clusterIP to make the service headless
+    template: templates/web-service.yaml
+    documentSelector:
+      path: kind
+      value: Service
+    set:
+      web:
+        service:
+          clusterIP: None
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.clusterIP
+          value: None
+  - it: does not include a spec.clusterIP by default, when none is given
+    template: templates/web-service.yaml
+    documentSelector:
+      path: kind
+      value: Service
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.clusterIP

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -387,6 +387,9 @@ web:
     # set type to NodePort if access to web needs access from outside the cluster
     # for more info see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: ClusterIP
+    # The below clusterIP setting can be set to "None" to make the temporal-web service headless.
+    # Note that this requires the web.service.type to be the default ClusterIP value.
+    # clusterIP:
     port: 8080
     annotations: {}
     # loadBalancerIP:


### PR DESCRIPTION
## What was changed
Addresses: https://github.com/temporalio/helm-charts/issues/680

This PR adds support for `Values.web.service.clusterIP`, which can be set to `None` to turn the `temporal-web` service into a headless service. 

## Why?
We need to be able to target the service with an external load balancer, which requires the service to be headless. This small change gives users the capability to convert the service into a headless one.

## Checklist
1. Closes https://github.com/temporalio/helm-charts/issues/680

2. How was this tested:
[x] Added `charts/temporal/tests/web_service_test.yaml` with new unit tests to test the new value.

3. Any docs updates needed?
- Inline comment docs were added above the new value to indicate that it's supported and explain its usage.
