### PR TITLE
fix: use constant name for schema job to enable proper hook cleanup

### DIFF
--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -1,4 +1,4 @@
-{{- $jobName := printf "%s-schema" (include "temporal.fullname" $) }}
+{{- $jobName := ternary (printf "%s-schema" (include "temporal.fullname" $)) (include "temporal.componentname" (list $ (printf "schema-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-" | replace "+" "-"))) $.Values.schema.useHelmHooks }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,7 +10,7 @@ metadata:
     {{- if $.Values.schema.useHelmHooks }}
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     {{- end }}
     {{- with $.Values.schema.jobAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -1,4 +1,4 @@
-{{- $jobName := include "temporal.componentname" (list $ (printf "schema-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-" | replace "+" "-")) }}
+{{- $jobName := printf "%s-schema" (include "temporal.fullname" $) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -23,12 +23,42 @@ tests:
       - containsDocument:
           kind: Job
           apiVersion: batch/v1
-  - it: replaces build metadata separators in the server job name
+  - it: uses a constant name for the schema job
     release:
       name: test
+    set:
+      schema:
+        useHelmHooks: true
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-visibility:3306"
+                  databaseName: temporal_visibility
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-temporal-schema
+      - equal:
+          path: spec.template.metadata.name
+          value: test-temporal-schema
+  - it: uses a dynamic name for the schema job when useHelmHooks is false
+    release:
+      name: test
+      revision: 0
     chart:
       version: 1.1.1+build
     set:
+      schema:
+        useHelmHooks: false
       server:
         config:
           persistence:
@@ -246,7 +276,7 @@ tests:
           value: "0"
       - equal:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
-          value: "before-hook-creation"
+          value: "before-hook-creation,hook-succeeded"
   - it: excludes Helm hook annotations when useHelmHooks is false
     set:
       server:


### PR DESCRIPTION
The schema job name previously included Chart.Version and Release.Revision, which caused the job name to change on every upgrade. This prevented the 'before-hook-creation' delete policy from cleaning up old jobs, since Helm treats differently-named resources as unrelated. This PR makes the job name stable when Helm hooks are enabled so cleanup works during upgrades.

## What was changed

The schema job name is now conditional on `schema.useHelmHooks`:

- When `schema.useHelmHooks=true` (default): a **constant** name based only on the release name, so Helm can delete/replace the prior hook Job on upgrade. The hook delete policy also gains `hook-succeeded` so the Job is cleaned up after it completes.
- When `schema.useHelmHooks=false`: the **original dynamic** name (including `Chart.Version` and `Release.Revision`) is preserved, so the immutable Job is replaced on upgrade.

### Before

```yaml
{{ $jobName := include "temporal.componentname" (list $ (printf "schema-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-" | replace "+" "-")) }}
```

### After

```yaml
{{ $jobName := ternary (printf "%s-schema" (include "temporal.fullname" $)) (include "temporal.componentname" (list $ (printf "schema-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-" | replace "+" "-"))) $.Values.schema.useHelmHooks }}
```

And the hook delete policy:

```yaml
"helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
```

## Why?

The dynamic job name changed on every upgrade (e.g., `temporal-schema-0-62-0-1` → `temporal-schema-0-63-0-2`). Because Helm treats differently-named resources as unrelated, `before-hook-creation` never cleaned up the old Job. This resulted in:

- Old completed jobs accumulating in the cluster
- Manual job deletion required during upgrades
- Failed upgrades when jobs with conflicting names exist

A constant name (when hooks are enabled) lets `before-hook-creation` properly clean up old jobs during upgrades. Keeping the dynamic name when hooks are disabled preserves the prior behavior for the immutable-Job-replacement path.

## Checklist

1. How was this tested:
- [x] `helm unittest charts/temporal -f 'tests/server_job_test.yaml'` — covers constant name (hooks on), dynamic name (hooks off), and the new delete policy
- [x] `helm template` renders the expected job name in both modes
- [x] Local Kind cluster: install → verify job runs → upgrade → verify old job deleted, new job created

2. Any docs updates needed?
- No README updates needed (internal template change)
- May want to mention in upgrade notes that the schema job name format changed when `useHelmHooks` is enabled