### PR TITLE
Add imagePullSecrets to test pod.

### DIFF
--- a/charts/temporal/templates/test.yaml
+++ b/charts/temporal/templates/test.yaml
@@ -23,4 +23,8 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- with $.Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never

--- a/charts/temporal/tests/test_pod_test.yaml
+++ b/charts/temporal/tests/test_pod_test.yaml
@@ -48,3 +48,15 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook"]
           value: test
+  - it: does not set imagePullSecrets by default
+    asserts:
+      - notExists:
+          path: spec.imagePullSecrets
+  - it: sets imagePullSecrets when specified
+    set:
+      imagePullSecrets:
+        - name: my-registry-secret
+    asserts:
+      - equal:
+          path: spec.imagePullSecrets[0].name
+          value: my-registry-secret


### PR DESCRIPTION

## What was changed
Add imagePullSecrets to test pod when set.

## Why?
Allows images to be pulled as expected in restricted environments.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/861

2. How was this tested:
Tests added.
