### PR TITLE
Add support for check-cassandra-service image specification

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         {{- end }}
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service
-          image: busybox
+          image: "{{ default "busybox" $.Values.cassandra.checkServiceImage }}"
           command: ['sh', '-c', 'until nc -z {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }}; do echo waiting for cassandra service; sleep 1; done;']
           {{- with $serviceValues.containerSecurityContext }}
           securityContext:

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -29,7 +29,7 @@ spec:
         {{- end }}
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service
-          image: busybox
+          image: "{{ default "busybox" $.Values.cassandra.checkServiceImage }}"
           command: ['sh', '-c', 'until nc -z {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }}; do echo waiting for cassandra service; sleep 1; done;']
           {{- with $.Values.schema.containerSecurityContext }}
           securityContext:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -542,5 +542,6 @@ cassandra:
     seed_size: 0
   service:
     type: ClusterIP
+  checkServiceImage: busybox
 mysql:
   enabled: false


### PR DESCRIPTION
## What was changed
Added ability to set the check-cassandra-service image via values.yaml.

## Why?
This is necessary to support deploying the chart in environments were docker.io is inaccessible (e.g. when images must come from a custom corporate on-prem registry, like Harbor).

## Checklist

1. Closes #659. 
    This PR improves on # 659 in a few ways: 
    1. Fully backwards compatible: if `cassandra.checkServiceImage` is not present it gracefully falls back to the existing `busybox` value.
    2. Better follows Helm naming conventions:
        - Utilizes [flat values](https://helm.sh/docs/chart_best_practices/values/#flat-or-nested-values) for optimal null-check safety.
        - Is more contextually relevant, nested in the cassandra stanza for which it relates. I verified `cassandra.checkServiceImage` won't clash with the upstream chart.
    3. Is more flexible:
        - By omitting `imagePullPolicy` Helm will [implicitly choose the most appropriate value](https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting) depending on image tag.
        - All combinations of registry, repository, image, and tag can be specified plainly in the "image" attribute.

3. How was this tested:
    `helm lint`, `helm template`, and test deployment on kubernetes v1.28

5. Any docs updates needed?
    No