### PR TITLE
Add clusterMetadata to clusterName to easily rename a cluster

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -104,18 +104,17 @@ data:
           bindOnIP: "0.0.0.0"
 
     clusterMetadata:
-    {{- with $server.config.clusterMetadata }}
+    {{- with (omit $server.config.clusterMetadata "clusterName") }}
       {{- toYaml . | nindent 8 }}
     {{- else }}
       enableGlobalNamespace: false
       failoverVersionIncrement: 10
-      masterClusterName: "active"
-      currentClusterName: "active"
+      masterClusterName: {{ $server.config.clusterMetadata.clusterName | quote }}
+      currentClusterName: {{ $server.config.clusterMetadata.clusterName | quote }}
       clusterInformation:
-        active:
+        {{ $server.config.clusterMetadata.clusterName }}:
           enabled: true
           initialFailoverVersion: 1
-          rpcName: "temporal-frontend"
           rpcAddress: "127.0.0.1:{{ $server.frontend.service.port }}"
           httpAddress: "127.0.0.1:{{ $server.frontend.service.httpPort }}"
     {{- end }}

--- a/charts/temporal/tests/server_configmap_test.yaml
+++ b/charts/temporal/tests/server_configmap_test.yaml
@@ -43,6 +43,53 @@ tests:
           path: data['config_template.yaml']
           pattern: 'password: \{\{ env "TEMPORAL_VISIBILITY_STORE_PASSWORD" \| quote \}\}'
 
+  - it: handles clusterMetadata clusterName
+    set:
+      server:
+        config:
+          persistence:
+            defaultStore: default
+            visibilityStore: visibility
+            datastores:
+              default:
+              visibility:
+          clusterMetadata:
+            clusterName: my-cluster
+    template: templates/server-configmap.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-config
+    asserts:
+      - matchRegex:
+          path: data['config_template.yaml']
+          pattern: 'masterClusterName: "my-cluster"\s+currentClusterName: "my-cluster"'
+      - matchRegex:
+          path: data['config_template.yaml']
+          pattern: 'clusterInformation:\s+my-cluster:'
+
+  - it: handles custom clusterMetadata
+    set:
+      server:
+        config:
+          persistence:
+            defaultStore: default
+            visibilityStore: visibility
+            datastores:
+              default:
+              visibility:
+          clusterMetadata:
+            clusterName: my-cluster # this is ignored
+            enableGlobalNamespace: true
+            failoverVersionIncrement: 20
+    template: templates/server-configmap.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-config
+    asserts:
+      - matchRegex:
+          path: data['config_template.yaml']
+          pattern: 'clusterMetadata:\s+enableGlobalNamespace: true\s+failoverVersionIncrement: 20'
+
   - it: handles additional stores
     set:
       server:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -221,6 +221,10 @@ server:
         #   sql:
         #     pluginName: postgres12
         #     ...
+    clusterMetadata:
+      # Sets the cluster name.
+      # If any other clusterMetadata fields are set, clusterName will be ignored, and those will be set as clusterMetadata instead.
+      clusterName: active
     namespaces:
       # Enable this to create namespaces
       create: false


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->


<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Add `server.config.clusterMetadata.clusterName` where if it's the only field in clusterMetadata, it's used with the default clusterMetadata with just the name change. It's fully compatible with the existing values (unless someone had specified `clusterMetadata.clusterName` which is unlikely, since that's a unused field in config) 

Remove `rpcName` in clusterMetadata. It was removed from temporal config in 2021.
## Why?
<!-- Tell your future self why have you made these changes -->
To make it easier to customize just the clusterName.

If anything else needs to be customized, whole clusterMetadata has to be provided.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Ran `helm template .` between main and this branch, and verified that only diff is removal of `rpcName` and config checksum.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
