### PR TITLE
fix: Add Helm hooks for schema Job to fix deployment ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,14 @@ web:
       value: /custom-path
 ```
 
+### Schema Setup and Deployment Ordering
+
+By default, the schema Job uses [Helm hooks](https://helm.sh/docs/topics/charts_hooks/) (`pre-install`, `pre-upgrade`) to ensure database and Elasticsearch schemas are set up before server pods start.
+
+ArgoCD [maps Helm hooks to ArgoCD hooks](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/) (`pre-install`/`pre-upgrade` → PreSync, `post-install`/`post-upgrade` → PostSync, `hook-weight` → sync-wave), so the default should work with ArgoCD. Caveats: ArgoCD cannot distinguish install from upgrade (every operation is a sync), and delete-policy follows [ArgoCD sync semantics](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) rather than Helm's per-hook lifecycle. If any ArgoCD-native hooks are defined, all Helm hooks are ignored.
+
+For explicit control, or when using Flux or Terraform, set `useHelmHooks: false`.
+
 ## Uninstalling
 
 Note: Depending on how the persistence is configured, this may remove all of the Temporal data.

--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ By default, the schema Job uses [Helm hooks](https://helm.sh/docs/topics/charts_
 
 ArgoCD [maps Helm hooks to ArgoCD hooks](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/) (`pre-install`/`pre-upgrade` → PreSync, `post-install`/`post-upgrade` → PostSync, `hook-weight` → sync-wave), so the default should work with ArgoCD. Caveats: ArgoCD cannot distinguish install from upgrade (every operation is a sync), and delete-policy follows [ArgoCD sync semantics](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) rather than Helm's per-hook lifecycle. If any ArgoCD-native hooks are defined, all Helm hooks are ignored.
 
-For explicit control, or when using Flux or Terraform, set `useHelmHooks: false`.
+For explicit control, or when using Flux, Rancher or Terraform, set `useHelmHooks: false`.
 
 ## Uninstalling
 

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -5,9 +5,16 @@ metadata:
   name: {{ $jobName }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
-  {{- with $.Values.schema.jobAnnotations }}
+  {{- if or $.Values.schema.useHelmHooks $.Values.schema.jobAnnotations }}
   annotations:
+    {{- if $.Values.schema.useHelmHooks }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- end }}
+    {{- with $.Values.schema.jobAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   backoffLimit: {{ $.Values.schema.backoffLimit }}

--- a/charts/temporal/templates/server-secret.yaml
+++ b/charts/temporal/templates/server-secret.yaml
@@ -6,9 +6,16 @@ metadata:
   name: {{ include "temporal.persistence.secretName" (list $ $store) }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "secret") | nindent 4 }}
-  {{- with $.Values.server.secretAnnotations }}
+  {{- if or $.Values.schema.useHelmHooks $.Values.server.secretAnnotations }}
   annotations:
+    {{- if $.Values.schema.useHelmHooks }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- end }}
+    {{- with $.Values.server.secretAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/temporal/templates/shim-configmap.yaml
+++ b/charts/temporal/templates/shim-configmap.yaml
@@ -5,6 +5,12 @@ metadata:
   name: "{{ include "temporal.fullname" $ }}-shims"
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}
+  {{- if $.Values.schema.useHelmHooks }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 data:
 {{- if $.Values.shims.dockerize }}
   dockerize: |-

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -206,6 +206,80 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[*].resources.limits.memory
           value: 16Gi
+  - it: includes Helm hook annotations by default
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-visibility:3306"
+                  databaseName: temporal_visibility
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "pre-install,pre-upgrade"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: "before-hook-creation"
+  - it: excludes Helm hook annotations when useHelmHooks is false
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-visibility:3306"
+                  databaseName: temporal_visibility
+      schema:
+        useHelmHooks: false
+    asserts:
+      - isNull:
+          path: metadata.annotations
+  - it: merges Helm hook annotations with custom jobAnnotations
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-visibility:3306"
+                  databaseName: temporal_visibility
+      schema:
+        useHelmHooks: true
+        jobAnnotations:
+          custom-job-annotation: abc
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "pre-install,pre-upgrade"
+      - equal:
+          path: metadata.annotations.custom-job-annotation
+          value: abc
   - it: includes custom annotations and labels for pod and job
     set:
       server:
@@ -223,6 +297,7 @@ tests:
                   connectAddr: "temporal-visibility:3306"
                   databaseName: temporal_visibility
       schema:
+        useHelmHooks: false
         jobAnnotations:
           custom-job-annotation: abc
         podAnnotations:

--- a/charts/temporal/tests/server_secret_test.yaml
+++ b/charts/temporal/tests/server_secret_test.yaml
@@ -57,3 +57,74 @@ tests:
       - containsDocument:
           kind: Secret
           apiVersion: v1
+  - it: includes Helm hook annotations by default
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  password: "test"
+              visibility:
+                sql:
+                  password: "test"
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-default-store
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "pre-install,pre-upgrade"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-1"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: "before-hook-creation"
+  - it: excludes Helm hook annotations when useHelmHooks is false
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  password: "test"
+              visibility:
+                sql:
+                  password: "test"
+      schema:
+        useHelmHooks: false
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-default-store
+    asserts:
+      - isNull:
+          path: metadata.annotations
+  - it: merges Helm hook annotations with custom secretAnnotations
+    set:
+      server:
+        secretAnnotations:
+          custom-annotation: abc
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  password: "test"
+              visibility:
+                sql:
+                  password: "test"
+      schema:
+        useHelmHooks: true
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-default-store
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "pre-install,pre-upgrade"
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: abc

--- a/charts/temporal/tests/shim_configmap_test.yaml
+++ b/charts/temporal/tests/shim_configmap_test.yaml
@@ -1,0 +1,25 @@
+suite: test shim configmap
+templates:
+  - shim-configmap.yaml
+tests:
+  - it: includes Helm hook annotations when useHelmHooks is true
+    set:
+      schema:
+        useHelmHooks: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "pre-install,pre-upgrade"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-1"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: "before-hook-creation"
+  - it: excludes Helm hook annotations when useHelmHooks is false
+    set:
+      schema:
+        useHelmHooks: false
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -529,7 +529,7 @@ web:
   podDisruptionBudget: {}
 schema:
   # Use Helm hooks to ensure schema setup completes before server pods start.
-  # Set to false if using ArgoCD, Flux, Rancher or Terraform.
+  # Set to false if using Flux, Rancher or Terraform.
   useHelmHooks: true
   backoffLimit: 100
   ttlSecondsAfterFinished: 86400

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -528,6 +528,9 @@ web:
   minReadySeconds: 0
   podDisruptionBudget: {}
 schema:
+  # Use Helm hooks to ensure schema setup completes before server pods start.
+  # Set to false if using ArgoCD, Flux, Rancher or Terraform.
+  useHelmHooks: true
   backoffLimit: 100
   ttlSecondsAfterFinished: 86400
   jobAnnotations: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added Helm hooks (`pre-install`, `pre-upgrade`) to the schema Job and shims ConfigMap to enforce deployment ordering. The schema Job now completes before server pods are created.


## Why?
<!-- Tell your future self why have you made these changes -->

When using Elasticsearch for visibility, a race condition exists between the schema Job and server Deployments. If a server pod writes to Elasticsearch before the schema Job creates the index with correct mappings, Elasticsearch auto-creates the index with wrong field types (e.g., `WorkflowId` as `text` instead of `keyword`). The schema Job then fails with `mapper [WorkflowId] cannot be changed from type [text] to [keyword]`.

Helm hooks eliminate this race by ensuring the schema Job runs and completes before any server Deployments are created.

## Checklist
<!--- add/delete as needed --->

1. Closes #882 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- `helm unittest`
- `helm template` verified hook annotations present
- Deployed on kind cluster with PostgreSQL + Elasticsearch:
   - Verified schema Job completes before server pods start
- Deployed via ArgoCD on kind cluster:
   - verified argoCD correctly mapped Helm hooks to PreSync wave
   
<img width="1639" height="643" alt="Screenshot 2026-04-13 at 2 54 19 PM" src="https://github.com/user-attachments/assets/789a4f99-8782-4f04-a2d2-6b02b681399b" />



3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Updated `README` with a new section "Schema Setup and Deployment Ordering"
