### PR TITLE
Adding default image check

### DIFF
--- a/.github/workflows/image-check.yml
+++ b/.github/workflows/image-check.yml
@@ -44,7 +44,7 @@ jobs:
           | while IFS= read -r img; do \
               [ -z "$img" ] && continue; \
               echo "Inspecting image: $img"; \
-              docker manifest inspect "$img" >/dev/null || echo "Invalid image: $img"; \
+              docker manifest inspect "$img" >/dev/null || echo "Invalid image: $img"; exit 2; \
           done
       
       - name: Run +mysql image check
@@ -58,5 +58,5 @@ jobs:
           | while IFS= read -r img; do \
               [ -z "$img" ] && continue; \
               echo "Inspecting image: $img"; \
-              docker manifest inspect "$img" >/dev/null || echo "Invalid image: $img"; \
+              docker manifest inspect "$img" >/dev/null || echo "Invalid image: $img"; exit 2; \
           done


### PR DESCRIPTION
## What was changed
Adding an image check test on trigger pull_request, this builds the manifest, pulls the images+tags being used and checks that they are available.

## Why?
0.68.0 had a breaking change that lasted a weekend, this should catch this and prevent it happening again.

