### PR TITLE
Don't camel case service names in YAML.

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -257,15 +257,3 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
-
-{{/*
-To modify camelCase to hyphenated internal-frontend service name
-*/}}
-{{- define "serviceName" -}}
-    {{- $service := index . 0 -}}
-    {{- if eq $service "internalFrontend" }}
-        {{- print "internal-frontend" }}
-    {{- else }}
-        {{- print $service }}
-    {{- end }}
-{{- end -}}

--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -33,16 +33,16 @@ spec:
           env:
             # TEMPORAL_CLI_ADDRESS is deprecated, use TEMPORAL_ADDRESS instead
             - name: TEMPORAL_CLI_ADDRESS
-              {{- if and (hasKey .Values.server "internalFrontend") .Values.server.internalFrontend.enabled }}
-              value: {{ include "temporal.fullname" $ }}-internal-frontend:{{ .Values.server.internalFrontend.service.port }}
+              {{- if and (index $.Values.server "internal-frontend").enabled }}
+              value: {{ include "temporal.fullname" $ }}-internal-frontend:{{ (index $.Values.server "internal-frontend").service.port }}
               {{- else }}
-              value: {{ include "temporal.fullname" $ }}-frontend:{{ .Values.server.frontend.service.port }}
+              value: {{ include "temporal.fullname" $ }}-frontend:{{ $.Values.server.frontend.service.port }}
               {{- end }}
             - name: TEMPORAL_ADDRESS
-              {{- if and (hasKey .Values.server "internalFrontend") .Values.server.internalFrontend.enabled }}
-              value: {{ include "temporal.fullname" $ }}-internal-frontend:{{ .Values.server.internalFrontend.service.port }}
+              {{- if (index $.Values.server "internal-frontend").enabled }}
+              value: {{ include "temporal.fullname" $ }}-internal-frontend:{{ (index $.Values.server "internal-frontend").service.port }}
               {{- else }}
