### PR TITLE
fix: add Helm hook annotations support for schema Job

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -5,10 +5,14 @@ metadata:
   name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
-  {{- with $.Values.schema.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    # When using Argo CD, enabling Helm hook annotations prevents the schema Job from being 
+    # considered part of the steady state and avoids perpetual OutOfSync after the job completes.
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
+    {{- with $.Values.schema.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   backoffLimit: {{ $.Values.schema.setup.backoffLimit }}
   ttlSecondsAfterFinished: 86400

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -445,12 +445,7 @@ schema:
   update:
     enabled: true
     backoffLimit: 100
-  # Annotations applied to the schema Job. When using Argo CD, enabling Helm hook annotations
-  # prevents the schema Job from being considered part of the steady state and avoids perpetual
-  # OutOfSync after the job completes.
-  annotations:
-    helm.sh/hook: "post-install,post-upgrade"
-    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
+  annotations: {}
   podAnnotations: {}
   podLabels: {}
   resources: {}


### PR DESCRIPTION
## Summary
Make the Temporal schema Job friendlier to GitOps/Argo CD by supporting Helm hook annotations via values and rendering them on the Job metadata.

## Problem
The chart currently creates the schema Job as a regular resource (with `ttlSecondsAfterFinished`). In Argo CD, after the Job completes and is cleaned up, the Application remains OutOfSync (Health: Missing) because the Job still exists in desired state but is absent from the live cluster.

Argo CD maps Helm hook annotations to its own hook phases. When a resource is annotated as a Helm hook, Argo CD doesn’t consider it part of the steady state, which avoids false drift for ephemeral Jobs.

## What changed
- Add a new values map: `schema.annotations`
  - Defaults:
    - `helm.sh/hook: "post-install,post-upgrade"`
    - `helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"`
- Render these annotations onto the schema Job (`templates/server-job.yaml`).

This keeps the migration Job managed by the chart and executed on install/upgrade, while preventing GitOps reconciliation noise.

## Rationale
- Hooks are the idiomatic way to model ephemeral install/upgrade tasks in Helm.
- Argo CD already maps Helm hooks to Argo CD hooks, which avoids steady-state drift.
- The Job continues to evolve with the chart across versions (no need for consumers to maintain a separate Job overlay).

## Compatibility
- Default values enable hook annotations out of the box; this is compatible with plain Helm usage and improves the UX for Argo CD users. If maintainers prefer an opt-in approach, defaults can be made empty and documented—consumers would then enable the map under `schema.annotations`.
- `ttlSecondsAfterFinished` remains; `hook-delete-policy` handles cleanup for successful runs. Keeping TTL is harmless and maintains existing behavior for environments not using Argo CD.

## Testing
- Rendered locally with `helm template` and verified the schema Job includes the expected annotations when defaults are used.

## Documentation
- If accepted, consider mentioning `schema.annotations` in README/values docs with a short note for GitOps users.

## References
- Argo CD mapping of Helm hooks: https://argo-cd.readthedocs.io/en/latest/user-guide/helm/#helm-hooks
