### PR TITLE
feat: add postInitContainers for admintools server job

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
-      {{- if or (or $.Values.server.additionalInitContainers $.Values.cassandra.enabled) (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
+      {{- if or (or $.Values.server.additionalInitContainers $.Values.cassandra.enabled) (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external) $.Values.server.postInitContainers }}
       initContainers:
         {{- with $.Values.server.additionalInitContainers }}
           {{- toYaml . | nindent 8}}
@@ -72,6 +72,9 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
+        {{- with $.Values.server.postInitContainers }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -182,6 +182,9 @@ spec:
               {{- end }}
           {{- end }}
         {{- end }}
+        {{- with $.Values.schema.postInitContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: done
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -85,3 +85,13 @@ tests:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
       - notExists:
           path: spec.template.metadata.annotations["prometheus.io/port"]
+  - it: includes postInit containers
+    template: templates/server-deployment.yaml
+    set:
+      server:
+        postInitContainers:
+          - name: my-post-init-container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[-1].name
+          value: my-post-init-container

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -19,6 +19,15 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: my-init-container
+  - it: includes postInit containers
+    set:
+      schema:
+        postInitContainers:
+          - name: my-post-init-container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[-1].name
+          value: my-post-init-container
   - it: includes additional volumes
     set:
       admintools:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -89,6 +89,7 @@ server:
   additionalEnv: []
   # for sidecar containers, add containers here with restartPolicy: Always
   additionalInitContainers: []
+  postInitContainers: []
   securityContext:
     fsGroup: 1000
     runAsUser: 1000
@@ -450,6 +451,7 @@ schema:
   resources: {}
   containerSecurityContext: {}
   securityContext: {}
+  postInitContainers: []
 elasticsearch:
   enabled: true
   replicas: 3


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Added a postInitContainers section to the end of the admintools server-job.yml

## Why?
<!-- Tell your future self why have you made these changes -->
To complete a feature that was proposed in https://github.com/temporalio/helm-charts/pull/624

PR seems abandoned and I needed this feature so I implemented it as described by @robholland 

## Checklist
<!--- add/delete as needed --->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Via `go test` from the `charts/temporal/tests/` directory
Via `helm unittest .` from the `charts/temporal/` directory

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No