### PR TITLE
bumping web version 2.40.1 -> 2.41.0

### DIFF
--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -381,7 +381,7 @@ web:
   replicaCount: 1
   image:
     repository: temporalio/ui
-    tag: 2.40.1
+    tag: 2.41.0
     pullPolicy: IfNotPresent
   service:
     # set type to NodePort if access to web needs access from outside the cluster


### PR DESCRIPTION
## What was changed
Bumping web version to [2.41.0](https://github.com/temporalio/ui/releases/tag/v2.41.0) - latest release

## Why?
New release of the web ui from Temporal

