### PR TITLE
Change image pull secrets to array instead of map

### DIFF
--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ""
 # Chart debug mode
 # (eg. disable helm hook delete policy)
 debug: false
-imagePullSecrets: {}
+imagePullSecrets: []
 # Custom Service account management
 serviceAccount:
   # Whether to create service account or not


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->
#700 for reference
<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Updated the imagepullsecret to an array as thats what a deployment expects

## Why?
<!-- Tell your future self why have you made these changes -->
To ensure this works
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#700 
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Tested locally by using kustomize to apply a locally modified values chart that used array instead of dict
3. Any docs updates needed?

<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No
