### PR TITLE
feat: Allow the ability to configure garbage collection on schema-job.

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -10,7 +10,11 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ $.Values.schema.backoffLimit }}
+  {{- if and $.Values.schema.garbageCollection $.Values.schema.garbageCollection.enabled }}
+  ttlSecondsAfterFinished: {{ $.Values.schema.garbageCollection.ttlSeconds | default 86400 }}
+  {{- else if not $.Values.schema.garbageCollection }}
   ttlSecondsAfterFinished: 86400
+  {{- end }}
   template:
     metadata:
       name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -508,6 +508,11 @@ web:
   minReadySeconds: 0
   podDisruptionBudget: {}
 schema:
+  garbageCollection:
+    # Enable or disable the job garbage collection
+    enabled: true
+    # If enabled, time before the job is removed in seconds. Default 86400
+    ttlSeconds: 86400
   backoffLimit: 100
   jobAnnotations: {}
   podAnnotations: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR gives the user the ability to configure schema-job garbage collection. Specifically the ability to enable or disable the garbage collection altogether as well as specify the desired time before garbage collection runs against the job if enabled.

See [Here](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/) for more information about kubernetes garbage collection on job resources.

## Why?
Currently garbage collection (.spec.ttlSecondsAfterFinished) is hard coded in the server-job manifest. This means that the job will always delete itself after the specified value (currently 86400). In some cases users may want to either configure the number of seconds before deleting the job manifest, or they may want to disable this garbage collection altogether. This PR takes care of both of those scenarios.


## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/735

2. How was this tested:
The chart was validated using helm template --debug as well as packaging it (helm package) and using it in a deployment.

3. Any docs updates needed?
No
