### PR TITLE
Fixed group name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @temporalio/devex
+* @temporalio/selfhosted


### PR DESCRIPTION
The `CODEOWNERS` file is invalid because it contains a group name (`devex`) that is non-existent. It was renamed to `selfhosted` some time ago and this PR updates it to match that new name.