### PR TITLE
Decouple server job manifests from Values.server.enabled

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.server.enabled }}{{- if or $.Values.schema.createDatabase.enabled $.Values.schema.setup.enabled $.Values.schema.update.enabled }}
+{{- if or $.Values.schema.createDatabase.enabled $.Values.schema.setup.enabled $.Values.schema.update.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -220,4 +220,4 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end -}}{{- end -}}
+{{- end -}}

--- a/charts/temporal/templates/server-secret.yaml
+++ b/charts/temporal/templates/server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.server.enabled }}
+{{- if or $.Values.server.enabled $.Values.schema.createDatabase.enabled $.Values.schema.setup.enabled $.Values.schema.update.enabled }}
   {{- range $store := (list "default" "visibility") }}
   {{- $storeConfig := index $.Values.server.config.persistence $store }}
   {{- $driver := include "temporal.persistence.driver" (list $ $store) -}}

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -2,6 +2,14 @@ suite: test server job
 templates:
   - server-job.yaml
 tests:
+  - it: is able to create the server job even if Values.server.enabled is false
+    set:
+      server:
+        enabled: false
+    asserts:
+      - containsDocument:
+          kind: Job
+          apiVersion: batch/v1
   - it: includes additional init containers
     set:
       admintools:

--- a/charts/temporal/tests/server_secret_test.yaml
+++ b/charts/temporal/tests/server_secret_test.yaml
@@ -1,0 +1,12 @@
+suite: test server secret
+templates:
+  - server-secret.yaml
+tests:
+  - it: creates the secret when the server job is enabled, even when server.enabled is false
+    set:
+      server:
+        enabled: false
+    asserts:
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1


### PR DESCRIPTION
## What was changed
Addresses: https://github.com/temporalio/helm-charts/issues/695

This PR allows the server job manifests to be generated even when `Values.server.enabled: false`. Previously, it was not possible to isolate the server job manifests from the rest of the server Deployments (e.g. History, Matching, Frontend, etc).

Additionally, it updates the logic in the server-secret template to ensure that the secrets manifests are still generated when `Values.server.enabled: false`, but one of the schema jobs is enabled. This ensures that the server job still has access to the DB credential secrets required to operate. 

## Why?
Running the schema migration jobs is something that we'd like to trigger independently from normal server deployments. Schema migrations are only needed in a couple cases:
1. When setting up a new cluster.
2. When performing a version upgrade.

Therefore, we want fine control over when these jobs get deployed, separate from the rest of the server Deployments.

## Checklist
1. Closes https://github.com/temporalio/helm-charts/issues/695

2. How was this tested:
[x] Created additional unit tests 