### PR TITLE
fix: add SERVICES env var for backward compatibility with default image

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -59,6 +59,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SERVICES
+              value: {{ $service }}
             - name: TEMPORAL_SERVICES
               value: {{ $service }}
             - name: TEMPORAL_SERVER_CONFIG_FILE_PATH


### PR DESCRIPTION
The default Docker image (temporalio/server:1.29.x) entrypoint script
reads SERVICES env var, not TEMPORAL_SERVICES. This causes all pods
to run all 4 services instead of their assigned service.

Fixes #848
