### PR TITLE
feat: Add scheduling fields and podLabels to helm test pod

### DIFF
--- a/charts/temporal/templates/test.yaml
+++ b/charts/temporal/templates/test.yaml
@@ -4,6 +4,9 @@ metadata:
   name: "{{ include "temporal.fullname" . }}-test-cluster-health"
   labels:
     {{- include "temporal.resourceLabels" (list $ "test" "") | nindent 4 }}
+    {{- with .Values.test.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     "helm.sh/hook": test
     {{- with .Values.test.podAnnotations }}
@@ -25,6 +28,18 @@ spec:
     {{- end }}
   {{- with $.Values.imagePullSecrets }}
   imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.test.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.test.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.test.tolerations }}
+  tolerations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   restartPolicy: Never

--- a/charts/temporal/tests/test_pod_test.yaml
+++ b/charts/temporal/tests/test_pod_test.yaml
@@ -60,3 +60,74 @@ tests:
       - equal:
           path: spec.imagePullSecrets[0].name
           value: my-registry-secret
+  - it: does not set custom pod labels by default
+    asserts:
+      - notExists:
+          path: metadata.labels.team
+  - it: includes custom pod labels when specified
+    set:
+      test:
+        podLabels:
+          team: platform
+          env: prod
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.labels.env
+          value: prod
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: test
+  - it: does not set nodeSelector by default
+    asserts:
+      - notExists:
+          path: spec.nodeSelector
+  - it: sets nodeSelector when specified
+    set:
+      test:
+        nodeSelector:
+          workload: temporal
+    asserts:
+      - equal:
+          path: spec.nodeSelector.workload
+          value: temporal
+  - it: does not set tolerations by default
+    asserts:
+      - notExists:
+          path: spec.tolerations
+  - it: sets tolerations when specified
+    set:
+      test:
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: temporal
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.tolerations[0].key
+          value: dedicated
+      - equal:
+          path: spec.tolerations[0].effect
+          value: NoSchedule
+  - it: does not set affinity by default
+    asserts:
+      - notExists:
+          path: spec.affinity
+  - it: sets affinity when specified
+    set:
+      test:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values: [amd64]
+    asserts:
+      - equal:
+          path: spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: kubernetes.io/arch

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -547,4 +547,8 @@ shims:
   elasticsearchTool: true
 test:
   podAnnotations: {}
+  podLabels: {}
   resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
## Summary

- Expose `nodeSelector`, `tolerations`, `affinity`, and `podLabels` on the helm test pod (`templates/test.yaml`), mirroring the pattern used by `admintools-deployment.yaml`, `server-deployment.yaml`, and `web-deployment.yaml`.
- Add empty defaults under the existing `test:` block in `values.yaml` so the change is fully backwards-compatible (no rendered output diff for existing installs).
- Add helm-unittest coverage for default and populated cases of each new field (8 new test cases, 15 total in `test_pod_test.yaml`).

Closes #908

## Why

When every node in a cluster carries taints (dedicated node pools, GPU pools, platform-managed pools), the helm test pod has nothing to tolerate them and remains `Pending`, so `helm test` hangs and eventually fails. This is a common failure mode when running Temporal under Flux `HelmRelease` or Argo CD with a post-deploy test gate. Every other workload in the chart already exposes these scheduling fields , the test pod was the lone outlier.

Per the contribution guide, this falls under **Resource management** (scheduling constraints required by platform policies) and **CI/CD system compatibility** (Flux / Argo CD running `helm test`).