### PR TITLE
Add support for adding custom annotations to "schema" job definition

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
+  {{- with $.Values.schema.jobAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   backoffLimit: {{ $.Values.schema.backoffLimit }}
   ttlSecondsAfterFinished: 86400

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -129,4 +129,36 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[*].resources.limits.memory
           value: 16Gi
-
+  - it: includes custom annotations and labels for pod and job
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-visibility:3306"
+                  databaseName: temporal_visibility
+      schema:
+        jobAnnotations:
+          custom-job-annotation: abc
+        podAnnotations:
+          custom-pod-annotation: def
+        podLabels:
+          custom-pod-label: ghi
+    asserts:
+      - equal:
+          path: metadata.annotations.custom-job-annotation
+          value: abc
+      - equal:
+          path: spec.template.metadata.annotations.custom-pod-annotation
+          value: def
+      - equal:
+          path: spec.template.metadata.labels.custom-pod-label
+          value: ghi

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -463,6 +463,7 @@ web:
   podDisruptionBudget: {}
 schema:
   backoffLimit: 100
+  jobAnnotations: {}
   podAnnotations: {}
   podLabels: {}
   resources: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added support for defining custom job annotations

## Why?
When using temporal helm chart together with ArgoCD job cannot be recreated.  
It is happening because ArgoCD is not using helm to install charts but it just renders them using helm template.
That has repercussion of job name to stay the same all the time (Revision is always 1): 
```
name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}
```

Adding a possiblility to add custom annotations allows us to define this one so that job is able to redeploy:
argocd.argoproj.io/sync-options: Replace=true,Force=true

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
N/A

2. How was this tested:
I extended tests to check that newly added jobAnnotations works. I also covered podAnnotations and podLabels in that test case since it was missing. I did run tests using `helm unittest .` and they passed correctly:
<img width="621" height="323" alt="image" src="https://github.com/user-attachments/assets/7ab67c20-cc7b-4a96-9ed2-fc7f211ddbcb" />


I also did render it locally. I created values.annotations.yaml with this content:
```
schema:
  jobAnnotations:
    custom-job-annotation: abc
  podAnnotations:
    custom-pod-annotation: def
  podLabels:
    custom-pod-label: ghi

```

and using that command:
```
helm template . -f values/values.postgresql.yaml -f values/values.annotations.yaml
```

I confirmed that it renders correctly and annotations and labels are present:
```
# Source: temporal/templates/server-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: release-name-temporal-schema-1
  labels:
    app.kubernetes.io/component: database
    app.kubernetes.io/name: temporal
    helm.sh/chart: temporal-1.0.0-rc.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.29.1"
    app.kubernetes.io/part-of: temporal
  annotations:
    custom-job-annotation: abc
spec:
  backoffLimit: 100
  ttlSecondsAfterFinished: 86400
  template:
    metadata:
      name: release-name-temporal-schema-1
      labels:
        app.kubernetes.io/component: database
        app.kubernetes.io/name: temporal
        helm.sh/chart: temporal-1.0.0-rc.1
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "1.29.1"
        app.kubernetes.io/part-of: temporal
        custom-pod-label: ghi
      annotations:
        custom-pod-annotation: def
```

3. Any docs updates needed?
N/A
