### PR TITLE
Update server-service.yaml

### DIFF
--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -1,7 +1,11 @@
 {{- if $.Values.server.enabled }}
-{{- range $service := (list "frontend" "internal-frontend") }}
-{{- $serviceValues := index $.Values.server $service }}
-{{- if $serviceValues.enabled }}
+{{- $services := list "frontend" }}
+{{- if $.Values.server.internalFrontend.enabled }}
+{{-   $services = concat $services (list "internalFrontend") }}
+{{- end }}
+{{- range $rawService := $services }}
+{{- $service := include "serviceName" (list $rawService) }}
+{{- $serviceValues := index $.Values.server $rawService }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## What was changed
Added a conditional check to only create the 'internalFrontend' service when 'internalFrontend.enabled: true' in values. The service list is now dynamically constructed instead of always iterating over both 'frontend' and 'internalFrontend'.

## Why?
Previously, the template always created Service resources for both 'frontend' and 'internalFrontend' regardless of their enabled status. This resulted in unnecessary/invalid service resources when 'internalFrontend.enabled: false'. The fix ensures services are only created when explicitly enabled.

## How was this changed
```yaml
# Before: Always iterates over both services
{{- range $rawService := (list "frontend" "internalFrontend") }}
# After: Dynamically builds list based on enabled flags
{{- $services := list "frontend" }}
{{- if $.Values.server.internalFrontend.enabled }}
{{-   $services = concat $services (list "internalFrontend") }}
{{- end }}
{{- range $rawService := $services }}
```

## Checklist
1. Closes
2. How was this tested:
      Ran helm template . between main and this branch, and verified that only diff is this config.
3. Any docs updates needed?