### PR TITLE
admintools tag 1.29.0 -> 1.29

### DIFF
--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -352,7 +352,7 @@ admintools:
   enabled: true
   image:
     repository: temporalio/admin-tools
-    tag: 1.29.0
+    tag: 1.29
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
## What was changed
Updated admin tools tag from 1.29.0 to 1.29, non-existent tag
https://hub.docker.com/r/temporalio/admin-tools/tags?name=1.29.0

## Why?
Because 0.68.0 helm chart release is now broken and unable to pull the admin tools image.

