### PR TITLE
Allow setting other config values in metrics

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -38,25 +38,11 @@ data:
       metrics:
         tags:
           type: {{ `{{ env "TEMPORAL_SERVICES" | quote }}` }}
-          {{- with (merge $server.config.metrics.tags $server.metrics.tags) }}
+          {{- with $server.config.metrics.tags }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
-        {{- with $server.metrics.excludeTags }}
-        excludeTags:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with $server.metrics.prefix }}
-        prefix: "{{- . }}"
-        {{- end }}
-        {{- with (omit $server.config.metrics "tags" "prometheus") }}
+        {{- with (omit $server.config.metrics "tags") }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with $server.config.prometheus }}
-        prometheus:
-          {{- toYaml . | nindent 10 }}
-        {{- else }}
-        prometheus:
-          {{- toYaml $server.config.metrics.prometheus | nindent 10 }}
         {{- end }}
 
       {{- with $server.config.tls }}

--- a/charts/temporal/tests/server_configmap_test.yaml
+++ b/charts/temporal/tests/server_configmap_test.yaml
@@ -135,7 +135,7 @@ tests:
           path: data['config_template.yaml']
           pattern: 'password: \{\{ env "TEMPORAL_VISIBILITY_STORE_PASSWORD" \| quote \}\}'
 
-  - it: handles metrics correctly with backwards compatibility
+  - it: handles metrics config
     set:
       server:
         config:
@@ -153,12 +153,9 @@ tests:
             prefix: "temporal_"
             tags:
               env: production
+            excludeTags:
+              ignored: ["tag1", "tag2"]
             withoutUnitSuffix: false
-        metrics:
-          tags:
-            region: us-west-2
-          excludeTags:
-            ignored: ["tag1", "tag2"]
     template: templates/server-configmap.yaml
     documentSelector:
       path: metadata.name
@@ -175,7 +172,7 @@ tests:
           pattern: "env: production"
       - matchRegex:
           path: data['config_template.yaml']
-          pattern: "region: us-west-2"
+          pattern: "withoutUnitSuffix: false"
       - matchRegex:
           path: data['config_template.yaml']
-          pattern: "withoutUnitSuffix: false"
+          pattern: "prometheus:\\s+listenAddress: 0.0.0.0:9090"

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -33,12 +33,6 @@ server:
     # prometheus.io/scrape
     annotations:
       enabled: true
-    # Additional tags to be added to Prometheus metrics. Deprecated, set server.config.metrics.tags.
-    tags: {}
-    # Tags to be excluded in Prometheus metrics. Deprecated, set server.config.metrics.excludeTags.
-    excludeTags: {}
-    # Deprecated, set server.config.metrics.prefix.
-    prefix:
     # Enable Prometheus ServiceMonitor
     # Use this if you installed the Prometheus Operator (https://github.com/coreos/prometheus-operator).
     serviceMonitor:
@@ -67,8 +61,6 @@ server:
       #   sourceLabels:
       #   - __name__
       #   targetLabel: __name__
-    prometheus:
-      timerType: histogram
   deploymentLabels: {}
   deploymentAnnotations: {}
   deploymentStrategy: {}
@@ -226,9 +218,12 @@ server:
       # Additional tags to be added to Prometheus metrics
       tags: {}
       # ... All other fields from https://github.com/temporalio/temporal/blob/main/common/metrics/config.go
+      # excludeTags: {}
+      # prefix: ""
+      # etc.
       prometheus:
-          timerType: histogram
-          listenAddress: "0.0.0.0:9090"
+        timerType: histogram
+        listenAddress: "0.0.0.0:9090"
     namespaces:
       # Enable this to create namespaces
       create: false


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Allow setting other [metrics fields](https://github.com/temporalio/temporal/blob/main/common/metrics/config.go) in config template.

Move the configuration related metrics field from `server.metrics` to `server.config.metrics`

## Why?
<!-- Tell your future self why have you made these changes -->
Add `server.config.metrics` which is used to generate metrics section for config for consistency with other configuration related data.
Default value of prometheus configuration has been moved to values.yaml.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Tested the full template by printing out various combinations. Verified no diff with default values.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Might be need to mention in breaking changes section of v1.
