### PR TITLE
[Feature Request] Add support for deploying and using PostgreSQL

### DIFF
--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -28,6 +28,10 @@ dependencies:
     repository: https://grafana.github.io/helm-charts
     version: 8.0.2
     condition: grafana.enabled
+  - name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 16.6.2
+    condition: postgresql.enabled
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/temporal/tests/postgresql.yaml
+++ b/charts/temporal/tests/postgresql.yaml
@@ -1,0 +1,47 @@
+cassandra:
+  enabled: false
+prometheus:
+  enabled: false
+grafana:
+  enabled: false
+elasticsearch:
+  enabled: false
+
+postgresql:
+  enabled: true
+  global:
+    postgresql:
+      auth:
+        username: antonio
+        password: brito
+  primary:
+    initdb:
+      scripts:
+        01-init.sql: |-
+          CREATE DATABASE "temporal";
+          CREATE DATABASE "temporal_visibility";
+  commonAnnotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
+
+server:
+  config:
+    persistence:
+      default:
+        driver: "sql"
+        sql:
+          driver: "postgres12"
+          host: "temporal-postgresql.temporal-tests.svc.cluster.local"
+          port: 5432
+          database: "temporal"
+          user: "antonio"
+          password: "brito"
+      visibility:
+        driver: "sql"
+        sql:
+          driver: "postgres12"
+          host: "temporal-postgresql.temporal-tests.svc.cluster.local"
+          port: 5432
+          database: "temporal_visibility"
+          user: "antonio"
+          password: "brito"


### PR DESCRIPTION
## What was changed
[Feature Request] Add support for deploying and using PostgreSQL -> https://github.com/temporalio/helm-charts/issues/637

## Why?
Deploy temporal using postgresql statefullset helm chart

## How was this tested:

```yaml
➜  helm template .  --name-template temporal -n temporal-tests -f  temporal/charts/temporal/tests/postgresql.yaml   > final.yaml --debug

➜ kubectl create ns temporal-tests

➜ kubectl apply -f temporal/charts/temporal/final.yaml -n temporal-tests


➜  kubectl get pods -n temporal-tests
NAME                                   READY   STATUS      RESTARTS        AGE
temporal-admintools-5bc4cc567c-j2dnb   1/1     Running     0               8m17s
temporal-frontend-95ff6bc98-9xdtb      1/1     Running     3 (7m53s ago)   8m16s
temporal-history-6f79b4677d-kxkl7      1/1     Running     3 (7m52s ago)   8m16s
temporal-matching-59d4b74dcf-5dw54     1/1     Running     3 (7m51s ago)   8m15s
temporal-postgresql-0                  1/1     Running     0               8m9s
temporal-schema-1-dw8sp                0/1     Completed   0               8m14s
temporal-web-67d4d56788-b487x          1/1     Running     0               8m14s
temporal-worker-55fdb9f8db-47t7f       1/1     Running     4 (7m31s ago)   8m15s
```
