### PR TITLE
Sanitize schema job names for chart build metadata

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -1,4 +1,4 @@
-{{- $jobName := include "temporal.componentname" (list $ (printf "schema-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-")) }}
+{{- $jobName := include "temporal.componentname" (list $ (printf "schema-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-" | replace "+" "-")) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/temporal/templates/server-namespace-job.yaml
+++ b/charts/temporal/templates/server-namespace-job.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.server.config.namespaces.create }}
-{{- $jobName := include "temporal.componentname" (list $ (printf "namespace-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-")) }}
+{{- $jobName := include "temporal.componentname" (list $ (printf "namespace-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-" | replace "+" "-")) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -23,6 +23,33 @@ tests:
       - containsDocument:
           kind: Job
           apiVersion: batch/v1
+  - it: replaces build metadata separators in the server job name
+    release:
+      name: test
+    chart:
+      version: 1.1.1+build
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-visibility:3306"
+                  databaseName: temporal_visibility
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-temporal-schema-1-1-1-build-0
+      - equal:
+          path: spec.template.metadata.name
+          value: test-temporal-schema-1-1-1-build-0
   - it: includes additional init containers
     set:
       server:

--- a/charts/temporal/tests/server_namespace_job_test.yaml
+++ b/charts/temporal/tests/server_namespace_job_test.yaml
@@ -24,6 +24,25 @@ tests:
       - containsDocument:
           kind: Job
           apiVersion: batch/v1
+  - it: replaces build metadata separators in the namespace job name
+    release:
+      name: test
+    chart:
+      version: 1.1.1+build
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-temporal-namespace-1-1-1-build-0
+      - equal:
+          path: spec.template.metadata.name
+          value: test-temporal-namespace-1-1-1-build-0
   - it: creates an init container per namespace
     set:
       server:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Sanitized the schema and namespace job names so chart versions with semver build metadata render valid Kubernetes job names. Added regression tests covering `Chart.Version` values that contain `+`.


## Why?
When the chart is deployed from a packaged version like `1.1.1+build`, that `+` was included in job names. Kubernetes job names cannot contain `+`, so installs via FluxCD could fail. This change normalizes that character to `-`.

## Checklist
<!--- add/delete as needed --->

1. Closes #899 

2. How was this tested:
`helm unittest -f tests/server_job_test.yaml -f tests/server_namespace_job_test.yaml .`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
n/a