### PR TITLE
Readiness auto-switch from grpc to tcpsocket probe when using TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,10 @@ TEMPORAL_AUTH_CLIENT_SECRET: xxxxxxxxxxxxxxx
 
 Reference: <https://docs.temporal.io/references/web-ui-server-env-vars>
 
+### Readiness probes
+
+The frontend and internal-frontend Deployments default to a `tcpSocket` readinessProbe, which works regardless of whether TLS is configured. If you are not using TLS and want a richer health check, you can opt into a gRPC probe by uncommenting the example block at `server.frontend.readinessProbe` (or `server.internal-frontend.readinessProbe`) in `values.yaml`. gRPC probes are not compatible with TLS — see [kubernetes/enhancements#4939](https://github.com/kubernetes/enhancements/issues/4939).
+
 ## Play With It
 
 ### Exploring Your Cluster

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -120,9 +120,27 @@ spec:
             tcpSocket:
               port: rpc
           {{- end }}
+          {{- /* gRPC probes don't support TLS; they are switched to tcpSocket when TLS is configured. */ -}}
+          {{- $tlsKey := "" }}
+          {{- if eq $service "frontend" }}
+          {{- $tlsKey = "frontend" }}
+          {{- end }}
+          {{- if eq $service "internal-frontend" }}
+          {{- $tlsKey = "internode" }}
+          {{- end }}
+          {{- $tlsCertFile := "" }}
+          {{- if $tlsKey }}
+          {{- $tlsCertFile = dig "tls" $tlsKey "server" "certFile" "" $.Values.server.config }}
+          {{- end }}
+          {{- if $tlsCertFile }}
+          readinessProbe:
+            tcpSocket:
+              port: rpc
+          {{- else }}
           {{- with default $.Values.server.readinessProbe $serviceValues.readinessProbe }}
           readinessProbe:
           {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             - name: config

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -120,27 +120,15 @@ spec:
             tcpSocket:
               port: rpc
           {{- end }}
-          {{- /* gRPC probes don't support TLS; they are switched to tcpSocket when TLS is configured. */ -}}
-          {{- $tlsKey := "" }}
-          {{- if eq $service "frontend" }}
-          {{- $tlsKey = "frontend" }}
-          {{- end }}
-          {{- if eq $service "internal-frontend" }}
-          {{- $tlsKey = "internode" }}
-          {{- end }}
-          {{- $tlsCertFile := "" }}
-          {{- if $tlsKey }}
-          {{- $tlsCertFile = dig "tls" $tlsKey "server" "certFile" "" $.Values.server.config }}
-          {{- end }}
-          {{- if $tlsCertFile }}
+          {{- /* Default to tcpSocket (works with TLS); users may override per-service via server.<svc>.readinessProbe. */ -}}
+          {{- $resolvedProbe := default $.Values.server.readinessProbe $serviceValues.readinessProbe }}
+          {{- if $resolvedProbe }}
+          readinessProbe:
+          {{- toYaml $resolvedProbe | nindent 12 }}
+          {{- else if or (eq $service "frontend") (eq $service "internal-frontend") }}
           readinessProbe:
             tcpSocket:
               port: rpc
-          {{- else }}
-          {{- with default $.Values.server.readinessProbe $serviceValues.readinessProbe }}
-          readinessProbe:
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: config

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -125,7 +125,7 @@ spec:
           {{- if $resolvedProbe }}
           readinessProbe:
           {{- toYaml $resolvedProbe | nindent 12 }}
-          {{- else if or (eq $service "frontend") (eq $service "internal-frontend") }}
+          {{- else if ne $service "worker" }}
           readinessProbe:
             tcpSocket:
               port: rpc

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -320,6 +320,48 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
           value: rpc
+  - it: frontend with TLS configured switches readinessProbe to tcpSocket
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        config:
+          tls:
+            frontend:
+              server:
+                certFile: /etc/certs/frontend.crt
+                keyFile: /etc/certs/frontend.key
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.grpc
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: rpc
+  - it: internal-frontend with internode TLS switches readinessProbe to tcpSocket
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-internal-frontend")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        internal-frontend:
+          enabled: true
+        config:
+          tls:
+            internode:
+              server:
+                certFile: /etc/certs/internode.crt
+                keyFile: /etc/certs/internode.key
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.grpc
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: rpc
 
   - it: additional environment variables are set on all services
     template: templates/server-deployment.yaml

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -320,27 +320,19 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
           value: rpc
-  - it: frontend with TLS configured switches readinessProbe to tcpSocket
+  - it: frontend readinessProbe defaults to tcpSocket
     template: templates/server-deployment.yaml
     documentSelector:
       path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
       value: Deployment
       matchMany: true
-    set:
-      server:
-        config:
-          tls:
-            frontend:
-              server:
-                certFile: /etc/certs/frontend.crt
-                keyFile: /etc/certs/frontend.key
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe.grpc
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
           value: rpc
-  - it: internal-frontend with internode TLS switches readinessProbe to tcpSocket
+  - it: internal-frontend readinessProbe defaults to tcpSocket
     template: templates/server-deployment.yaml
     documentSelector:
       path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-internal-frontend")].kind'
@@ -350,12 +342,6 @@ tests:
       server:
         internal-frontend:
           enabled: true
-        config:
-          tls:
-            internode:
-              server:
-                certFile: /etc/certs/internode.crt
-                keyFile: /etc/certs/internode.key
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe.grpc

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -271,7 +271,7 @@ tests:
       - equal:
           path: spec.strategy.rollingUpdate.maxUnavailable
           value: 0
-  - it: readinessProbe defaults to empty
+  - it: worker readinessProbe defaults to empty
     template: templates/server-deployment.yaml
     documentSelector:
       path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-worker")].kind'
@@ -280,6 +280,22 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe
+  - it: non-worker readinessProbe defaults to tcpSocket
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name != "RELEASE-NAME-temporal-worker")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        internal-frontend:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.grpc
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: rpc
   - it: readinessProbe is set for frontend service
     template: templates/server-deployment.yaml
     documentSelector:
@@ -317,34 +333,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
           value: 300
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
-          value: rpc
-  - it: frontend readinessProbe defaults to tcpSocket
-    template: templates/server-deployment.yaml
-    documentSelector:
-      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend")].kind'
-      value: Deployment
-      matchMany: true
-    asserts:
-      - notExists:
-          path: spec.template.spec.containers[0].readinessProbe.grpc
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
-          value: rpc
-  - it: internal-frontend readinessProbe defaults to tcpSocket
-    template: templates/server-deployment.yaml
-    documentSelector:
-      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-internal-frontend")].kind'
-      value: Deployment
-      matchMany: true
-    set:
-      server:
-        internal-frontend:
-          enabled: true
-    asserts:
-      - notExists:
-          path: spec.template.spec.containers[0].readinessProbe.grpc
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
           value: rpc

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -259,11 +259,13 @@ server:
       membershipAppProtocol: tcp
       httpPort: 7243
       httpAppProtocol: http
-    # Auto-replaced with a tcpSocket probe when server.config.tls.frontend is set (kubernetes/enhancements#4939).
-    readinessProbe:
-      grpc:
-        port: 7233
-        service: temporal.api.workflowservice.v1.WorkflowService
+    # Defaults to a tcpSocket probe; uncomment below for a gRPC probe.
+    # gRPC probes don't yet support TLS (kubernetes/enhancements#4939), so opt in only when TLS is off.
+    readinessProbe: {}
+    # readinessProbe:
+    #   grpc:
+    #     port: 7233
+    #     service: temporal.api.workflowservice.v1.WorkflowService
     ingress:
       enabled: false
       # className:
@@ -313,11 +315,13 @@ server:
       membershipAppProtocol: tcp
       httpPort: 7246
       httpAppProtocol: http
-    # Auto-replaced with a tcpSocket probe when server.config.tls.internode is set (kubernetes/enhancements#4939).
-    readinessProbe:
-      grpc:
-        port: 7236
-        service: temporal.api.workflowservice.v1.WorkflowService
+    # Defaults to a tcpSocket probe; uncomment below for a gRPC probe.
+    # gRPC probes don't yet support TLS (kubernetes/enhancements#4939), so opt in only when TLS is off.
+    readinessProbe: {}
+    # readinessProbe:
+    #   grpc:
+    #     port: 7236
+    #     service: temporal.api.workflowservice.v1.WorkflowService
     metrics:
       annotations:
         enabled: true

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -259,6 +259,7 @@ server:
       membershipAppProtocol: tcp
       httpPort: 7243
       httpAppProtocol: http
+    # Auto-replaced with a tcpSocket probe when server.config.tls.frontend is set (kubernetes/enhancements#4939).
     readinessProbe:
       grpc:
         port: 7233
@@ -312,6 +313,7 @@ server:
       membershipAppProtocol: tcp
       httpPort: 7246
       httpAppProtocol: http
+    # Auto-replaced with a tcpSocket probe when server.config.tls.internode is set (kubernetes/enhancements#4939).
     readinessProbe:
       grpc:
         port: 7236


### PR DESCRIPTION
## What was changed
When TLS is enabled, switch frontend/internode to use tcpSocket readiness probes instead of grpc probes

## Why?
grpc readiness probes do not support TLS credentials: kubernetes/enhancements#4939

## Checklist

1. Closes #894 

2. How was this tested:
- Ran tests
- Added tests
- Sample kind cluster run

3. Any docs updates needed?
N/A