### PR TITLE
add HorizontalPodAutoscaler support for server services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Temporal Helm Chart
+
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftemporalio%2Ftemporal-helm-charts.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftemporalio%2Ftemporal-helm-charts?ref=badge_shield)
 
 > **For users upgrading from 0.x releases:** Please see [UPGRADING.md](UPGRADING.md) for important migration information and breaking changes.
@@ -16,8 +17,9 @@ This Helm Chart code is tested by a dedicated test pipeline. It is also used ext
 ## Prerequisites
 
 This sequence assumes
-* that your system is configured to access a kubernetes cluster (e. g. [AWS EKS](https://aws.amazon.com/eks/), [kind](https://kind.sigs.k8s.io/), or [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/))
-* that your machine has the following installed and able to access your cluster:
+
+- that your system is configured to access a kubernetes cluster (e. g. [AWS EKS](https://aws.amazon.com/eks/), [kind](https://kind.sigs.k8s.io/), or [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/))
+- that your machine has the following installed and able to access your cluster:
   - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
   - [Helm v3](https://helm.sh)
 
@@ -42,6 +44,7 @@ The sections that follow describe various deployment configurations using persis
 ### Persistence Configuration
 
 Temporal requires persistence stores for:
+
 - **Default store**: Stores workflow execution data (history, tasks, etc.)
 - **Visibility store**: Stores workflow visibility/search data
 
@@ -61,7 +64,7 @@ server:
           sql:
             createDatabase: true
             manageSchema: true
-            pluginName: mysql8  # or postgres12, postgres12_pgx
+            pluginName: mysql8 # or postgres12, postgres12_pgx
             driverName: mysql8
             databaseName: temporal
             connectAddr: "mysql.example.com:3306"
@@ -91,6 +94,7 @@ server:
 ```
 
 **Key points:**
+
 - Driver is determined by which key is present (`sql:`, `cassandra:`, or `elasticsearch:`)
 - **Helm-specific fields** (stripped before rendering to server config):
   - `createDatabase`: If `true`, the chart will create the database/keyspace if it doesn't exist (default: `true`)
@@ -191,7 +195,6 @@ extraObjects:
           key: prod/temporal/db
           property: password
 ```
-
 
 #### Example with SealedSecrets
 
@@ -390,11 +393,12 @@ helm install --repo https://go.temporal.io/helm-charts -f elasticsearch.values.y
 
 By default archival is disabled. You can enable it with one of the three provider options:
 
-* File Store, values file `values/values.archival.filestore.yaml`
-* S3, values file `values/values.archival.s3.yaml`
-* GCloud, values file `values/values.archival.gcloud.yaml`
+- File Store, values file `values/values.archival.filestore.yaml`
+- S3, values file `values/values.archival.s3.yaml`
+- GCloud, values file `values/values.archival.gcloud.yaml`
 
 So to use the minimal command again and to enable archival with file store provider:
+
 ```bash
 helm install --repo https://go.temporal.io/helm-charts -f values/values.archival.filestore.yaml temporal temporal --timeout 900s
 ```
@@ -424,6 +428,53 @@ TEMPORAL_AUTH_CLIENT_SECRET: xxxxxxxxxxxxxxx
 ```
 
 Reference: <https://docs.temporal.io/references/web-ui-server-env-vars>
+
+### Enable Autoscaling (HPA)
+
+By default all server services run with a static replica count. You can enable a `HorizontalPodAutoscaler` (autoscaling/v2) per service to let Kubernetes scale replicas automatically based on CPU or memory utilisation.
+
+Autoscaling is supported for `frontend`, `internal-frontend`, `history`, `matching`, and `worker`. When enabled, `spec.replicas` is omitted from the Deployment so the HPA is the sole replica controller.
+
+```yaml
+server:
+  frontend:
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 70 # optional, omit to disable memory scaling
+      behavior: # optional, tune scale-up/down behaviour
+        scaleUp:
+          stabilizationWindowSeconds: 60
+          policies:
+            - type: Pods
+              value: 2
+              periodSeconds: 60
+        scaleDown:
+          stabilizationWindowSeconds: 300
+      customMetrics: [] # optional, any extra autoscaling/v2 metric objects
+  history:
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+  matching:
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+  worker:
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+```
+
+> **Note:** To use memory-based autoscaling, ensure your pods have `resources.requests.memory` set, otherwise the HPA cannot calculate utilisation.
 
 ## Play With It
 
@@ -549,25 +600,29 @@ and navigate to http://127.0.0.1:8080 in your browser.
 
 There are a number of preconfigured dashboards that you may import into your Grafana installation.
 
-* [Server-General](https://raw.githubusercontent.com/temporalio/dashboards/helm/server/server-general.json)
-* [SDK-General](https://raw.githubusercontent.com/temporalio/dashboards/helm/sdk/sdk-general.json)
-* [Misc - Advanced Visibility Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/advanced-visibility-specific.json)
-* [Misc - Cluster Monitoring Kubernetes](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/clustermonitoring-kubernetes.json)
-* [Misc - Frontend Service Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/frontend-service-specific.json)
-* [Misc - History Service Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/history-service-specific.json)
-* [Misc - Matching Service Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/matching-service-specific.json)
-* [Misc - Worker Service Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/worker-service-specific.json)
+- [Server-General](https://raw.githubusercontent.com/temporalio/dashboards/helm/server/server-general.json)
+- [SDK-General](https://raw.githubusercontent.com/temporalio/dashboards/helm/sdk/sdk-general.json)
+- [Misc - Advanced Visibility Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/advanced-visibility-specific.json)
+- [Misc - Cluster Monitoring Kubernetes](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/clustermonitoring-kubernetes.json)
+- [Misc - Frontend Service Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/frontend-service-specific.json)
+- [Misc - History Service Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/history-service-specific.json)
+- [Misc - Matching Service Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/matching-service-specific.json)
+- [Misc - Worker Service Specific](https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/worker-service-specific.json)
 
 ### Updating Dynamic Configs
 
 By default dynamic config is empty, if you want to override some properties for your cluster, you should:
+
 1. Create a yaml file with your config (for example dc.yaml).
 2. Populate it with some values under server.dynamicConfig prefix (use the sample provided at `values/values.dynamic_config.yaml` as a starting point)
 3. Install your helm configuration:
+
 ```bash
 helm install --repo https://go.temporal.io/helm-charts -f values/values.dynamic_config.yaml temporal temporal --timeout 900s
 ```
+
 Note that if you already have a running cluster you can use the "helm upgrade" command to change dynamic config values:
+
 ```bash
 helm upgrade --repo https://go.temporal.io/helm-charts -f values/values.dynamic_config.yaml temporal temporal --timeout 900s
 ```
@@ -579,6 +634,7 @@ If a rolling upgrade is not desirable, you can also generate the ConfigMap file 
 ```bash
 kubectl apply -f dynamicconfigmap.yaml
 ```
+
 You can use helm upgrade with the "--dry-run" option to generate the content for the dynamicconfigmap.yaml.
 
 The dynamic-config ConfigMap is referenced as a mounted volume within the Temporal Containers, so any applied change will be automatically picked up by all pods within a few minutes without the need for pod recycling. See k8S documentation (https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically) for more details on how this works.
@@ -617,8 +673,9 @@ helm uninstall temporal
 To upgrade your cluster, upgrade your database schema (if the release includes schema changes), and then use `helm upgrade` command to perform a rolling upgrade of your installation.
 
 Note:
-* Not supported: running newer binaries with an older schema.
-* Supported: downgrading binaries – running older binaries with a newer schema.
+
+- Not supported: running newer binaries with an older schema.
+- Supported: downgrading binaries – running older binaries with a newer schema.
 
 # Contributing
 
@@ -628,6 +685,6 @@ Please see our [CONTRIBUTING guide](CONTRIBUTING.md).
 
 Many thanks to [Banzai Cloud](https://github.com/banzaicloud) whose [Cadence Helm Charts](https://github.com/banzaicloud/banzai-charts/tree/master/cadence) heavily inspired this work.
 
-
 ## License
+
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftemporalio%2Ftemporal-helm-charts.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftemporalio%2Ftemporal-helm-charts?ref=badge_large)

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -14,7 +14,9 @@ metadata:
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "deployment") | nindent 4 }}
 spec:
+  {{- if not (dig "autoscaling" "enabled" false $serviceValues) }}
   replicas: {{ default $.Values.server.replicaCount $serviceValues.replicaCount }}
+  {{- end }}
   {{- with (default $.Values.server.deploymentStrategy $serviceValues.deploymentStrategy) }}
   strategy:
   {{- toYaml . | nindent 4 }}

--- a/charts/temporal/templates/server-hpa.yaml
+++ b/charts/temporal/templates/server-hpa.yaml
@@ -1,0 +1,47 @@
+{{- if $.Values.server.enabled }}
+{{- range $service := (list "frontend" "internal-frontend" "history" "matching" "worker") }}
+{{- $serviceValues := index $.Values.server $service }}
+{{- if and $serviceValues.enabled (dig "autoscaling" "enabled" false $serviceValues) }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "temporal.componentname" (list $ $service) }}
+  annotations:
+    {{- include "temporal.resourceAnnotations" (list $ $service "hpa") | nindent 4 }}
+  labels:
+    {{- include "temporal.resourceLabels" (list $ $service "hpa") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "temporal.componentname" (list $ $service) }}
+  minReplicas: {{ $serviceValues.autoscaling.minReplicas }}
+  maxReplicas: {{ $serviceValues.autoscaling.maxReplicas }}
+  metrics:
+    {{- if $serviceValues.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $serviceValues.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $serviceValues.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $serviceValues.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with $serviceValues.autoscaling.customMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $serviceValues.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -310,9 +310,9 @@ tests:
       server:
         history:
           readinessProbe:
-             initialDelaySeconds: 300
-             tcpSocket:
-               port: rpc
+            initialDelaySeconds: 300
+            tcpSocket:
+              port: rpc
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
@@ -324,7 +324,7 @@ tests:
   - it: additional environment variables are set on all services
     template: templates/server-deployment.yaml
     documentSelector:
-      path: '$.kind'
+      path: "$.kind"
       value: Deployment
       matchMany: true
     set:
@@ -400,3 +400,116 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: TEMPORAL_SECONDARY_VISIBILITY_STORE_PASSWORD
+
+  - it: omits replicas when autoscaling is enabled
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    set:
+      server:
+        frontend:
+          autoscaling:
+            enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: sets replicas when autoscaling is disabled
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    set:
+      server:
+        frontend:
+          replicaCount: 3
+          autoscaling:
+            enabled: false
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: applies per-service replicaCount overrides alongside global replicaCount
+    template: templates/server-deployment.yaml
+    set:
+      server:
+        replicaCount: 4
+        frontend:
+          replicaCount: 8
+        history:
+          replicaCount: 8
+        matching:
+          replicaCount: 4
+        worker:
+          replicaCount: 8
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 8
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-frontend
+      - equal:
+          path: spec.replicas
+          value: 8
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-history
+      - equal:
+          path: spec.replicas
+          value: 4
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-matching
+      - equal:
+          path: spec.replicas
+          value: 8
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-worker
+
+  - it: global replicaCount applies to services without a per-service override
+    template: templates/server-deployment.yaml
+    set:
+      server:
+        replicaCount: 4
+        frontend:
+          replicaCount: 8
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 4
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-history
+      - equal:
+          path: spec.replicas
+          value: 4
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-matching
+      - equal:
+          path: spec.replicas
+          value: 4
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-worker
+
+  - it: HPA takes precedence over replicaCount when both are set
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    set:
+      server:
+        frontend:
+          replicaCount: 8
+          autoscaling:
+            enabled: true
+            minReplicas: 2
+            maxReplicas: 10
+    asserts:
+      - notExists:
+          path: spec.replicas

--- a/charts/temporal/tests/server_hpa_test.yaml
+++ b/charts/temporal/tests/server_hpa_test.yaml
@@ -1,0 +1,224 @@
+suite: test server hpa
+templates:
+  - server-hpa.yaml
+set:
+  server:
+    enabled: true
+    config:
+      persistence:
+        defaultStore: default
+        visibilityStore: visibility
+        datastores:
+          default:
+            sql:
+              password: "secret"
+          visibility:
+            sql:
+              password: "secret"
+    frontend:
+      enabled: true
+    history:
+      enabled: true
+    matching:
+      enabled: true
+    worker:
+      enabled: true
+
+tests:
+  - it: does not create HPA by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates HPA for frontend when enabled
+    set:
+      server.frontend.autoscaling.enabled: true
+    asserts:
+      - containsDocument:
+          kind: HorizontalPodAutoscaler
+          apiVersion: autoscaling/v2
+          name: RELEASE-NAME-temporal-frontend
+
+  - it: creates HPA for history when enabled
+    set:
+      server.history.autoscaling.enabled: true
+    asserts:
+      - containsDocument:
+          kind: HorizontalPodAutoscaler
+          apiVersion: autoscaling/v2
+          name: RELEASE-NAME-temporal-history
+
+  - it: creates HPA for matching when enabled
+    set:
+      server.matching.autoscaling.enabled: true
+    asserts:
+      - containsDocument:
+          kind: HorizontalPodAutoscaler
+          apiVersion: autoscaling/v2
+          name: RELEASE-NAME-temporal-matching
+
+  - it: creates HPA for worker when enabled
+    set:
+      server.worker.autoscaling.enabled: true
+    asserts:
+      - containsDocument:
+          kind: HorizontalPodAutoscaler
+          apiVersion: autoscaling/v2
+          name: RELEASE-NAME-temporal-worker
+
+  - it: creates HPAs for all services when all enabled
+    set:
+      server.frontend.autoscaling.enabled: true
+      server.history.autoscaling.enabled: true
+      server.matching.autoscaling.enabled: true
+      server.worker.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: sets default minReplicas and maxReplicas
+    set:
+      server.frontend.autoscaling.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+
+  - it: respects custom minReplicas and maxReplicas
+    set:
+      server.frontend.autoscaling.enabled: true
+      server.frontend.autoscaling.minReplicas: 2
+      server.frontend.autoscaling.maxReplicas: 10
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  - it: sets CPU metric by default
+    set:
+      server.frontend.autoscaling.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 80
+
+  - it: sets memory metric when configured
+    set:
+      server.frontend.autoscaling.enabled: true
+      server.frontend.autoscaling.targetMemoryUtilizationPercentage: 75
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: sets scaleTargetRef to the correct deployment
+    set:
+      server.worker.autoscaling.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-worker
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.apiVersion
+          value: apps/v1
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-temporal-worker
+
+  - it: sets scale behavior when configured
+    set:
+      server.frontend.autoscaling.enabled: true
+      server.frontend.autoscaling.behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+
+  - it: sets scaleUp behavior when configured
+    set:
+      server.frontend.autoscaling.enabled: true
+      server.frontend.autoscaling.behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 60
+          policies:
+            - type: Pods
+              value: 2
+              periodSeconds: 60
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 60
+      - equal:
+          path: spec.behavior.scaleUp.policies[0].type
+          value: Pods
+      - equal:
+          path: spec.behavior.scaleUp.policies[0].value
+          value: 2
+
+  - it: sets both scaleUp and scaleDown behavior when configured
+    set:
+      server.frontend.autoscaling.enabled: true
+      server.frontend.autoscaling.behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 60
+        scaleDown:
+          stabilizationWindowSeconds: 300
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 60
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+
+  - it: does not create HPA when service is disabled
+    set:
+      server.frontend.enabled: false
+      server.frontend.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -306,6 +306,14 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: ""
+      customMetrics: []
+      behavior: {}
   internal-frontend:
     # Enable this to create internal-frontend
     enabled: false
@@ -344,6 +352,14 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: ""
+      customMetrics: []
+      behavior: {}
   history:
     enabled: true
     service:
@@ -374,6 +390,14 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: ""
+      customMetrics: []
+      behavior: {}
   matching:
     enabled: true
     service:
@@ -404,6 +428,14 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: ""
+      customMetrics: []
+      behavior: {}
   worker:
     enabled: true
     service:
@@ -434,6 +466,14 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: ""
+      customMetrics: []
+      behavior: {}
 admintools:
   enabled: true
   image:


### PR DESCRIPTION
  ## What was changed
  - Added `charts/temporal/templates/server-hpa.yaml` to render a
  `HorizontalPodAutoscaler` (autoscaling/v2) for `frontend`,
  `internal-frontend`, `history`, `matching`, and `worker` services
  - Added `autoscaling` config block to each server service in `values.yaml`
  (disabled by default — no breaking change)
  - Updated `server-deployment.yaml` to omit `spec.replicas` when autoscaling is
   enabled, preventing conflicts between the HPA and the Deployment controller
  - Updated `README.md` with an autoscaling configuration section including CPU,
   memory, behavior, and custom metrics examples

  ## Why?
  Without HPA support, scaling Temporal server services requires manual
  `replicaCount` changes. This change allows operators to enable
  CPU/memory-based autoscaling per service without any custom resource
  workarounds. As Temporal workloads are often bursty, HPA support allows
  running cost-efficiently without over-provisioning.


  1. Closes #911

  2. How was this tested:
  - `helm unittest charts/temporal` passes all 149 tests
  - New test suite `tests/server_hpa_test.yaml` covers: HPA disabled by default,
   per-service creation, minReplicas/maxReplicas, CPU and memory metrics,
  scaleTargetRef correctness, scaleUp behavior, scaleDown behavior, combined
  scaleUp+scaleDown, and skipping when the service itself is disabled
  - `tests/server_deployment_test.yaml` extended to verify: `spec.replicas` is
  omitted when autoscaling is enabled, per-service `replicaCount` overrides
  alongside a global `replicaCount`, global fallback for services without a
  per-service override, and HPA takes precedence when both `autoscaling.enabled:
   true` and `replicaCount` are set simultaneously

  3. Any docs updates needed?
  - `README.md` updated with a new "Enable Autoscaling (HPA)" section
  documenting all available values