### PR TITLE
Move namespace creation into a separate job.

### DIFF
--- a/charts/temporal/ci/postgres-values.yaml
+++ b/charts/temporal/ci/postgres-values.yaml
@@ -22,3 +22,8 @@ server:
             connectProtocol: "tcp"
             user: temporal
             password: temporal
+    namespaces:
+      create: true
+      namespace:
+        - name: test
+          retention: 1d

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -134,50 +134,7 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
-        {{- if $.Values.server.config.namespaces.create }}
-          {{- range $namespace := $.Values.server.config.namespaces.namespace }}
-        - name: create-{{ $namespace.name }}-namespace
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
-          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
-          command: ['/bin/sh','-c']
-          args: ['temporal operator namespace describe -n {{ $namespace.name }} || temporal operator namespace create -n {{ $namespace.name }}{{- if hasKey $namespace "retention" }} --retention {{ $namespace.retention }}{{- end }}']
-          env:
-            - name: TEMPORAL_ADDRESS
-              {{- if (index $.Values.server "internal-frontend").enabled }}
-              value: {{ include "temporal.fullname" $ }}-internal-frontend.{{ $.Release.Namespace }}.svc:{{ (index $.Values.server "internal-frontend").service.port }}
-              {{- else if $.Values.server.frontend.ingress.enabled }}
-              value: "{{ index $.Values.server.frontend.ingress.hosts 0 }}"
-              {{- else }}
-              value: "{{ include "temporal.fullname" $ }}-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
-              {{- end }}
-              {{- with $.Values.admintools.additionalEnv }}
-                {{- toYaml . | nindent 12 }}
-              {{- end }}
-              {{- if or $.Values.admintools.additionalEnvSecretName $.Values.admintools.additionalEnvConfigMapName }}
-          envFrom:
-              {{- with $.Values.admintools.additionalEnvSecretName }}
-            - secretRef:
-                name: {{ . }}
-              {{- end }}
-              {{- with $.Values.admintools.additionalEnvConfigMapName }}
-            - configMapRef:
-                name: {{ . }}
-              {{- end }}
-              {{- end }}
-              {{- with $.Values.admintools.additionalVolumeMounts }}
-          volumeMounts:
-                {{- toYaml . | nindent 12 }}
-              {{- end }}
-              {{- with $.Values.schema.resources }}
-          resources:
-                {{- toYaml . | nindent 12 }}
-              {{- end }}
-              {{- with $.Values.schema.containerSecurityContext }}
-          securityContext:
-                {{- toYaml . | nindent 12 }}
-              {{- end }}
-          {{- end }}
-        {{- end }}
+
       containers:
         - name: done
           image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"

