### PR TITLE
Fix rendering for --datacenter option.

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -37,8 +37,7 @@ spec:
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
             {{- if eq $store.driver "cassandra" }}
-          command: ['temporal-cassandra-tool', 'create', '-k', '{{ $store.config.keyspace }}', '--replication-factor', '{{ $store.config.replicationFactor | default 1 }}'{{- if $store.config.datacenter }}, '--
-datacenter', '{{ $store.config.datacenter }}'{{- end }}]
+          command: ['temporal-cassandra-tool', 'create', '-k', '{{ $store.config.keyspace }}', '--replication-factor', '{{ $store.config.replicationFactor | default 1 }}'{{- if $store.config.datacenter }}, '--datacenter', '{{ $store.config.datacenter }}'{{- end }}]
             {{- else if eq $store.driver "sql" }}
           command: ['temporal-sql-tool', 'create-database']
             {{- else -}}


### PR DESCRIPTION
## What was changed
Removed newline from `command ...`.

## Why?
The newline broke rendering resulting in `-- datacenter` in the rendered command YAML.