### PR TITLE
Templates now have metadata.namespace defined

### DIFF
--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "temporal.componentname" (list $ "admintools") }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
     {{- include "temporal.resourceAnnotations" (list $ "admintools" "deployment") | nindent 4 }}
   labels:

--- a/charts/temporal/templates/frontend-ingress.yaml
+++ b/charts/temporal/templates/frontend-ingress.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "temporal.componentname" (list $ "frontend") }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "frontend" "") | nindent 4 }}
 {{- with .Values.server.frontend.ingress.annotations }}

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ include "temporal.fullname" $ }}-config"
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}
 data:

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -7,6 +7,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "temporal.componentname" (list $ $service) }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
     {{- include "temporal.resourceAnnotations" (list $ $service "deployment") | nindent 4 }}
   labels:

--- a/charts/temporal/templates/server-dynamicconfigmap.yaml
+++ b/charts/temporal/templates/server-dynamicconfigmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ include "temporal.fullname" $ }}-dynamic-config"
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}
 data:

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
 spec:

--- a/charts/temporal/templates/server-pdb.yaml
+++ b/charts/temporal/templates/server-pdb.yaml
@@ -8,6 +8,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "temporal.componentname" (list $ $service) }}-pdb
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
 spec:

--- a/charts/temporal/templates/server-secret.yaml
+++ b/charts/temporal/templates/server-secret.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "secret") | nindent 4 }}
   {{- with $.Values.server.secretAnnotations }}

--- a/charts/temporal/templates/server-service-monitor.yaml
+++ b/charts/temporal/templates/server-service-monitor.yaml
@@ -8,6 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "temporal.componentname" (list $ $service) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
     {{- with (default $.Values.server.metrics.serviceMonitor.additionalLabels $serviceValues.metrics.serviceMonitor.additionalLabels) }}

--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "temporal.componentname" (list $ $service) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
   {{- if $serviceValues.service.annotations }}

--- a/charts/temporal/templates/serviceaccount.yaml
+++ b/charts/temporal/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "temporal.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}
   annotations:

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "temporal.componentname" (list $ "web") }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
     {{- include "temporal.resourceAnnotations" (list $ "web" "deployment") | nindent 4 }}
   labels:

--- a/charts/temporal/templates/web-ingress.yaml
+++ b/charts/temporal/templates/web-ingress.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "temporal.componentname" (list $ "web") }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
 {{- with .Values.web.ingress.annotations }}

--- a/charts/temporal/templates/web-pdb.yaml
+++ b/charts/temporal/templates/web-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "temporal.componentname" (list $ "web") }}-pdb
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
 spec:

--- a/charts/temporal/templates/web-service.yaml
+++ b/charts/temporal/templates/web-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "temporal.componentname" (list $ "web") }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
   {{- if .Values.web.service.annotations }}


### PR DESCRIPTION
## What was changed
Templates now have `metadata.namespace` defined to `$.Release.Namespace`

## Why?
Leaving namespace undefined works while using `helm install -n my-namespace`. When using `helm template -n my-namespace` however the namespace will not appear in the yamls.

1. Closes
I have not created an issue for this.

2. How was this tested:
By templating the chart.

3. Any docs updates needed?
With no new values - probably not.
