### PR TITLE
prevent creation of headless services when server.enabled: false

### DIFF
--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -35,6 +35,7 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- if $.Values.server.enabled }}
 {{- range $rawService := (list "frontend" "internalFrontend" "matching" "history" "worker") }}
 {{- $service := include "serviceName" (list $rawService) }}
 {{- $serviceValues := index $.Values.server $rawService }}
@@ -92,5 +93,6 @@ spec:
     app.kubernetes.io/component: {{ $service }}
 
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/temporal/tests/server_service_test.yaml
+++ b/charts/temporal/tests/server_service_test.yaml
@@ -32,3 +32,13 @@ tests:
           path: metadata.annotations["prometheus.io/scrape"]
       - notExists:
           path: metadata.annotations["prometheus.io/port"]
+  - it: doesn't create any services when the server is disabled
+    template: templates/server-service.yaml
+    set:
+      server:
+        enabled: false
+    asserts:
+      - not: true
+        containsDocument:
+          kind: Service
+          apiVersion: v1


### PR DESCRIPTION
## What was changed
Addresses: https://github.com/temporalio/helm-charts/issues/688

## Why?
I noticed in the helm chart template for the server services, setting server.enabled: false [disables one type of service](https://github.com/abarganier/helm-charts-temporal/blob/7832ae79fcb5f781b70eaedf01546b629272c408/charts/temporal/templates/server-service.yaml#L1) from being created, but the [headless services still get created](https://github.com/abarganier/helm-charts-temporal/blob/7832ae79fcb5f781b70eaedf01546b629272c408/charts/temporal/templates/server-service.yaml#L38-L41).

This PR prevents the headless service manifests from being generated if `server.enabled: false` is set in the Helm values.

## Checklist
1. Closes https://github.com/temporalio/helm-charts/issues/688

2. How was this tested:
- [x] Added a unit test to verify non service manifests are generated when `server.enabled: false`

3. Any docs updates needed? No.
