### PR TITLE
Add an option to disable creating shims

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -115,9 +115,11 @@ spec:
               subPath: config_template.yaml
             - name: dynamic-config
               mountPath: /etc/temporal/dynamic_config
+            {{- if $.Values.shims.dockerize }}
             - name: shims
               mountPath: /usr/local/bin/dockerize
               subPath: dockerize
+            {{- end }}
             {{- if $.Values.server.additionalVolumeMounts }}
             {{- toYaml $.Values.server.additionalVolumeMounts | nindent 12}}
             {{- end }}
@@ -132,10 +134,12 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if $.Values.shims.dockerize }}
         - name: shims
           configMap:
             name: "{{ include "temporal.fullname" $ }}-shims"
             defaultMode: 0555
+        {{- end }}
         - name: config
           configMap:
             name: "{{ include "temporal.fullname" $ }}-config"

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -84,9 +84,11 @@ datacenter', '{{ $store.config.datacenter }}'{{- end }}]
             {{- with $.Values.admintools.additionalVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if $.Values.shims.elasticsearchTool }}
             - name: shims
               mountPath: /usr/local/sbin/temporal-elasticsearch-tool
               subPath: temporal-elasticsearch-tool
+            {{- end }}
             {{- with $.Values.schema.resources }}
           resources:
               {{- toYaml . | nindent 12 }}
@@ -164,13 +166,15 @@ datacenter', '{{ $store.config.datacenter }}'{{- end }}]
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or $.Values.admintools.additionalVolumes true }}
+      {{- if or $.Values.admintools.additionalVolumes $.Values.shims.elasticsearchTool }}
       volumes:
         {{- with $.Values.admintools.additionalVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if $.Values.shims.elasticsearchTool }}
         - name: shims
           configMap:
             name: "{{ include "temporal.fullname" $ }}-shims"
             defaultMode: 0555
+        {{- end }}
       {{- end }}

--- a/charts/temporal/templates/shim-configmap.yaml
+++ b/charts/temporal/templates/shim-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if or $.Values.shims.dockerize $.Values.shims.elasticsearchTool }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,6 +6,7 @@ metadata:
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}
 data:
+{{- if $.Values.shims.dockerize }}
   dockerize: |-
     #!/bin/sh
     set -e
@@ -38,6 +40,8 @@ data:
 
         echo "Skipped dockerize, copied $SRC to $DST"
     fi
+{{- end }}
+{{- if $.Values.shims.elasticsearchTool }}
   temporal-elasticsearch-tool: |-
     #!/bin/sh
     set -e
@@ -312,3 +316,5 @@ data:
             exit 1
             ;;
     esac
+{{- end }}
+{{- end }}

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -78,6 +78,41 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: my-init-container
+  - it: includes volume mounts with shim by default
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: .kind
+      value: Deployment
+      matchMany: true
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name=='config')]
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name=='dynamic-config')]
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name=='shims')]
+      - exists:
+          path: spec.template.spec.volumes[?(@.name=='config')]
+      - exists:
+          path: spec.template.spec.volumes[?(@.name=='dynamic-config')]
+      - exists:
+          path: spec.template.spec.volumes[?(@.name=='shims')]
+  - it: includes additional volumes without shim when disabled
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: .kind
+      value: Deployment
+      matchMany: true
+    set:
+      shims:
+        dockerize: false
+    asserts:
+      - exists:
+          path: spec.template.spec.volumes[?(@.name=='config')]
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name=='shims')]
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name=='shims')]
   - it: omits prometheus annotations when disabled
     template: templates/server-deployment.yaml
     documentSelector:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -503,5 +503,8 @@ schema:
   resources: {}
   containerSecurityContext: {}
   securityContext: {}
+shims:
+  dockerize: true
+  elasticsearchTool: true
 test:
   podAnnotations: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added an option to disable creation of dockerize and elasticsearch-tool shims. They're needed in <= v1.29, but can be disabled for >= v1.30.

## Why?
<!-- Tell your future self why have you made these changes -->
To avoid unnecessary volume mounts when they're not needed.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Compared results of `helm template .` with and without this change.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
