### PR TITLE
Include admintools additionalEnvSecretName in server job

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -116,6 +116,11 @@ datacenter', '{{ $store.config.datacenter }}'{{- end }}]
               {{- with $.Values.admintools.additionalEnv }}
                 {{- toYaml . | nindent 12 }}
               {{- end }}
+              {{- with $.Values.admintools.additionalEnvSecretName }}
+          envFrom:
+            - secretRef:
+                name: {{ . }}
+              {{- end }}
               {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:
                 {{- toYaml . | nindent 12 }}

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -46,6 +46,36 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: my-init-container
+  - it: includes additional environment variables
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-visibility:3306"
+                  databaseName: temporal_visibility
+          namespaces:
+            create: true
+      admintools:
+        additionalEnv:
+          - name: MY_ENV_VAR
+            value: my-value
+        additionalEnvSecretName: env-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="MY_ENV_VAR")].value
+          value: my-value
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].envFrom[0].secretRef.name
+          value: env-secret
   - it: includes additional volumes
     set:
       server:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Include `admintools.additionalEnvSecretName` in server-job

## Why?
<!-- Tell your future self why have you made these changes -->
Everywhere else, additionalEnvSecretName is included whenever additionalEnv is added. Add it to server-job for consistency.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested: Added a unit test
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
