### PR TITLE
Add readiness probes

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -135,6 +135,10 @@ spec:
              initialDelaySeconds: 150
              tcpSocket:
                port: rpc
+          readinessProbe:
+              initialDelaySeconds: 10
+              tcpSocket:
+                port: rpc
           {{- end }}
           volumeMounts:
             - name: config

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -49,6 +49,10 @@ spec:
             initialDelaySeconds: 10
             tcpSocket:
               port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            tcpSocket:
+              port: http
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## What was changed
Adding readiness probes to web and server deployment.

## Why?
Currently we send requests to these pods even when these are not fully started. These basic readiness should help wait before sending requests that temporal is up.

## Checklist

1. Closes #710
