### PR TITLE
feat: Allow setting terminationGracePeriodSeconds

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -176,6 +176,7 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      terminationGracePeriodSeconds: {{ default $.Values.server.terminationGracePeriodSeconds $serviceValues.terminationGracePeriodSeconds }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -160,6 +160,31 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 30
+  - it: terminationGracePeriodSeconds is null by default
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
+      value: Deployment
+      matchMany: true
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: null
+  - it: terminationGracePeriodSeconds favors service specific resources
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        terminationGracePeriodSeconds: 30
+        frontend:
+          terminationGracePeriodSeconds: 60
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
   - it: renders log config with defaults
     template: templates/server-configmap.yaml
     asserts:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -90,6 +90,7 @@ server:
   tolerations: []
   affinity: {}
   minReadySeconds: 0
+  terminationGracePeriodSeconds: null
   additionalVolumes: []
   additionalVolumeMounts: []
   additionalEnv: []


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Allow setting terminationGracePeriodSeconds for server deployment.

Default value is set to null instead of 0. ~It doesn't allow setting terminationGracePeriodSeconds to 0 but that shouldn't be too much limitation.~

## Why?
<!-- Tell your future self why have you made these changes -->
This can be used to give higher drain time when shutting down services during a deployment

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested: Added unit test
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
