### PR TITLE
[Feature Request] add keda worker autoscaler based on targetQueueSize

### DIFF
--- a/charts/temporal/ci/keda.yaml
+++ b/charts/temporal/ci/keda.yaml
@@ -1,0 +1,88 @@
+elasticsearch:
+  enabled: false
+cassandra:
+  enabled: false
+prometheus:
+  enabled: false
+grafana:
+  enabled: false
+worker:
+  keda:
+    enabled: true
+    pollingInterval: 30
+    # -- Period (in seconds) to wait after the last trigger reported active before scaling the resource back to 0
+    cooldownPeriod: 300
+    # -- The delay (in seconds) before the `cooldownPeriod` starts after the initial creation of the `ScaledObject`.
+    initialCooldownPeriod: 0
+    # -- Minimum number of replicas KEDA will scale the resource down to.
+    # By default, it’s scale to zero, but you can use it with some other value as well.
+    minReplicaCount: 0
+    # -- This setting is passed to the HPA definition that KEDA will create for a given resource and
+    # holds the maximum number of replicas of the target resource.
+    maxReplicaCount: 5
+    fallback: {}
+    # server.keda.fallback -- Defines a number of replicas to fall back to if a scaler is in an error state.
+    # @raw
+    # Example:
+    # ```yaml
+    # fallback:             # Optional. Section to specify fallback options
+    #   failureThreshold: 3 # Mandatory if fallback section is included
+    #   replicas: 6         # Mandatory if fallback section is included
+    # ```
+    advanced: {}
+    # server.keda.advanced -- Specifies HPA related options
+    # @raw
+    # Example:
+    # ```yaml
+    # advanced:
+    #   horizontalPodAutoscalerConfig:
+    #     behavior:
+    #       scaleDown:
+    #         stabilizationWindowSeconds: 300
+    #         policies:
+    #           - type: Percent
+    #             value: 100
+    #             periodSeconds: 15
+    # ```
+    triggers:
+    # server.keda.triggers -- List of triggers to activate scaling of the target resource
+    # @raw
+    # Example:
+    # ```yaml
+    # triggers:
+      - type: temporal
+        metadata:
+          namespace: default
+          taskQueue: "workflow_with_single_noop_activity:test"
+          targetQueueSize: "2"
+          activationTargetQueueSize: "0"
+          endpoint: temporal-frontend.temporal.svc.cluster.local:7233
+          queueTypes: workflow # optional
+          buildId: 1.0.0 # optional
+          selectAllActive: false # optional
+          selectUnversioned: false optional
+          minConnectTimeout: 5 # optional
+          unsafeSsl: false # optional
+      - type: temporal
+        metadata:
+          namespace: default
+          taskQueue: "workflow:test"
+          targetQueueSize: "2"
+          activationTargetQueueSize: "0"
+          endpoint: temporal-frontend.temporal.svc.cluster.local:7233
+          queueTypes: workflow # optional
+          buildId: 1.0.0 # optional
+          selectAllActive: false # optional
+          selectUnversioned: false optional
+          minConnectTimeout: 5 # optional
+          unsafeSsl: false # optional
+    # ```
+    annotations: {}
+    # server.keda.annotations -- Annotations to apply to the ScaledObject CRD.
+    # @raw
+    # Example:
+    # ```yaml
+    # annotations:
+    #   autoscaling.keda.sh/paused-replicas: "0"
+    #   autoscaling.keda.sh/paused: "true"
+    # ```

--- a/charts/temporal/ci/keda.yaml
+++ b/charts/temporal/ci/keda.yaml
@@ -10,46 +10,11 @@ worker:
   keda:
     enabled: true
     pollingInterval: 30
-    # -- Period (in seconds) to wait after the last trigger reported active before scaling the resource back to 0
     cooldownPeriod: 300
-    # -- The delay (in seconds) before the `cooldownPeriod` starts after the initial creation of the `ScaledObject`.
     initialCooldownPeriod: 0
-    # -- Minimum number of replicas KEDA will scale the resource down to.
-    # By default, it’s scale to zero, but you can use it with some other value as well.
     minReplicaCount: 0
-    # -- This setting is passed to the HPA definition that KEDA will create for a given resource and
-    # holds the maximum number of replicas of the target resource.
     maxReplicaCount: 5
-    fallback: {}
-    # server.keda.fallback -- Defines a number of replicas to fall back to if a scaler is in an error state.
-    # @raw
-    # Example:
-    # ```yaml
-    # fallback:             # Optional. Section to specify fallback options
-    #   failureThreshold: 3 # Mandatory if fallback section is included
-    #   replicas: 6         # Mandatory if fallback section is included
-    # ```
-    advanced: {}
-    # server.keda.advanced -- Specifies HPA related options
-    # @raw
-    # Example:
-    # ```yaml
-    # advanced:
-    #   horizontalPodAutoscalerConfig:
-    #     behavior:
-    #       scaleDown:
-    #         stabilizationWindowSeconds: 300
-    #         policies:
-    #           - type: Percent
-    #             value: 100
-    #             periodSeconds: 15
-    # ```
     triggers:
-    # server.keda.triggers -- List of triggers to activate scaling of the target resource
-    # @raw
-    # Example:
-    # ```yaml
-    # triggers:
       - type: temporal
         metadata:
           namespace: default
@@ -57,12 +22,7 @@ worker:
           targetQueueSize: "2"
           activationTargetQueueSize: "0"
           endpoint: temporal-frontend.temporal.svc.cluster.local:7233
