### PR TITLE
Fix: removes check-cassandra-service

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -44,13 +44,6 @@ spec:
           {{- toYaml . | nindent 8}}
         {{- end }}
         {{- if $.Values.cassandra.enabled }}
-        - name: check-cassandra-service
-          image: busybox
-          command: ['sh', '-c', 'until nc -z {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }}; do echo waiting for cassandra service; sleep 1; done;']
-          {{- with $serviceValues.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
         - name: check-cassandra
           image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
           imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -28,13 +28,6 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if $.Values.cassandra.enabled }}
-        - name: check-cassandra-service
-          image: busybox
-          command: ['sh', '-c', 'until nc -z {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }}; do echo waiting for cassandra service; sleep 1; done;']
-          {{- with $.Values.schema.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
         - name: check-cassandra
           image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
           imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}


### PR DESCRIPTION
## What was changed
Removes `check-cassandra-service` per https://github.com/temporalio/helm-charts/pull/684#issuecomment-2792971071

## Why?
> Let's just scrap the check-cassandra-service container? I can't see the value as the check-cassandra container will (correctly) fail until Cassandra is up anyway. -- @robholland https://github.com/temporalio/helm-charts/pull/684#issuecomment-2792971071


## Checklist
<!--- add/delete as needed --->

1. Closes:
    * #659 
    * #684

2. How was this tested:
helm lint, helm template, and test deployment on kubernetes v1.28

3. Any docs updates needed?
N/A
