### PR TITLE
update - fix: wire Cassandra mTLS client cert/key env vars in admintools-env template

### DIFF
--- a/charts/temporal/templates/_admintools-env.yaml
+++ b/charts/temporal/templates/_admintools-env.yaml
@@ -23,6 +23,12 @@
 - name: CASSANDRA_TLS_DISABLE_HOST_VERIFICATION
   value: {{ not .enableHostVerification | quote }}
     {{- end }}
+    {{- if and .certFile .keyFile }}
+- name: CASSANDRA_TLS_CERT
+  value: {{ .certFile }}
+- name: CASSANDRA_TLS_KEY
+  value: {{ .keyFile }}
+    {{- end }}
   {{- end }}
 {{- else if eq $store.driver "sql" -}}
 - name: SQL_PLUGIN

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -566,6 +566,105 @@ tests:
           value: aws-sdk-default
       - isNull:
           path: spec.template.spec.initContainers[?(@.name=="manage-schema-visibility-store")].env[?(@.name=="AWS_SESSION_TOKEN")]
+  - it: sets Cassandra TLS environment variables with all options
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                cassandra:
+                  hosts: "cassandra.default.svc.cluster.local"
+                  port: 9042
+                  keyspace: temporal
+                  user: "user"
+                  password: "password"
+                  tls:
+                    enabled: true
+                    caFile: /etc/tls/ca.crt
+                    certFile: /etc/tls/client.crt
+                    keyFile: /etc/tls/client.key
+                    enableHostVerification: false
+              visibility:
+                cassandra:
+                  hosts: "cassandra.default.svc.cluster.local"
+                  port: 9042
+                  keyspace: temporal_visibility
+                  user: "user"
+                  password: "password"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="CASSANDRA_ENABLE_TLS")].value
+          value: "true"
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="CASSANDRA_TLS_CA")].value
+          value: /etc/tls/ca.crt
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="CASSANDRA_TLS_CERT")].value
+          value: /etc/tls/client.crt
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="CASSANDRA_TLS_KEY")].value
+          value: /etc/tls/client.key
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="CASSANDRA_TLS_DISABLE_HOST_VERIFICATION")].value
+          value: "true"
+  - it: sets Cassandra TLS enabled without optional fields
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                cassandra:
+                  hosts: "cassandra.default.svc.cluster.local"
+                  port: 9042
+                  keyspace: temporal
+                  user: "user"
+                  password: "password"
+                  tls:
+                    enabled: true
+              visibility:
+                cassandra:
+                  hosts: "cassandra.default.svc.cluster.local"
+                  port: 9042
+                  keyspace: temporal_visibility
+                  user: "user"
+                  password: "password"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="CASSANDRA_ENABLE_TLS")].value
+          value: "true"
+      - isNull:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="CASSANDRA_TLS_CA")]
+      - isNull:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="CASSANDRA_TLS_DISABLE_HOST_VERIFICATION")]
+  - it: inverts enableHostVerification for Cassandra TLS
+    set:
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                cassandra:
+                  hosts: "cassandra.default.svc.cluster.local"
+                  port: 9042
+                  keyspace: temporal
+                  user: "user"
+                  password: "password"
+                  tls:
+                    enabled: true
+                    enableHostVerification: true
+              visibility:
+                cassandra:
+                  hosts: "cassandra.default.svc.cluster.local"
+                  port: 9042
+                  keyspace: temporal_visibility
+                  user: "user"
+                  password: "password"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="manage-schema-default-store")].env[?(@.name=="CASSANDRA_TLS_DISABLE_HOST_VERIFICATION")].value
+          value: "false"
   - it: extracts SQL_HOST and SQL_PORT from a single-host connectAddr
     set:
       server:

--- a/charts/temporal/values/values.cassandra.yaml
+++ b/charts/temporal/values/values.cassandra.yaml
@@ -11,7 +11,7 @@ server:
       datastores:
         default:
           cassandra:
-            hosts: "cassandra.default.svc.cluster.local"  # or "host1,host2"
+            hosts: "cassandra.default.svc.cluster.local" # or "host1,host2"
             port: 9042
             keyspace: temporal
             user: "user"
@@ -24,6 +24,12 @@ server:
               default:
                 consistency: "local_quorum"
                 serialConsistency: "local_serial"
+            # tls:
+            #   enabled: true
+            #   caFile: /path/to/ca.crt
+            #   certFile: /path/to/client.crt
+            #   keyFile: /path/to/client.key
+            #   enableHostVerification: true
           # faultInjection:
           #   targets:
           #     dataStores:
@@ -51,4 +57,3 @@ server:
             connectProtocol: "tcp"
             user: temporal
             password: password
-


### PR DESCRIPTION
The Cassandra TLS block in _admintools-env.yaml set CASSANDRA_TLS_CA when
  caFile is configured but never set CASSANDRA_TLS_CERT / CASSANDRA_TLS_KEY even
   when certFile / keyFile are present in the persistence TLS config. This made
  mTLS impossible for the schema migrator job regardless of values.

  SQL and Elasticsearch blocks in the same template already handle certFile/
  keyFile correctly. This aligns Cassandra with the same pattern.

  The env var names match what temporal-cassandra-tool reads, confirmed in
  tools/cassandra/handler.go and common/auth/tls.go in the temporal repo.

  Fixes #886

  ## What was changed

  Added `CASSANDRA_TLS_CERT` and `CASSANDRA_TLS_KEY` env vars to the Cassandra
  TLS block in `charts/temporal/templates/_admintools-env.yaml`, mirroring the
  pattern already used for SQL and Elasticsearch.

  ## Why?

  The schema migrator job could not use mTLS to connect to Cassandra even when
   wired them into env vars. `temporal-cassandra-tool` already supports these
  env vars, so the fix is entirely in the Helm template.

  ## Checklist

  1. Closes #886

  2. How was this tested:
     Verified with `helm template` across three scenarios:
     - **No TLS** — no TLS env vars rendered (no regression)
     - **One-way TLS** (`caFile` only) — existing vars render exactly as before
  (no regression)
     - **mTLS** (`certFile` + `keyFile`) — `CASSANDRA_TLS_CERT` and
  `CASSANDRA_TLS_KEY` correctly appear in the schema job output

  3. Any docs updates needed?
     No — the existing values comments for `certFile`/`keyFile` under the
  Cassandra TLS config are sufficient.
  
  
  There was some issue with earlier PR and I was not able to make CLA work. Hence I closed that PR and opened this.
  Here is the OLD pr https://github.com/temporalio/helm-charts/pull/906
  It was reviewed by @stuart-wells 
  
In this PR i have fixed all the comments from @stuart-wells 
  