### PR TITLE
Add Support for new Config Loading

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -85,6 +85,8 @@ spec:
                   fieldPath: status.podIP
             - name: SERVICES
               value: {{ $service }}
+            - name: TEMPORAL_SERVER_CONFIG_FILE_PATH
+              value: /etc/temporal/config/config_template.yaml
             {{- if ne (include "temporal.persistence.driver" (list $ "default")) "custom" }}
             - name: TEMPORAL_STORE_PASSWORD
               valueFrom:


### PR DESCRIPTION
## What was changed

 Added `TEMPORAL_SERVER_CONFIG_FILE_PATH` environment variable to support the new config loading functionality added in this PR: https://github.com/temporalio/temporal/pull/8477
These changes are backward compatible and will be needed in server version v1.30 and above. 
