### PR TITLE
feat: add web.useInternalFrontend option for Web UI

### DIFF
--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -39,7 +39,11 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: TEMPORAL_ADDRESS
+              {{- if and .Values.web.useInternalFrontend (index $.Values.server "internal-frontend").enabled }}
+              value: "{{ include "temporal.fullname" $ }}-internal-frontend.{{ .Release.Namespace }}.svc:{{ (index $.Values.server "internal-frontend").service.port }}"
+              {{- else }}
               value: "{{ include "temporal.fullname" $ }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
+              {{- end }}
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -497,6 +497,12 @@ web:
   affinity: {}
   additionalVolumes: []
   additionalVolumeMounts: []
+  # When enabled, the Web UI connects to internal-frontend instead of frontend.
+  # This allows the Web UI to bypass server-side authorization, since internal-frontend
+  # is not subject to the authorizer. Requires server.internal-frontend.enabled to be true.
+  # If you need authenticated Web UI access (e.g., via SSO/OIDC), leave this as false
+  # and configure TEMPORAL_AUTH_* environment variables in additionalEnv instead.
+  useInternalFrontend: false
   # Adjust Web UI config with environment variables:
   # https://docs.temporal.io/references/web-ui-environment-variables
   additionalEnv: []


### PR DESCRIPTION
## What was changed

Added a `web.useInternalFrontend` option (default: `false`) to `values.yaml`
and a conditional in `web-deployment.yaml` that points the Web UI at
`internal-frontend` instead of `frontend` when enabled.

**Files changed:**

- `charts/temporal/templates/web-deployment.yaml` — conditional
  `TEMPORAL_ADDRESS` based on `web.useInternalFrontend` and
  `server.internal-frontend.enabled`
- `charts/temporal/values.yaml` — new `web.useInternalFrontend: false` with documentation

## Why?

We would like to have an option to pass through auth as admintools and others
too. Only configuring auth for the api for now.

## Checklist

1. Closes — N/A (no existing issue for this)

2. How was this tested:

Verified with `helm template` that both cases render correctly:

```
# useInternalFrontend: false (default) — no behavior change
TEMPORAL_ADDRESS: "temporal-frontend.default.svc:7233"

# useInternalFrontend: true + server.internal-frontend.enabled: true
TEMPORAL_ADDRESS: "temporal-internal-frontend.default.svc:7236"
```

Also tested on a live staging deployment — Web UI successfully connects and
displays data when pointed at internal-frontend.

3. Any docs updates needed?

The `values.yaml` comment documents the option.
The [Web UI environment variables reference](https://docs.temporal.io/references/web-ui-environment-variables)
on docs.temporal.io could mention this option, but it is not strictly required.