### PR TITLE
Create a unique setup/update Job name per release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,10 @@ helm uninstall temporaltest
 
 ## Upgrading
 
-To upgrade your cluster, upgrade your database schema (if the release includes schema changes), and then use `helm upgrade` command to perform a rolling upgrade of your installation.
+To upgrade your cluster:
+
+* Upgrade your database schema (if `schema.update.enabled` is `false`)
+* Run `helm upgrade` command to perform a rolling upgrade of your installation
 
 Note:
 * Not supported: running newer binaries with an older schema.
@@ -538,6 +541,8 @@ Note:
 Example:
 
 ### Upgrade Schema
+
+**These steps are only required if `schema.update.enabled` is `false`**. If schema update is enabled the Helm chart will do this for you.
 
 Here are examples of commands you can use to upgrade the "default" schema in your "bring your own" Cassandra database.
 

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -1,16 +1,17 @@
 {{- if or $.Values.schema.createDatabase.enabled $.Values.schema.setup.enabled $.Values.schema.update.enabled }}
+{{- $semVer := semver $.Chart.AppVersion }}
+{{- $jobName := include "temporal.componentname" (list $ (printf "schema-%d-%d-rev-%d" $semVer.Major $semVer.Minor .Release.Revision)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}
+  name: {{ $jobName }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
 spec:
   backoffLimit: {{ $.Values.schema.setup.backoffLimit }}
-  ttlSecondsAfterFinished: 86400
   template:
     metadata:
-      name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}
+      name: {{ $jobName }}
       labels:
         {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 8 }}
         {{- with $.Values.schema.podLabels }}


### PR DESCRIPTION
## Why?

The helm chart currently creates a job to setup and update the schema named `temporal-schema-{{Helm chart version}}` since #564 which is often just `temporal-schema-1`. The lifetime of this chart is 1 day, which has two separate impacts:

* The chart must be manually deleted before an upgrade can occur 
  * #554
  * #735
* ArgoCD shows OutOfSync / Helm diff after Job expires
  * #636 
  * #709
  * #743
* Instructions say a user must run the upgrade, but the chart does it for you if `schema.update` is enabled
  * #737

## What was changed

1. Give the schema update job and pod a name including the major-minor version of Temporal. This will allow multiple minor version upgrades to succeed without having to manually remove the job.

2. Remove the job removal TTL the value of which was debatable, but regardless of value will show sync issues with  Helm diff and ArgoCD sync status. As the use of Helm hooks was explicitly removed in #522 to resolve issues with `--wait`, this provides another way to retain diff/sync. This also means that job update logs are retained and available for life of the helm release.

3. Updated the README to make it clear the manual update steps aren't required if update is enabled.

## Checklist

1. Closes #554 #735 #636 #709 #737

3. How was this tested: it's only a name change, helm upgrade did it all 😁 

5. Any docs updates needed?

Updates to the README are included.