### PR TITLE
Add ttlSecondsAfterFinished to the schema job and allow setting to nu…

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -7,7 +7,9 @@ metadata:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
 spec:
   backoffLimit: {{ $.Values.schema.setup.backoffLimit }}
-  ttlSecondsAfterFinished: 86400
+  {{- if $.Values.schema.setup.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ $.Values.schema.setup.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       name: {{ include "temporal.componentname" (list $ (printf "schema-%d" .Release.Revision | replace "." "-")) }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -468,6 +468,7 @@ schema:
   setup:
     enabled: true
     backoffLimit: 100
+    ttlSecondsAfterFinished: 86400
   update:
     enabled: true
     backoffLimit: 100


### PR DESCRIPTION
…ll to disable

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Allow for configuring the ttlSecondsAfterFinished for the server job. You can set it to null to disable it entirely. 

## Why?
<!-- Tell your future self why have you made these changes -->
For users who use ArgoCD, this TTL causes applications to go out of sync. This causes alerts to fire and masks any other issues in the environment. Allowing users to disable this via the helm chart would allow users to more effectively use this helm chart with the gitops approach. 


## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/735

2. How was this tested:

Tested with various settings of ttlSecondsAfterFinished:


```
# Values.yaml:
ttlSecondsAfterFinished: null

# Server-job.yaml:
# ttlSecondsAfterFinished missing
```

And

```
# Values.yaml:
ttlSecondsAfterFinished: 5

# Server-job.yaml:
spec:
  backoffLimit: 100
  ttlSecondsAfterFinished: 5
```


3. Any docs updates needed?
NA - the README does not contain anything about the schema job right now
