### PR TITLE
Bumping Grafana to version 10.1.2, adding optional log datasource

### DIFF
--- a/charts/temporal/Chart.lock
+++ b/charts/temporal/Chart.lock
@@ -10,6 +10,12 @@ dependencies:
   version: 7.17.3
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 8.0.2
-digest: sha256:f74565632d43941cad32e713f73481b3d8065d9c462473e80d86fd1f7c5049af
-generated: "2024-10-07T14:43:06.775398+01:00"
+  version: 10.1.2
+- name: loki
+  repository: https://grafana.github.io/helm-charts
+  version: 6.43.0
+- name: promtail
+  repository: https://grafana.github.io/helm-charts
+  version: 6.17.0
+digest: sha256:3b7d04d5fcf3f4f14b201b111a66f8faee1bc4d2fab1586e6e83190d905ef5bb
+generated: "2025-10-23T10:03:16.88618-06:00"

--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -26,8 +26,16 @@ dependencies:
     condition: elasticsearch.enabled
   - name: grafana
     repository: https://grafana.github.io/helm-charts
-    version: 8.0.2
+    version: 10.1.2
     condition: grafana.enabled
+  - name: loki
+    repository: https://grafana.github.io/helm-charts
+    version: 6.43.0
+    condition: loki.enabled
+  - name: promtail
+    repository: https://grafana.github.io/helm-charts
+    version: 6.17.0
+    condition: promtail.enabled
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -468,6 +468,122 @@ prometheus:
   enabled: true
   nodeExporter:
     enabled: false
+
+loki:
+  enabled: enable
+  deploymentMode: SingleBinary
+  singleBinary:
+    replicas: 1
+  minio:
+    enabled: true
+  backend:
+    replicas: 0
+  read:
+    replicas: 0
+  write:
+    replicas: 0
+  ingester:
+    replicas: 0
+  querier:
+    replicas: 0
+  queryFrontend:
+    replicas: 0
+  queryScheduler:
+    replicas: 0
+  distributor:
+    replicas: 0
+  compactor:
+    replicas: 0
+  indexGateway:
+    replicas: 0
+  bloomCompactor:
+    replicas: 0
+  bloomGateway:
+    replicas: 0
+  chunksCache:
+    allocatedMemory: 1024
+  persistence:
+    enabled: false
+  loki:
+    auth_enabled: false
+    commonConfig:
+      replication_factor: 1
+    storage:
+      type: filesystem
+      bucketNames:
+        chunks: loki-chunks
+        ruler: loki-ruler
+        admin: loki-admin
+      filesystem:
+        chunks_directory: /var/loki/chunks
+        rules_directory: /var/loki/rules
+    schemaConfig:
+      configs:
+        - from: "2024-01-01"
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+    pattern_ingester:
+      enabled: true
+    limits_config:
+      allow_structured_metadata: true
+      volume_enabled: true
+    ruler:
+      enable_api: true
+
+promtail:
+  enabled: enable
+  config:
+    clients:
+      - url: http://{{ .Release.Name }}-loki-gateway/loki/api/v1/push
+    snippets: 
+      scrapeConfigs: |
+        - job_name: kubernetes-pods
+          pipeline_stages:
+            {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            # Only keep core Temporal pods
+            - action: keep
+              source_labels:
+                - __meta_kubernetes_pod_label_app_kubernetes_io_component
+              regex: frontend|history|matching|worker|web
+
+            # Copy component into labels
+            - source_labels:
+                - __meta_kubernetes_pod_label_app_kubernetes_io_component
+              action: replace
+              target_label: temporal_service_name
+
+            - source_labels:
+                - temporal_service_name
+              action: replace
+              target_label: service_name
+
+            - source_labels:
+                - temporal_service_name
+              action: replace
+              target_label: app
+
+            # Drop everything else (optional safety net)
+            - action: drop
+              source_labels:
+                - service_name
+              regex: ""
+
+            # standard pod log path
+            - action: replace
+              replacement: /var/log/pods/*$1/*.log
+              separator: /
+              source_labels:
+                - __meta_kubernetes_pod_uid
+                - __meta_kubernetes_pod_container_name
+              target_label: __path__
+
 grafana:
   enabled: true
   replicas: 1
@@ -489,6 +605,7 @@ grafana:
           editable: true
           options:
             path: /var/lib/grafana/dashboards/default
+  
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -498,6 +615,12 @@ grafana:
           url: http://{{ .Release.Name }}-prometheus-server
           access: proxy
           isDefault: true
+        - name: Loki
+          type: loki
+          access: proxy
+          url: http://{{ .Release.Name }}-loki:3100
+          jsonData:
+            maxLines: 1000
   dashboards:
     default:
       server-general-github:


### PR DESCRIPTION
## What was changed
Bumping Grafana helm chart to latest version.
Adding optional loki datasource and promtail scraping

## Why?
Further complete the "batteries included" offering and provide users a basic implementation they can use in a live environment / setup.