-          queueTypes: workflow # optional
-          buildId: 1.0.0 # optional
-          selectAllActive: false # optional
-          selectUnversioned: false optional
-          minConnectTimeout: 5 # optional
-          unsafeSsl: false # optional
+          queueTypes: workflow
       - type: temporal
         metadata:
           namespace: default
@@ -70,19 +30,3 @@ worker:
           targetQueueSize: "2"
           activationTargetQueueSize: "0"
           endpoint: temporal-frontend.temporal.svc.cluster.local:7233
-          queueTypes: workflow # optional
-          buildId: 1.0.0 # optional
-          selectAllActive: false # optional
-          selectUnversioned: false optional
-          minConnectTimeout: 5 # optional
-          unsafeSsl: false # optional
-    # ```
-    annotations: {}
-    # server.keda.annotations -- Annotations to apply to the ScaledObject CRD.
-    # @raw
-    # Example:
-    # ```yaml
-    # annotations:
-    #   autoscaling.keda.sh/paused-replicas: "0"
-    #   autoscaling.keda.sh/paused: "true"
-    # ```

--- a/charts/temporal/templates/keda-scaledobject.yaml
+++ b/charts/temporal/templates/keda-scaledobject.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.worker.keda.enabled }}
+{{- range $rawService := (list "worker") }}
+{{- $service := include "serviceName" (list $rawService) }}
+{{- $serviceValues := index $.Values $rawService }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "temporal.componentname" (list $ $service) }}
+  annotations:
+    {{- include "temporal.resourceAnnotations" (list $ $service "keda") | nindent 4 }}
+  labels:
+    {{- include "temporal.resourceLabels" (list $ $service "keda") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "temporal.componentname" (list $ $service) }}
+  pollingInterval: {{ $serviceValues.keda.pollingInterval }}
+  cooldownPeriod: {{ $serviceValues.keda.cooldownPeriod }}
+  initialCooldownPeriod: {{ $serviceValues.keda.initialCooldownPeriod }}
+  minReplicaCount: {{ $serviceValues.keda.minReplicaCount }}
+  maxReplicaCount: {{ $serviceValues.keda.maxReplicaCount }}
+  {{- with $serviceValues.keda.fallback }}
+  fallback:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $serviceValues.keda.advanced }}
+  advanced:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $serviceValues.keda.triggers }}
+  triggers:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- else }}
+    {{- fail "At least one element in `$serviceValues.keda.triggers` is required!" }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -348,6 +348,55 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    keda:
+      enabled: true
+      pollingInterval: 30
+      cooldownPeriod: 300
+      initialCooldownPeriod: 0
+      minReplicaCount: 0
+      maxReplicaCount: 5
+      fallback: {}
+      # failureThreshold: 3
+      # replicas: 6
+      advanced: {}
+      # horizontalPodAutoscalerConfig:
+      #   behavior:
+      #     scaleDown:
+      #       stabilizationWindowSeconds: 300
+      #       policies:
+      #         - type: Percent
+      #           value: 100
+      #           periodSeconds: 15
+      triggers: []
+        # - type: temporal
+        #   metadata:
+        #     namespace: default
+        #     taskQueue: "workflow_with_single_noop_activity:test"
+        #     targetQueueSize: "2"
+        #     activationTargetQueueSize: "0"
+        #     endpoint: temporal-frontend.temporal.svc.cluster.local:7233
+        #     queueTypes: workflow # optional
+        #     buildId: 1.0.0 # optional
+        #     selectAllActive: false # optional
+        #     selectUnversioned: false optional
+        #     minConnectTimeout: 5 # optional
+        #     unsafeSsl: false # optional
+        # - type: temporal
+        #   metadata:
+        #     namespace: default
+        #     taskQueue: "workflow:test"
+        #     targetQueueSize: "2"
+        #     activationTargetQueueSize: "0"
+        #     endpoint: temporal-frontend.temporal.svc.cluster.local:7233
+        #     queueTypes: workflow # optional
+        #     buildId: 1.0.0 # optional
+        #     selectAllActive: false # optional
+        #     selectUnversioned: false optional
+        #     minConnectTimeout: 5 # optional
+        #     unsafeSsl: false # optional
+      annotations: {}
+      #   autoscaling.keda.sh/paused-replicas: "0"
+      #   autoscaling.keda.sh/paused: "true"
 admintools:
   enabled: true
   image:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -349,7 +349,7 @@ server:
     topologySpreadConstraints: []
     podDisruptionBudget: {}
     keda:
-      enabled: true
+      enabled: false
       pollingInterval: 30
       cooldownPeriod: 300
       initialCooldownPeriod: 0


### PR DESCRIPTION
[Feature Request] add keda worker autoscaler based on targetQueueSize

@robholland @tomwheeler , Can you please review? Thanks

## What was changed
Add keda-scaledobject.yaml to templates

## Why?
keda v.2.17.0 contains a Temporal Worker scaler.
This solution empowers developers to dynamically scale the number of Temporal workers based on the size of the Task Queue backlog.

Info:
https://temporal.io/blog/announcing-keda-based-auto-scaling-for-temporal-workers 
https://keda.sh/docs/2.17/scalers/temporal/ 
https://github.com/kedacore/keda/releases/tag/v2.17.0 

## How was this tested:
➜  helm template .  --name-template temporal -n temporal-tests -f ci/keda.yaml   > final.yaml --debug