### PR TITLE
add resources config for test.yaml

### DIFF
--- a/charts/temporal/templates/test.yaml
+++ b/charts/temporal/templates/test.yaml
@@ -19,4 +19,8 @@ spec:
     env:
       - name: TEMPORAL_ADDRESS
         value: {{ include "temporal.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }}
+    {{- with .Values.test.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   restartPolicy: Never

--- a/charts/temporal/tests/test_pod_test.yaml
+++ b/charts/temporal/tests/test_pod_test.yaml
@@ -11,6 +11,27 @@ tests:
     asserts:
       - notExists:
           path: metadata.annotations["sidecar.istio.io/inject"]
+  - it: does not set resources by default
+    asserts:
+      - notExists:
+          path: spec.containers[0].resources
+  - it: sets resources when specified
+    set:
+      test:
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.limits.cpu
+          value: 100m
+      - equal:
+          path: spec.containers[0].resources.requests.memory
+          value: 128Mi
   - it: includes custom pod annotations when specified
     set:
       test:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -529,3 +529,4 @@ shims:
   elasticsearchTool: true
 test:
   podAnnotations: {}
+  resources: {}


### PR DESCRIPTION
## What was changed
Added `resources` config support to the `cluster-health` test pod container, with corresponding `values.yaml` entry and helm-unittest tests.

## Why?
Many organizations enforce resource limits/requests via CI linters (e.g. OPA/Gatekeeper policies). Without this, `helm test` would fail in such environments.

## Checklist

1. Closes N/A

2. How was this tested:
   - Added helm-unittest tests covering: no resources by default, and correct rendering when `test.resources` is set

3. Any docs updates needed?
   No.