### PR TITLE
Allow setting additional environment variables from ConfigMap too

### DIFF
--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -47,10 +47,16 @@ spec:
           {{- with .Values.admintools.additionalEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.admintools.additionalEnvSecretName }}
+          {{- if or .Values.admintools.additionalEnvSecretName .Values.admintools.additionalEnvConfigMapName }}
           envFrom:
+          {{- with .Values.admintools.additionalEnvSecretName }}
             - secretRef:
                 name: {{ . }}
+          {{- end }}
+          {{- with .Values.admintools.additionalEnvConfigMapName }}
+            - configMapRef:
+                name: {{ . }}
+          {{- end }}
           {{- end }}
           livenessProbe:
               exec:

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -75,10 +75,16 @@ spec:
           {{- if or $.Values.server.additionalEnv $serviceValues.additionalEnv }}
           {{- toYaml (default $.Values.server.additionalEnv $serviceValues.additionalEnv) | nindent 12 }}
           {{- end }}
-          {{- if $.Values.server.additionalEnvSecretName }}
+          {{- if or $.Values.server.additionalEnvSecretName $.Values.server.additionalEnvConfigMapName }}
           envFrom:
+          {{- if $.Values.server.additionalEnvSecretName }}
             - secretRef:
                 name: {{ $.Values.server.additionalEnvSecretName }}
+          {{- end }}
+          {{- if $.Values.server.additionalEnvConfigMapName }}
+            - configMapRef:
+                name: {{ $.Values.server.additionalEnvConfigMapName }}
+          {{- end }}
           {{- end }}
           # For Istio service mesh - make sure ports are defined here and in the headless service, see:
           # https://istio.io/latest/docs/ops/configuration/traffic-management/traffic-routing/#headless-services

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -116,10 +116,16 @@ datacenter', '{{ $store.config.datacenter }}'{{- end }}]
               {{- with $.Values.admintools.additionalEnv }}
                 {{- toYaml . | nindent 12 }}
               {{- end }}
-              {{- with $.Values.admintools.additionalEnvSecretName }}
+              {{- if or $.Values.admintools.additionalEnvSecretName $.Values.admintools.additionalEnvConfigMapName }}
           envFrom:
+              {{- with $.Values.admintools.additionalEnvSecretName }}
             - secretRef:
                 name: {{ . }}
+              {{- end }}
+              {{- with $.Values.admintools.additionalEnvConfigMapName }}
+            - configMapRef:
+                name: {{ . }}
+              {{- end }}
               {{- end }}
               {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -40,10 +40,16 @@ spec:
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}
-          {{- if .Values.web.additionalEnvSecretName }}
+          {{- if or .Values.web.additionalEnvSecretName .Values.web.additionalEnvConfigMapName }}
           envFrom:
+          {{- if .Values.web.additionalEnvSecretName }}
             - secretRef:
                 name: {{ .Values.web.additionalEnvSecretName }}
+          {{- end }}
+          {{- if .Values.web.additionalEnvConfigMapName }}
+            - configMapRef:
+                name: {{ .Values.web.additionalEnvConfigMapName }}
+          {{- end }}
           {{- end }}
           livenessProbe:
             initialDelaySeconds: 10

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -260,3 +260,26 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
           value: rpc
+  - it: additional environment variables are set on all services
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$.kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        additionalEnv:
+          - name: HELLO
+            value: world
+        additionalEnvSecretName: secret-env
+        additionalEnvConfigMapName: configmap-env
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="HELLO")].value
+          value: world
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: secret-env
+      - equal: 
+          path: spec.template.spec.containers[0].envFrom[1].configMapRef.name
+          value: configmap-env

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -69,6 +69,7 @@ tests:
           - name: MY_ENV_VAR
             value: my-value
         additionalEnvSecretName: env-secret
+        additionalEnvConfigMapName: env-configmap
     asserts:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="MY_ENV_VAR")].value
@@ -76,6 +77,9 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].envFrom[0].secretRef.name
           value: env-secret
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].envFrom[1].configMapRef.name
+          value: env-configmap
   - it: includes additional volumes
     set:
       server:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -93,6 +93,8 @@ server:
   additionalVolumes: []
   additionalVolumeMounts: []
   additionalEnv: []
+  additionalEnvSecretName: ""
+  additionalEnvConfigMapName: ""
   # for sidecar containers, add containers here with restartPolicy: Always
   additionalInitContainers: []
   securityContext:
@@ -337,7 +339,6 @@ server:
     tolerations: []
     affinity: {}
     additionalEnv: []
-    additionalEnvSecretName: ""
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
@@ -419,6 +420,7 @@ admintools:
   additionalVolumeMounts: []
   additionalEnv: []
   additionalEnvSecretName: ""
+  additionalEnvConfigMapName: ""
   # for sidecar containers, add containers here with restartPolicy: Always
   additionalInitContainers: []
   resources: {}
@@ -490,6 +492,7 @@ web:
   # https://docs.temporal.io/references/web-ui-environment-variables
   additionalEnv: []
   additionalEnvSecretName: ""
+  additionalEnvConfigMapName: ""
   containerSecurityContext: {}
   securityContext: {}
   topologySpreadConstraints: []


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add an option to add environment variable from configmap, similar to existing option for secrets

## Why?
<!-- Tell your future self why have you made these changes -->
It's more ergonomical to add all environment variables at once in a configmap or a secret, instead of adding them in additionalEnv. Using ConfigMap makes it easier to use than a Secret

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