-              value: {{ include "temporal.fullname" $ }}-frontend:{{ .Values.server.frontend.service.port }}
+              value: {{ include "temporal.fullname" $ }}-frontend:{{ $.Values.server.frontend.service.port }}
               {{- end }}
           {{- with .Values.admintools.additionalEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -75,13 +75,15 @@ data:
           membershipPort: {{ $server.frontend.service.membershipPort }}
           bindOnIP: "0.0.0.0"
 
-      {{- if and (hasKey .Values.server "internalFrontend") .Values.server.internalFrontend.enabled }}
+      {{- with (index $.Values.server "internal-frontend") }}
+      {{- if .enabled }}
       internal-frontend:
         rpc:
-          grpcPort: {{ $server.internalFrontend.service.port }}
-          httpPort: {{ $server.internalFrontend.service.httpPort }}
-          membershipPort: {{ $server.internalFrontend.service.membershipPort }}
+          grpcPort: {{ .service.port }}
+          httpPort: {{ .service.httpPort }}
+          membershipPort: {{ .service.membershipPort }}
           bindOnIP: "0.0.0.0"
+      {{- end }}
       {{- end }}
 
       history:
@@ -138,7 +140,7 @@ data:
       {{- toYaml . | nindent 6 }}
     {{- end }}
 
-    {{- if not (and (hasKey .Values.server "internalFrontend") .Values.server.internalFrontend.enabled) }}
+    {{- if not (index $.Values.server "internal-frontend").enabled }}
     publicClient:
       hostPort: "{{ include "temporal.componentname" (list $ "frontend") }}:{{ $server.frontend.service.port }}"
     {{- end }}

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -1,9 +1,8 @@
 {{- if $.Values.server.enabled }}
 {{- $defaultStore := include "temporal.persistence.getStoreByType" (list $ "default") | fromYaml -}}
 {{- $visibilityStore := include "temporal.persistence.getStoreByType" (list $ "visibility") | fromYaml -}}
-{{- range $rawService := (list "frontend" "internalFrontend" "history" "matching" "worker") }}
-{{- $service := include "serviceName" (list $rawService) }}
-{{- $serviceValues := index $.Values.server $rawService }}
+{{- range $service := (list "frontend" "internal-frontend" "history" "matching" "worker") }}
+{{- $serviceValues := index $.Values.server $service }}
 {{- if or (not (hasKey $serviceValues "enabled")) $serviceValues.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -64,7 +63,7 @@ spec:
               {{- include "temporal.password-env" (list $ $defaultStore) | nindent 14 }}
             - name: TEMPORAL_VISIBILITY_STORE_PASSWORD
               {{- include "temporal.password-env" (list $ $visibilityStore) | nindent 14 }}
-          {{- if and (hasKey $.Values.server "internalFrontend") $.Values.server.internalFrontend.enabled }}
+          {{- if (index $.Values.server "internal-frontend").enabled }}
             - name: USE_INTERNAL_FRONTEND
               value: "1"
           {{- end }}

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -106,8 +106,8 @@ datacenter', '{{ $store.config.datacenter }}'{{- end }}]
           args: ['temporal operator namespace describe -n {{ $namespace.name }} || temporal operator namespace create -n {{ $namespace.name }}{{- if hasKey $namespace "retention" }} --retention {{ $namespace.retention }}{{- end }}']
           env:
             - name: TEMPORAL_ADDRESS
-              {{- if and (hasKey $.Values.server "internalFrontend") $.Values.server.internalFrontend.enabled }}
-              value: {{ include "temporal.fullname" $ }}-internal-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.internalFrontend.service.port }}
+              {{- if (index $.Values.server "internal-frontend").enabled }}
+              value: {{ include "temporal.fullname" $ }}-internal-frontend.{{ $.Release.Namespace }}.svc:{{ (index $.Values.server "internal-frontend").service.port }}
               {{- else if $.Values.server.frontend.ingress.enabled }}
               value: "{{ index $.Values.server.frontend.ingress.hosts 0 }}"
               {{- else }}

--- a/charts/temporal/templates/server-pdb.yaml
+++ b/charts/temporal/templates/server-pdb.yaml
@@ -1,9 +1,7 @@
 {{- if $.Values.server.enabled }}
-{{- range $rawService := (list "frontend" "internalFrontend" "history" "matching" "worker") }}
-{{- $service := include "serviceName" (list $rawService) }}
-{{- $serviceValues := index $.Values.server $rawService }}
-{{- if or (not (hasKey $serviceValues "enabled")) $serviceValues.enabled }}
-{{- if and (gt ($serviceValues.replicaCount | int) 0) ($serviceValues.podDisruptionBudget) }}
+{{- range $service := (list "frontend" "internal-frontend" "history" "matching" "worker") }}
+{{- $serviceValues := index $.Values.server $service }}
+{{- if and $serviceValues.enabled (gt ($serviceValues.replicaCount | int) 0) ($serviceValues.podDisruptionBudget) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -19,6 +17,5 @@ spec:
       app.kubernetes.io/component: {{ $service }}
 {{- end }}
 ---
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/temporal/templates/server-service-monitor.yaml
+++ b/charts/temporal/templates/server-service-monitor.yaml
@@ -1,8 +1,7 @@
 {{- if $.Values.server.enabled }}
-{{- range $rawService := (list "frontend" "internalFrontend" "matching" "history" "worker") }}
-{{- $service := include "serviceName" (list $rawService) }}
-{{- $serviceValues := index $.Values.server $rawService }}
-{{- if or (not (hasKey $serviceValues "enabled")) $serviceValues.enabled }}
+{{- range $service := (list "frontend" "internal-frontend" "matching" "history" "worker") }}
+{{- $serviceValues := index $.Values.server $service }}
+{{- if $serviceValues.enabled }}
 {{- if (default $.Values.server.metrics.serviceMonitor.enabled $serviceValues.metrics.serviceMonitor.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -1,7 +1,6 @@
 {{- if $.Values.server.enabled }}
-{{- range $rawService := (list "frontend" "internalFrontend") }}
-{{- $service := include "serviceName" (list $rawService) }}
-{{- $serviceValues := index $.Values.server $rawService }}
+{{- range $service := (list "frontend" "internal-frontend") }}
+{{- $serviceValues := index $.Values.server $service }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -42,10 +41,9 @@ spec:
 {{- end }}
 
 {{- if $.Values.server.enabled }}
-{{- range $rawService := (list "frontend" "internalFrontend" "matching" "history" "worker") }}
-{{- $service := include "serviceName" (list $rawService) }}
-{{- $serviceValues := index $.Values.server $rawService }}
-{{- if or (not (hasKey $serviceValues "enabled")) $serviceValues.enabled }}
+{{- range $service := (list "frontend" "internal-frontend" "matching" "history" "worker") }}
+{{- $serviceValues := index $.Values.server $service }}
+{{- if $serviceValues.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/temporal/tests/server_pdb_test.yaml
+++ b/charts/temporal/tests/server_pdb_test.yaml
@@ -3,7 +3,9 @@ templates:
   - server-pdb.yaml
 set:
   server:
+    enabled: true
     frontend:
+      enabled: true
       replicaCount: 1
 tests:
   - it: creates pdb when specified

--- a/charts/temporal/tests/server_service_test.yaml
+++ b/charts/temporal/tests/server_service_test.yaml
@@ -3,17 +3,24 @@ templates:
   - server-service.yaml
 set:
   server:
-    internalFrontend:
+    internal-frontend:
       enabled: true
     replicaCount: 2
     resources:
       requests:
         cpu: 100m
     frontend:
+      enabled: true
       replicaCount: 3
       resources:
         requests:
           cpu: 200m
+    history:
+      enabled: true
+    matching:
+      enabled: true
+    worker:
+      enabled: true
 tests:
   - it: omits prometheus annotations when disabled
     template: templates/server-service.yaml
@@ -306,7 +313,7 @@ tests:
       matchMany: true
     set:
       server:
-        internalFrontend:
+        internal-frontend:
           service:
             appProtocol: grpc
             httpAppProtocol: http2
@@ -378,7 +385,7 @@ tests:
       matchMany: true
     set:
       server:
-        internalFrontend:
+        internal-frontend:
           service:
             appProtocol: grpc
             membershipAppProtocol: tls

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -275,7 +275,7 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
-  internalFrontend:
+  internal-frontend:
     # Enable this to create internal-frontend
     enabled: false
     service:


### PR DESCRIPTION
It's more intuitive to keep the YAML structure using kubernetes style naming.

## What was changed
Stopped using camel case in the values YAML for services.

## Why?
It's more intuitive that the names match between kubernetes and the values. This also simplifies code, at the cost of making it impossible to use dot notation for retrieval. I consider that a good trade off however, as that is only maintainer facing and will fail cleanly.

## Checklist
<!--- add/delete as needed --->

1. Closes #682

2. How was this tested:
Adjusted tests as required.

This replaces https://github.com/temporalio/helm-charts/pull/683