### PR TITLE
Correct enableGlobalDomain to enableGlobalNamespace

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -156,7 +156,7 @@ data:
     {{- with $server.config.clusterMetadata }}
       {{- toYaml . | nindent 8 }}
     {{- else }}
-      enableGlobalDomain: false
+      enableGlobalNamespace: false
       failoverVersionIncrement: 10
       masterClusterName: "active"
       currentClusterName: "active"


### PR DESCRIPTION
## What was changed

Change `enableGlobalDomain` to `enableGlobalNamespace`

## Why?

This rename happened long time ago in Temporal: https://github.com/temporalio/temporal/pull/260

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
