### PR TITLE
VLN-470: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Lint Charts
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added a workflow-level permissions block limiting the GITHUB_TOKEN to contents read access for linting-only CI run.