### PR TITLE
feat: Add minReadySeconds support

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "deployment") | nindent 4 }}
 spec:
+  minReadySeconds: {{ default $.Values.server.minReadySeconds $serviceValues.minReadySeconds }}
   replicas: {{ default $.Values.server.replicaCount $serviceValues.replicaCount }}
   selector:
     matchLabels:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -23,6 +23,7 @@ server:
     tag: 1.28.0
     pullPolicy: IfNotPresent
   # Global default settings (can be overridden per service)
+  minReadySeconds: 0
   replicaCount: 1
   metrics:
     # Annotate pods directly with Prometheus annotations.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->
<!--- For ALL Contributors 👇 -->
## What was changed
This PR adds supports for `minReadySeconds` on server components
## Why?
When we perform any update to Temporal, it rotates Temporal pods and shard-rebalancing kicks in.
The current Chart makes rotating pods too quick and the system became unstable. We get many 5xx and latency spikes during that time.
By adding this parameter and slow down pods rotation a bit, we could slow down shard-rebalancing and help stablize the system.
## Checklist
<!--- add/delete as needed --->
1. Close
N/A

2. How was this tested: We've been running this in production for more than 1 year with our fork.
<!--- Please describe how you tested your changes/how we can test them -->


4. Any docs updates needed?
N/A
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
