### PR TITLE
Note and warn about the internal-frontend key change.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -143,7 +143,23 @@ helm install --repo https://go.temporal.io/helm-charts \
 - Import the dashboards listed above
 - Configure Prometheus ServiceMonitor if using Prometheus Operator (enabled via `server.metrics.serviceMonitor.enabled`)
 
-### 7. imagePullSecrets Format Change
+### 7. `internalFrontend` Key Renamed to `internal-frontend`
+
+**Previous versions:**
+- The internal frontend service was configured under `server.internalFrontend`
+
+**v1.0.0-rc.2:**
+- The key is now `server.internal-frontend` (hyphenated, matching the Temporal service name)
+
+**Migration:**
+- Rename `server.internalFrontend` to `server.internal-frontend` in your values file:
+  ```yaml
+  server:
+    internal-frontend:
+      enabled: true
+  ```
+
+### 8. imagePullSecrets Format Change
 
 **Previous versions:**
 - `imagePullSecrets` was a map: `imagePullSecrets: {}`
@@ -159,7 +175,7 @@ helm install --repo https://go.temporal.io/helm-charts \
     - name: my-registry-secret
   ```
 
-### 8. New Configuration Options
+### 9. New Configuration Options
 
 **v1.0.0-rc.2 adds the following new configuration options:**
 
@@ -180,7 +196,7 @@ server:
 
 #### Deployment Strategy
 - `server.deploymentStrategy` - Configure custom deployment strategies for server services
-- Per-service `deploymentStrategy` options (frontend, history, matching, worker, internalFrontend)
+- Per-service `deploymentStrategy` options (frontend, history, matching, worker, internal-frontend)
 
 **Example:**
 ```yaml
@@ -362,6 +378,7 @@ If you encounter issues during migration:
 | Installation | Simple install | Requires version flag and persistence config |
 | Secrets | May have used different format | Use `existingSecret` and `secretKey` |
 | imagePullSecrets | Map format `{}` | Array format `[]` |
+| internalFrontend key | `server.internalFrontend` | `server.internal-frontend` |
 
 ## Notes
 

--- a/charts/temporal/templates/_deprecations.tpl
+++ b/charts/temporal/templates/_deprecations.tpl
@@ -78,6 +78,13 @@ Call this from a top-level template so it is always evaluated during rendering.
 {{- end -}}
 
 {{/* ------------------------------------------------------------------ */}}
+{{/* internalFrontend renamed to internal-frontend                       */}}
+{{/* ------------------------------------------------------------------ */}}
+{{- if .Values.server.internalFrontend -}}
+  {{- fail "'server.internalFrontend' is no longer supported. Rename to 'server.internal-frontend'. See UPGRADING.md." -}}
+{{- end -}}
+
+{{/* ------------------------------------------------------------------ */}}
 {{/* imagePullSecrets format changed from map to array in v1.0.0-rc.2   */}}
 {{/* ------------------------------------------------------------------ */}}
 {{- if kindIs "map" .Values.imagePullSecrets -}}


### PR DESCRIPTION
## What was changed
Updated the deprecation checks to spot legacy `internalFrontend` key.

## Why?
Helps users upgrade to the new configuration.
