### PR TITLE
fix: web ui uses internalFrontend when available

### DIFF
--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -36,7 +36,11 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: TEMPORAL_ADDRESS
+              {{- if and (hasKey .Values.server "internalFrontend") .Values.server.internalFrontend.enabled .Values.web.useInternalFrontend }}
+              value: "{{ include "temporal.fullname" $ }}-internal-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.internalFrontend.service.port }}"
+              {{- else }}
               value: "{{ include "temporal.fullname" $ }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
+              {{- end }}
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -436,6 +436,7 @@ web:
   securityContext: {}
   topologySpreadConstraints: []
   podDisruptionBudget: {}
+  useInternalFrontend: false
 schema:
   createDatabase:
     enabled: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This pull request allow the web ui to use the internal frontend when it's available.

## Why?
With the current configuration the web ui is only linked to the common frontend, when anabling authorization on this frontend, the UI is enable to work properly. Using the internal frontend allows using a different OIDC provider for jwt access then the jwt authorization in the frontend.

## Checklist
<!--- add/delete as needed --->

1. Closes #706 

2. How was this tested:
deployed and working in our system.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
