### PR TITLE
Backports the fix for broadcastAddress interpolation from the v1.x-rc…

### DIFF
--- a/charts/temporal/templates/server-dockerize-configmap.yaml
+++ b/charts/temporal/templates/server-dockerize-configmap.yaml
@@ -83,7 +83,7 @@ data:
       membership:
         name: temporal
         maxJoinDuration: 30s
-        broadcastAddress: {{ `{{ .Env.POD_IP }}` }}
+        broadcastAddress: {{ `{{ env "POD_IP" | quote }}` }}
 
       pprof:
         port: 7936


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Wraps the environment variable in quotes using the | quote helper. This ensures the IP is treated as a string regardless of its format. This was already done in the -rc branch, so I am backporting this to the stable branch: https://github.com/temporalio/helm-charts/blob/temporal-1.0.0-rc.2/charts/temporal/templates/server-configmap.yaml#L33

## Why?
In IPv6 clusters, POD_IP can contain trailing double-colons (e.g., 2600:...::). When dockerize interpolates this into the YAML without quotes, the YAML parser fails with mapping values are not allowed in this context.

```
2026/03/19 18:25:53 Loading config files=[config/docker.yaml]
Unable to load configuration: config file corrupted: yaml: line 43: mapping values are not allowed in this context.
```

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/824

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Running:

```
 helm template . --show-only templates/server-dockerize-configmap.yaml --no-hooks
```

yields:

```
global:
      membership:
        name: temporal
        maxJoinDuration: 30s
        broadcastAddress: {{ env "POD_IP" | quote }}
```


To show the error I have created a local file:
```
broadcastAddress: {{ .Env.POD_IP }}
```

And ran a docker image:
```
docker run --rm -v "$(pwd):/data" -e POD_IP="2600:1f14::" alpine:latest sh -c "
  apk add --no-cache python3 py3-pip &&
  pip3 install PyYAML --break-system-packages &&
  wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz &&
  tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz &&

  echo '--- Rendering Template ---' &&
  dockerize -template /data/test.yaml:/data/rendered.yaml &&

  echo '--- Rendered Content ---' &&
  cat /data/rendered.yaml &&

  echo '--- YAML Validation ---' &&
  python3 -c \"import yaml, sys; yaml.safe_load(open('/data/rendered.yaml'))\"
"
```
Which yields the error:

```
  File "/usr/lib/python3.12/site-packages/yaml/scanner.py", line 577, in fetch_value
    raise ScannerError(None, None,
yaml.scanner.ScannerError: mapping values are not allowed here
```

And after changing the file to a slightly different version (Since env is a helm specific tool):

```
broadcastAddress: "{{ .Env.POD_IP }}"
```
I now get:

```
dockerize
--- Rendering Template ---
--- Rendered Content ---
broadcastAddress: "2600:1f14::"
--- YAML Validation ---
```
3. Any docs updates needed?
None.
