### PR TITLE
Update group name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @temporalio/selfhosted
+* @temporalio/selfhosting


### PR DESCRIPTION
## What was changed
I changed the group name in `CODEOWNERS` from `selfhosted` to `selfhosting`. 

## Why?
I used the wrong group name in an earlier PR (the previous name was also wrong, but my recollection of the new name was incorrect; this fixes it.