### PR TITLE
Allow configuring the setup job's ttlSecondsAfterFinished value

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
 spec:
   backoffLimit: {{ $.Values.schema.setup.backoffLimit }}
-  ttlSecondsAfterFinished: 86400
+  ttlSecondsAfterFinished: {{ $.Values.schema.setup.ttlSecondsAfterFinished }}
   template:
     metadata:
       name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -442,6 +442,7 @@ schema:
   setup:
     enabled: true
     backoffLimit: 100
+    ttlSecondsAfterFinished: 86400
   update:
     enabled: true
     backoffLimit: 100


### PR DESCRIPTION
## What was changed

`schema.setup.ttlSecondsAfterFinished` is now exposed via `values.yaml`.

## Why?

We run a temporal deployed via ArgoCD. After the current default value of ttlSecondsAfterFinished (1 day), the schema job gets removed and ArgoCD then marks the project as out-of sync. We would like to keep the finished schema job indefinitely.

## Checklist

1. How was this tested:

> Tested locally by running the helm chart.

2. Any docs updates needed

> None that I am aware of.
