### PR TITLE
Adding web.bypassAuth field

### DIFF
--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -36,7 +36,11 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: TEMPORAL_ADDRESS
-              value: "{{ include "temporal.fullname" $ }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
+              {{- if .Values.web.bypassAuth }}
+              value: {{ include "temporal.fullname" $ }}-internal-frontend:{{ .Values.server.internalFrontend.service.port }}
+              {{- else }}
+              value: {{ include "temporal.fullname" $ }}-frontend:{{ .Values.server.frontend.service.port }}
+              {{- end }}
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -436,6 +436,8 @@ web:
   securityContext: {}
   topologySpreadConstraints: []
   podDisruptionBudget: {}
+  # Set to true to have the web UI connect to the internal-frontend service.
+  bypassAuth: false
 schema:
   createDatabase:
     enabled: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adding web.bypass auth bool toggle

## Why?
Enables switching web deployments `TEMPORAL_ADDRESS` from frontend to internal-frontend. Useful for teams who are setting up auth only for CLI and SDK connections but not web.

## Checklist
<!--- add/delete as needed --->

1. Closes: N/A

2. How was this tested:

```bash
cd charts/temporal
helm template . -f test-values.yml > manifest.yml
```

#### test-values.yml test #1
```yaml
web:
  enabled: true
```

Results
```yaml
          env:
            - name: TEMPORAL_ADDRESS
              value: release-name-temporal-frontend:7233
```

#### test-values.yml test #2
```yaml
web:
  bypassAuth: true
  enabled: true
```

Results
```yaml
          env:
            - name: TEMPORAL_ADDRESS
              value: release-name-temporal-internal-frontend:7236
```


4. Any docs updates needed?
No README update needed. Comment in values.yml for users.
