### PR TITLE
fix: pass admintools.additionalEnv to create-store and manage-schema containers (#865)

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -45,6 +45,20 @@ spec:
             {{- end }}
           env:
             {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}
+            {{- with $.Values.admintools.additionalEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if or $.Values.admintools.additionalEnvSecretName $.Values.admintools.additionalEnvConfigMapName }}
+          envFrom:
+              {{- with $.Values.admintools.additionalEnvSecretName }}
+            - secretRef:
+                name: {{ . }}
+              {{- end }}
+              {{- with $.Values.admintools.additionalEnvConfigMapName }}
+            - configMapRef:
+                name: {{ . }}
+              {{- end }}
+            {{- end }}
             {{- with $.Values.admintools.additionalVolumeMounts }}
           volumeMounts:
               {{- toYaml . | nindent 12 }}
@@ -80,6 +94,20 @@ spec:
             {{- end }}
           env:
             {{- include "temporal.admintools-env" (list $ $store) | nindent 12 }}
+            {{- with $.Values.admintools.additionalEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if or $.Values.admintools.additionalEnvSecretName $.Values.admintools.additionalEnvConfigMapName }}
+          envFrom:
+              {{- with $.Values.admintools.additionalEnvSecretName }}
+            - secretRef:
+                name: {{ . }}
+              {{- end }}
+              {{- with $.Values.admintools.additionalEnvConfigMapName }}
+            - configMapRef:
+                name: {{ . }}
+              {{- end }}
+            {{- end }}
           volumeMounts:
             {{- with $.Values.admintools.additionalVolumeMounts }}
               {{- toYaml . | nindent 12 }}

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -54,11 +54,15 @@ tests:
             datastores:
               default:
                 sql:
+                  createDatabase: true
+                  manageSchema: true
                   pluginName: mysql8
                   connectAddr: "temporal-persistence:3306"
                   databaseName: temporal
               visibility:
                 sql:
+                  createDatabase: true
+                  manageSchema: true
                   pluginName: mysql8
                   connectAddr: "temporal-visibility:3306"
                   databaseName: temporal_visibility
@@ -71,6 +75,45 @@ tests:
         additionalEnvSecretName: env-secret
         additionalEnvConfigMapName: env-configmap
     asserts:
+      # create-*-store containers
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-store")].env[?(@.name=="MY_ENV_VAR")].value
+          value: my-value
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-store")].envFrom[0].secretRef.name
+          value: env-secret
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-store")].envFrom[1].configMapRef.name
+          value: env-configmap
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-visibility-store")].env[?(@.name=="MY_ENV_VAR")].value
+          value: my-value
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-visibility-store")].envFrom[0].secretRef.name
+          value: env-secret
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-visibility-store")].envFrom[1].configMapRef.name
+          value: env-configmap
+      # manage-schema-*-store containers
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="MY_ENV_VAR")].value
+          value: my-value
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].envFrom[0].secretRef.name
+          value: env-secret
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].envFrom[1].configMapRef.name
+          value: env-configmap
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="MY_ENV_VAR")].value
+          value: my-value
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].envFrom[0].secretRef.name
+          value: env-secret
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].envFrom[1].configMapRef.name
+          value: env-configmap
+      # create-*-namespace containers
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="MY_ENV_VAR")].value
           value: my-value


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This change added `additionalEnv`, `additionalEnvSecretName`, and `additionalEnvConfigMapName` support to the `create-*-store` and `manage-schema-*-store` init containers in `server-job.yaml`. 

Before the change these were only passed to the `create-*-namespace` containers.

Updated unit tests to assert that additional env are present on all init container types.


## Why?
<!-- Tell your future self why have you made these changes -->
Bug fix: Environment variables set via `admintools.additionalEnv` are not inherited by the create-default-store, setup-default-store, and update-default-store init containers.

## Checklist
<!--- add/delete as needed --->

1. Closes #865 

2. How was this tested:
Updated `helm unittest` test case "includes additional environment variables" in `server_job_test.yaml` to cover all init container types


3. Any docs updates needed?
Bug fix, README already covers this feature. 