### PR TITLE
feat(web): add web.temporalAddress to override TEMPORAL_ADDRESS env var

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -61,6 +61,36 @@ and we want to make sure that the component is included in the name.
 {{- end -}}
 
 {{/*
+Frontend service address as a short in-cluster name (host:port).
+*/}}
+{{- define "temporal.frontendAddress" -}}
+{{- printf "%s-frontend:%d" (include "temporal.fullname" .) (.Values.server.frontend.service.port | int) -}}
+{{- end -}}
+
+{{/*
+Frontend service address as a fully-qualified cluster DNS name (host.namespace.svc:port).
+*/}}
+{{- define "temporal.frontendAddress.fqdn" -}}
+{{- printf "%s-frontend.%s.svc:%d" (include "temporal.fullname" .) .Release.Namespace (.Values.server.frontend.service.port | int) -}}
+{{- end -}}
+
+{{/*
+Internal-frontend service address as a short in-cluster name (host:port).
+*/}}
+{{- define "temporal.internalFrontendAddress" -}}
+{{- $internalFrontend := index .Values.server "internal-frontend" -}}
+{{- printf "%s-internal-frontend:%d" (include "temporal.fullname" .) ($internalFrontend.service.port | int) -}}
+{{- end -}}
+
+{{/*
+Internal-frontend service address as a fully-qualified cluster DNS name (host.namespace.svc:port).
+*/}}
+{{- define "temporal.internalFrontendAddress.fqdn" -}}
+{{- $internalFrontend := index .Values.server "internal-frontend" -}}
+{{- printf "%s-internal-frontend.%s.svc:%d" (include "temporal.fullname" .) .Release.Namespace ($internalFrontend.service.port | int) -}}
+{{- end -}}
+
+{{/*
 Define the AppVersion
 */}}
 {{- define "temporal.appVersion" -}}

--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -36,16 +36,18 @@ spec:
           env:
             # TEMPORAL_CLI_ADDRESS is deprecated, use TEMPORAL_ADDRESS instead
             - name: TEMPORAL_CLI_ADDRESS
-              {{- if and (index $.Values.server "internal-frontend").enabled }}
-              value: {{ include "temporal.fullname" $ }}-internal-frontend:{{ (index $.Values.server "internal-frontend").service.port }}
+              {{- if (index $.Values.server "internal-frontend").enabled }}
+              value: {{ include "temporal.internalFrontendAddress" $ }}
               {{- else }}
-              value: {{ include "temporal.fullname" $ }}-frontend:{{ $.Values.server.frontend.service.port }}
+              value: {{ include "temporal.frontendAddress" $ }}
               {{- end }}
             - name: TEMPORAL_ADDRESS
-              {{- if (index $.Values.server "internal-frontend").enabled }}
-              value: {{ include "temporal.fullname" $ }}-internal-frontend:{{ (index $.Values.server "internal-frontend").service.port }}
+              {{- if .Values.admintools.temporalAddress }}
+              value: {{ .Values.admintools.temporalAddress }}
+              {{- else if (index $.Values.server "internal-frontend").enabled }}
+              value: {{ include "temporal.internalFrontendAddress" $ }}
               {{- else }}
