### PR TITLE
[Feature Request] Add support Mysql chart dependency

### DIFF
--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -28,6 +28,10 @@ dependencies:
     repository: https://grafana.github.io/helm-charts
     version: 8.0.2
     condition: grafana.enabled
+  - name: mysql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 12.3.3
+    condition: mysql.enabled
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/temporal/ci/mysql.yaml
+++ b/charts/temporal/ci/mysql.yaml
@@ -1,0 +1,42 @@
+cassandra:
+  enabled: false
+prometheus:
+  enabled: false
+grafana:
+  enabled: false
+elasticsearch:
+  enabled: false
+
+mysql:
+  enabled: true
+  auth:
+    rootPassword: jeremias
+  initdbScripts:
+    init.sql: |
+      CREATE DATABASE temporal;
+      CREATE DATABASE temporal_visibility;
+  commonAnnotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
+
+server:
+  config:
+    persistence:
+      default:
+        driver: "sql"
+        sql:
+          driver: "mysql8"
+          host: "temporal-mysql.temporal-tests.svc.cluster.local"
+          port: 3306
+          database: "temporal"
+          user: "root"
+          password: "jeremias"
+      visibility:
+        driver: "sql"
+        sql:
+          driver: "mysql8"
+          host: "temporal-mysql.temporal-tests.svc.cluster.local"
+          port: 3306
+          database: "temporal_visibility"
+          user: "root"
+          password: "jeremias"


### PR DESCRIPTION
## What was changed
[Feature Request] Add support PostgreSQL chart dependency -> https://github.com/temporalio/helm-charts/issues/637
This is an initial commit. Probably more work needs to be done on _helpers.tpl and server-job.yaml

Cc @tomwheeler @robholland 

## Why?
Deploy temporal using postgresql statefullset helm chart

## How was this tested:

```yaml
➜  helm template .  --name-template temporal -n temporal-tests -f  /temporal/charts/temporal/ci/mysql.yaml   > final.yaml --debug

➜  kubectl create ns temporal-tests

➜  kubectl apply -f /temporal/charts/temporal/final.yaml -n temporal-tests


➜   kubectl get pods -n temporal-tests
➜  stuff kubectl get pods -n temporal-tests
NAME                                  READY   STATUS      RESTARTS      AGE
temporal-admintools-b46669795-rtljr   1/1     Running     0             2m14s
temporal-frontend-6c84c54ccc-56hpq    1/1     Running     4 (78s ago)   2m14s
temporal-history-7f4dbfbbdc-6rm2k     1/1     Running     4 (76s ago)   2m13s
temporal-matching-6cbfcc7dfd-lp2cp    1/1     Running     4 (75s ago)   2m12s
temporal-mysql-0                      1/1     Running     0             2m6s
temporal-schema-1-9jq72               0/1     Completed   0             2m11s
temporal-web-99bb6db94-5zffh          1/1     Running     0             2m11s
temporal-worker-54d8489b6f-8qxpc      1/1     Running     4 (92s ago)   2m12s
```

![image](https://github.com/user-attachments/assets/74bea8b0-b8d6-4375-b411-e43efcbf9981)

![image](https://github.com/user-attachments/assets/8762837a-c6e4-4899-9161-25cbd3ff10a5)