--- a/charts/temporal/templates/server-namespace-job.yaml
+++ b/charts/temporal/templates/server-namespace-job.yaml
@@ -1,0 +1,107 @@
+{{- if $.Values.server.config.namespaces.create }}
+{{- $jobName := include "temporal.componentname" (list $ (printf "namespace-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-")) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}
+  labels:
+    {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
+  {{- with $.Values.schema.jobAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: {{ $.Values.schema.backoffLimit }}
+  ttlSecondsAfterFinished: {{ $.Values.schema.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      name: {{ $jobName }}
+      labels:
+        {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 8 }}
+        {{- with $.Values.schema.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $.Values.schema.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{ include "temporal.serviceAccount" $ }}
+      restartPolicy: OnFailure
+      initContainers:
+        {{- range $namespace := $.Values.server.config.namespaces.namespace }}
+        - name: create-{{ $namespace.name }}-namespace
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['/bin/sh', '-c']
+          args: ['temporal operator namespace describe -n {{ $namespace.name }} || temporal operator namespace create -n {{ $namespace.name }}{{- if hasKey $namespace "retention" }} --retention {{ $namespace.retention }}{{- end }}']
+          env:
+            - name: TEMPORAL_ADDRESS
+              {{- if (index $.Values.server "internal-frontend").enabled }}
+              value: {{ include "temporal.fullname" $ }}-internal-frontend.{{ $.Release.Namespace }}.svc:{{ (index $.Values.server "internal-frontend").service.port }}
+              {{- else if $.Values.server.frontend.ingress.enabled }}
+              value: "{{ index $.Values.server.frontend.ingress.hosts 0 }}"
+              {{- else }}
+              value: "{{ include "temporal.fullname" $ }}-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
+              {{- end }}
+            {{- with $.Values.admintools.additionalEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or $.Values.admintools.additionalEnvSecretName $.Values.admintools.additionalEnvConfigMapName }}
+          envFrom:
+            {{- with $.Values.admintools.additionalEnvSecretName }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- with $.Values.admintools.additionalEnvConfigMapName }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
+          {{- end }}
+          {{- with $.Values.admintools.additionalVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.schema.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.schema.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      containers:
+        - name: done
+          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
+          command: ['sh', '-c', 'echo "Namespace setup completed"']
+          {{- with $.Values.schema.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.schema.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with $.Values.schema.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.admintools.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.admintools.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.admintools.additionalVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -66,8 +66,6 @@ tests:
                   pluginName: mysql8
                   connectAddr: "temporal-visibility:3306"
                   databaseName: temporal_visibility
-          namespaces:
-            create: true
       admintools:
         additionalEnv:
           - name: MY_ENV_VAR
@@ -112,16 +110,6 @@ tests:
           value: env-secret
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].envFrom[1].configMapRef.name
-          value: env-configmap
-      # create-*-namespace containers
-      - equal:
-          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="MY_ENV_VAR")].value
-          value: my-value
-      - equal:
-          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].envFrom[0].secretRef.name
-          value: env-secret
-      - equal:
-          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].envFrom[1].configMapRef.name
           value: env-configmap
   - it: includes additional volumes
     set:

--- a/charts/temporal/tests/server_namespace_job_test.yaml
+++ b/charts/temporal/tests/server_namespace_job_test.yaml
@@ -1,0 +1,176 @@
+suite: test server namespace job
+templates:
+  - server-namespace-job.yaml
+tests:
+  - it: does not create the namespace job when namespaces.create is false
+    set:
+      server:
+        config:
+          namespaces:
+            create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates the namespace job when namespaces.create is true
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+                retention: 3d
+    asserts:
+      - containsDocument:
+          kind: Job
+          apiVersion: batch/v1
+  - it: creates an init container per namespace
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+                retention: 3d
+              - name: my-namespace
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: create-default-namespace
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: create-my-namespace-namespace
+  - it: sets TEMPORAL_ADDRESS to the frontend service by default
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="TEMPORAL_ADDRESS")].value
+          value: RELEASE-NAME-temporal-frontend.NAMESPACE.svc:7233
+  - it: sets TEMPORAL_ADDRESS to the internal-frontend service when enabled
+    set:
+      server:
+        internal-frontend:
+          enabled: true
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="TEMPORAL_ADDRESS")].value
+          value: RELEASE-NAME-temporal-internal-frontend.NAMESPACE.svc:7236
+  - it: includes additional environment variables
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+      admintools:
+        additionalEnv:
+          - name: MY_ENV_VAR
+            value: my-value
+        additionalEnvSecretName: env-secret
+        additionalEnvConfigMapName: env-configmap
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="MY_ENV_VAR")].value
+          value: my-value
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].envFrom[0].secretRef.name
+          value: env-secret
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].envFrom[1].configMapRef.name
+          value: env-configmap
+  - it: does not include Helm hook annotations
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+    asserts:
+      - isNull:
+          path: metadata.annotations["helm.sh/hook"]
+  - it: sets backoffLimit and ttlSecondsAfterFinished from schema values
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+      schema:
+        backoffLimit: 5
+        ttlSecondsAfterFinished: 3600
+    asserts:
+      - equal:
+          path: spec.backoffLimit
+          value: 5
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 3600
+  - it: includes custom annotations and labels for pod and job
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+      schema:
+        jobAnnotations:
+          custom-job-annotation: abc
+        podAnnotations:
+          custom-pod-annotation: def
+        podLabels:
+          custom-pod-label: ghi
+    asserts:
+      - equal:
+          path: metadata.annotations.custom-job-annotation
+          value: abc
+      - equal:
+          path: spec.template.metadata.annotations.custom-pod-annotation
+          value: def
+      - equal:
+          path: spec.template.metadata.labels.custom-pod-label
+          value: ghi
+  - it: includes resource limits and requests on init containers
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+      schema:
+        resources:
+          requests:
+            cpu: 12
+            memory: 12Gi
+          limits:
+            cpu: 16
+            memory: 16Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[*].resources.requests.cpu
+          value: 12
+      - equal:
+          path: spec.template.spec.initContainers[*].resources.requests.memory
+          value: 12Gi
+      - equal:
+          path: spec.template.spec.initContainers[*].resources.limits.cpu
+          value: 16
+      - equal:
+          path: spec.template.spec.initContainers[*].resources.limits.memory
+          value: 16Gi


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Moved namespace creation into a separate job.

## Why?
Namespace creation requires the frontend service, so now we have helm hooks preventing the services coming up until the schema job finishes the job would get stuck.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/891

2. How was this tested:
Added namespace creation to one of the CI setups.