-              value: {{ include "temporal.fullname" $ }}-frontend:{{ $.Values.server.frontend.service.port }}
+              value: {{ include "temporal.frontendAddress" $ }}
               {{- end }}
           {{- with .Values.admintools.additionalEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -39,7 +39,11 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: TEMPORAL_ADDRESS
-              value: "{{ .Values.web.temporalAddress | default (printf "%s-frontend.%s.svc:%d" (include "temporal.fullname" $) .Release.Namespace (.Values.server.frontend.service.port | int)) }}"
+              {{- if .Values.web.temporalAddress }}
+              value: {{ .Values.web.temporalAddress }}
+              {{- else }}
+              value: {{ include "temporal.frontendAddress.fqdn" $ }}
+              {{- end }}
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: TEMPORAL_ADDRESS
-              value: "{{ include "temporal.fullname" $ }}-frontend.{{ .Release.Namespace }}.svc:{{ .Values.server.frontend.service.port }}"
+              value: "{{ .Values.web.temporalAddress | default (printf "%s-frontend.%s.svc:%d" (include "temporal.fullname" $) .Release.Namespace (.Values.server.frontend.service.port | int)) }}"
           {{- if .Values.web.additionalEnv }}
           {{- toYaml .Values.web.additionalEnv | nindent 12 }}
           {{- end }}

--- a/charts/temporal/tests/admintools_deployment_test.yaml
+++ b/charts/temporal/tests/admintools_deployment_test.yaml
@@ -37,3 +37,30 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 10
+  - it: TEMPORAL_ADDRESS uses admintools.temporalAddress when set
+    set:
+      admintools:
+        temporalAddress: "my-temporal:7233"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEMPORAL_ADDRESS
+            value: "my-temporal:7233"
+  - it: TEMPORAL_ADDRESS falls back to default when admintools.temporalAddress is not set
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEMPORAL_ADDRESS
+            value: RELEASE-NAME-temporal-frontend:7233
+  - it: TEMPORAL_ADDRESS falls back to default when admintools.temporalAddress is empty string
+    set:
+      admintools:
+        temporalAddress: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEMPORAL_ADDRESS
+            value: RELEASE-NAME-temporal-frontend:7233

--- a/charts/temporal/tests/web_service_test.yaml
+++ b/charts/temporal/tests/web_service_test.yaml
@@ -90,3 +90,14 @@ tests:
           content:
             name: TEMPORAL_ADDRESS
             value: "localhost:7233"
+  - it: TEMPORAL_ADDRESS falls back to default when web.temporalAddress is empty string
+    template: templates/web-deployment.yaml
+    set:
+      web:
+        temporalAddress: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEMPORAL_ADDRESS
+            value: RELEASE-NAME-temporal-frontend.NAMESPACE.svc:7233

--- a/charts/temporal/tests/web_service_test.yaml
+++ b/charts/temporal/tests/web_service_test.yaml
@@ -71,3 +71,22 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 10
+  - it: TEMPORAL_ADDRESS defaults to frontend service address
+    template: templates/web-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEMPORAL_ADDRESS
+            value: RELEASE-NAME-temporal-frontend.NAMESPACE.svc:7233
+  - it: TEMPORAL_ADDRESS can be overridden via web.temporalAddress
+    template: templates/web-deployment.yaml
+    set:
+      web:
+        temporalAddress: "localhost:7233"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEMPORAL_ADDRESS
+            value: "localhost:7233"

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -457,6 +457,7 @@ admintools:
   additionalEnv: []
   additionalEnvSecretName: ""
   additionalEnvConfigMapName: ""
+  # temporalAddress: "localhost:7233"
   # for sidecar containers, add containers here with restartPolicy: Always
   additionalInitContainers: []
   resources: {}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -486,7 +486,7 @@ web:
   # Override the address the UI uses to connect to the Temporal frontend.
   # Defaults to <fullname>-frontend.<namespace>.svc:<server.frontend.service.port>.
   # Useful when running a proxy sidecar that intercepts gRPC traffic.
-  # temporalAddress: ""
+  # temporalAddress: "localhost:7233"
   readinessProbe:
     initialDelaySeconds: 10
     httpGet:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -483,6 +483,10 @@ web:
     appProtocol: http
     annotations: {}
     # loadBalancerIP:
+  # Override the address the UI uses to connect to the Temporal frontend.
+  # Defaults to <fullname>-frontend.<namespace>.svc:<server.frontend.service.port>.
+  # Useful when running a proxy sidecar that intercepts gRPC traffic.
+  # temporalAddress: ""
   readinessProbe:
     initialDelaySeconds: 10
     httpGet:


### PR DESCRIPTION
Hello! I just ran into this issue while trying to find a workaround to Dex/Google OAuth/temporal-ui not playing nicely when we have a custom JWT issuer for temporal to enable per-tenant namespace access to temporal resources.

It's my first contrib and I think I followed everything in CONTRIBUTING.md but let me know if I need changes, thanks!

## Summary

The `temporal-web` deployment hard-codes `TEMPORAL_ADDRESS` to point at the Temporal frontend service. There is no way to override this, which makes it impossible to interpose a proxy sidecar between the UI and the frontend without forking the chart.

## Change

Add an optional `web.temporalAddress` value. When set, it is used directly as `TEMPORAL_ADDRESS`. When unset, existing default behavior is preserved exactly, no breaking change.

## Testing

Two helm-unittest tests added to `tests/web_service_test.yaml`:
- Default produces the existing `<fullname>-frontend.<namespace>.svc:<port>` value
- Override via `web.temporalAddress` produces the custom value

All 134 tests pass (`helm unittest charts/temporal`).

## Motivation

Needed for auth proxy patterns where a sidecar intercepts the UI's outbound gRPC connection to swap authentication tokens. Without this, `additionalEnv` produces a duplicate `TEMPORAL_ADDRESS` key which ArgoCD rejects during structured merge diff validation.
