### PR TITLE
added support for servicelabels on services

### DIFF
--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -7,7 +7,7 @@ kind: Service
 metadata:
   name: {{ include "temporal.componentname" (list $ $service) }}
   labels:
-    {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
+    {{- include "temporal.resourceLabels" (list $ $service "service") | nindent 4 }}
   {{- if $serviceValues.service.annotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $serviceValues.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/charts/temporal/tests/server_service_test.yaml
+++ b/charts/temporal/tests/server_service_test.yaml
@@ -530,3 +530,22 @@ tests:
             port: 9090
             protocol: TCP
             targetPort: metrics
+  - it: add custom label for frontend service
+    template: templates/server-service.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
+      value: Service
+      matchMany: true
+    set:
+      server:
+        frontend:
+          serviceLabels:
+            label1: value1
+            label2: value2
+    asserts:
+      - equal:
+          path: metadata.labels["label1"]
+          value: value1
+      - equal:
+          path: metadata.labels["label2"]
+          value: value2

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -269,6 +269,7 @@ server:
     deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
+    serviceLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -306,6 +307,7 @@ server:
     deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
+    serviceLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -334,6 +336,7 @@ server:
     deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
+    serviceLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -362,6 +365,7 @@ server:
     deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
+    serviceLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -390,6 +394,7 @@ server:
     deploymentStrategy: {}
     podAnnotations: {}
     podLabels: {}
+    serviceLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- **server-service.yaml**
  -  Added service to the resourceLabel call
- **values.yaml**
  - Added a serviceLabel field to each service
- **Tests**
  - Added unit test to verify correct generation of service manifest   
## Why?
<!-- Tell your future self why have you made these changes -->
I am in need of custom set of labels on the service for our prometheus scrape metrics from the service monitor

1. Closes <!-- add issue number here -->
No related issue, but I had a short conversation with Rob Holland on the community slack

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added a unit test to verify the correct generation of the service manifest

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Not that I am aware of
