### PR TITLE
Add AWS signing for ES.

### DIFF
--- a/charts/temporal/templates/_admintools-env.yaml
+++ b/charts/temporal/templates/_admintools-env.yaml
@@ -106,6 +106,24 @@
   value: {{ not .enableHostVerification | quote }}
     {{- end }}
   {{- end }}
+  {{- with index $store.config "aws-request-signing" }}
+    {{- with .credentialProvider }}
+- name: AWS_CREDENTIALS
+  value: {{ . | quote }}
+    {{- end }}
+    {{- with .region }}
+- name: AWS_REGION
+  value: {{ . | quote }}
+    {{- end }}
+    {{- if eq .credentialProvider "static" }}
+      {{- with .static }}
+        {{- with .token }}
+- name: AWS_SESSION_TOKEN
+  value: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- else -}}
     {{- fail (printf "No valid persistence driver configuration found for %s store" $store.name) -}}
 {{- end -}}

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -308,3 +308,102 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="ES_TLS_DISABLE_HOST_VERIFICATION")].value
           value: "false"
+  - it: sets Elasticsearch AWS request signing environment variables
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                elasticsearch:
+                  version: v7
+                  url:
+                    scheme: https
+                    host: "elasticsearch:9200"
+                  username: ""
+                  password: ""
+                  indices:
+                    visibility: temporal_visibility_v1
+                  aws-request-signing:
+                    credentialProvider: environment
+                    region: us-east-1
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_CREDENTIALS")].value
+          value: environment
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_REGION")].value
+          value: us-east-1
+      - isNull:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_SESSION_TOKEN")]
+  - it: sets AWS_SESSION_TOKEN for static Elasticsearch AWS credentials
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                elasticsearch:
+                  version: v7
+                  url:
+                    scheme: https
+                    host: "elasticsearch:9200"
+                  username: myAccessKeyID
+                  password: mySecretAccessKey
+                  indices:
+                    visibility: temporal_visibility_v1
+                  aws-request-signing:
+                    credentialProvider: static
+                    region: us-east-1
+                    static:
+                      token: mySessionToken
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_CREDENTIALS")].value
+          value: static
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_REGION")].value
+          value: us-east-1
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_SESSION_TOKEN")].value
+          value: mySessionToken
+  - it: omits AWS_SESSION_TOKEN when not using static Elasticsearch AWS credentials
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                elasticsearch:
+                  version: v7
+                  url:
+                    scheme: https
+                    host: "elasticsearch:9200"
+                  username: ""
+                  password: ""
+                  indices:
+                    visibility: temporal_visibility_v1
+                  aws-request-signing:
+                    credentialProvider: aws-sdk-default
+                    region: eu-west-1
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_CREDENTIALS")].value
+          value: aws-sdk-default
+      - isNull:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_SESSION_TOKEN")]

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -217,6 +217,13 @@ server:
         #     keyFile: /path/to/client.key
         #     serverName: elasticsearch.internal
         #     enableHostVerification: true
+        #   aws-request-signing:
+        #     credentialProvider: environment  # static, environment, or aws-sdk-default
+        #     region: us-east-1
+        #     static:
+        #       accessKeyID: ""
+        #       secretAccessKey: ""
+        #       token: ""
         # Additional stores can be added here and will pass through directly
         # archive:
         #   sql:

--- a/charts/temporal/values/values.elasticsearch.yaml
+++ b/charts/temporal/values/values.elasticsearch.yaml
@@ -39,3 +39,10 @@ server:
             #   keyFile: /path/to/client.key
             #   serverName: elasticsearch.internal
             #   enableHostVerification: true
+            # aws-request-signing:
+            #   credentialProvider: environment  # static, environment, or aws-sdk-default
+            #   region: us-east-1
+            #   static:
+            #     accessKeyID: ""
+            #     secretAccessKey: ""
+            #     token: ""


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Wire through the server persistence config to the admintools env.

## Why?
Allows `elasticsearch-tool` to connect to AWS OpenSearch.
