### PR TITLE
Feat: Add deploymentStrategy

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -15,6 +15,10 @@ metadata:
     {{- include "temporal.resourceLabels" (list $ $service "deployment") | nindent 4 }}
 spec:
   replicas: {{ default $.Values.server.replicaCount $serviceValues.replicaCount }}
+  {{- with (default $.Values.server.deploymentStrategy $serviceValues.deploymentStrategy) }}
+  strategy:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "temporal.name" $ }}

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -162,3 +162,52 @@ tests:
       - matchRegex:
           path: data["config_template.yaml"]
           pattern: 'format: "json"'
+  - it: deploymentStrategy defaults to service wide resources
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        deploymentStrategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxSurge: 25%
+            maxUnavailable: 25%
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 25%
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 25%
+  - it: deploymentStrategy favours service specific resources
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        deploymentStrategy:
+          type: Recreate
+        frontend:
+          deploymentStrategy:
+            type: RollingUpdate
+            rollingUpdate:
+              maxSurge: 1
+              maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -69,6 +69,7 @@ server:
       timerType: histogram
   deploymentLabels: {}
   deploymentAnnotations: {}
+  deploymentStrategy: {}
   podAnnotations: {}
   podLabels: {}
   secretLabels: {}
@@ -252,6 +253,7 @@ server:
       # timerType: histogram
     deploymentLabels: {}
     deploymentAnnotations: {}
+    deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -284,6 +286,7 @@ server:
       # timerType: histogram
     deploymentLabels: {}
     deploymentAnnotations: {}
+    deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -310,6 +313,7 @@ server:
       # timerType: histogram
     deploymentLabels: {}
     deploymentAnnotations: {}
+    deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -337,6 +341,7 @@ server:
       # timerType: histogram
     deploymentLabels: {}
     deploymentAnnotations: {}
+    deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -363,6 +368,7 @@ server:
       # timerType: histogram
     deploymentLabels: {}
     deploymentAnnotations: {}
+    deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
     resources: {}
@@ -385,6 +391,7 @@ admintools:
     annotations: {}
   deploymentLabels: {}
   deploymentAnnotations: {}
+  deploymentStrategy: {}
   podLabels: {}
   podAnnotations: {}
   nodeSelector: {}
@@ -437,6 +444,7 @@ web:
     #      - chart-example.local
   deploymentLabels: {}
   deploymentAnnotations: {}
+  deploymentStrategy: {}
   podAnnotations: {}
   podLabels: {}
   resources: {}


### PR DESCRIPTION
## What was changed
This change adds supports for custom deployment strategy for server deployment.

## Why?
At the moment it's always rolling update with 25% maxSurge and 25% maxUnavailable.
We'd like to slow down rolling update for history deployments.

## Checklist
1. How was this tested:
* Helm template
* Helm test
* The changes had been running in our fork on production for few months.

3. Any docs updates needed?
N/A
