### PR TITLE
Support pgx style connectAddr.

### DIFF
--- a/charts/temporal/templates/_admintools-env.yaml
+++ b/charts/temporal/templates/_admintools-env.yaml
@@ -28,9 +28,9 @@
 - name: SQL_PLUGIN
   value: {{ required (printf "Please specify pluginName for %s store (e.g., mysql8, postgres12, postgres12_pgx)" $store.name) $store.config.pluginName }}
 - name: SQL_HOST
-  value: {{ required (printf "Please specify connectAddr for %s store" $store.name) $store.config.connectAddr | splitList ":" | first }}
+  value: {{ required (printf "Please specify connectAddr for %s store" $store.name) $store.config.connectAddr | splitList "," | first | splitList ":" | first }}
 - name: SQL_PORT
-  value: {{ required (printf "Port must be specified in connectAddr for %s store. Expected format: 'host:port' (e.g., 'localhost:5432')" $store.name) ($store.config.connectAddr | splitList ":" | rest | first) | quote }}
+  value: {{ required (printf "Port must be specified in connectAddr for %s store. Expected format: 'host:port' (e.g., 'localhost:5432')" $store.name) ($store.config.connectAddr | splitList "," | first | splitList ":" | rest | first) | quote }}
 - name: SQL_DATABASE
   value: {{ required (printf "Please specify databaseName for %s store" $store.name) $store.config.databaseName }}
 - name: SQL_USER

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -476,3 +476,49 @@ tests:
           value: aws-sdk-default
       - isNull:
           path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_SESSION_TOKEN")]
+  - it: extracts SQL_HOST and SQL_PORT from a single-host connectAddr
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: postgres12
+                  connectAddr: "postgres-host:5432"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: postgres12
+                  connectAddr: "postgres-host:5432"
+                  databaseName: temporal_visibility
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="SQL_HOST")].value
+          value: postgres-host
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="SQL_PORT")].value
+          value: "5432"
+  - it: extracts SQL_HOST and SQL_PORT from the first host in a multi-host connectAddr
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: postgres12
+                  connectAddr: "host1:5432,host2:5432,host3:5432"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: postgres12
+                  connectAddr: "host1:5432,host2:5432,host3:5432"
+                  databaseName: temporal_visibility
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="SQL_HOST")].value
+          value: host1
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="SQL_PORT")].value
+          value: "5432"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Parse the first host from `connectAddr` for schema operations.

## Why?

For `postgres_pgx` driver we support multiple hosts for the server to connect to. For schema operations however, we must use a single host.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/634

2. How was this tested:
Tests added.
