### PR TITLE
Enable metrics annotations for matching service by default

### DIFF
--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -329,7 +329,7 @@ server:
       membershipAppProtocol: tcp
     metrics:
       annotations:
-        enabled: false
+        enabled: true
       serviceMonitor: {}
       # enabled: false
       prometheus: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
https://github.com/temporalio/helm-charts/commit/f9fcbdf6819410e388421a2a8fb1ff363b4d5f83 but missed setting it to true for matching service requiring users to override it.

## Why?
<!-- Tell your future self why have you made these changes -->
To not have to override it separately to add metrics annotations.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> N/A

2. How was this tested: N/A
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
