### PR TITLE
feat(web,frontend): add httproute

### DIFF
--- a/charts/temporal/templates/frontend-httproute.yaml
+++ b/charts/temporal/templates/frontend-httproute.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.server.frontend.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "temporal.componentname" (list $ "frontend") }}
+  labels:
+    {{- include "temporal.resourceLabels" (list $ "frontend" "") | nindent 4 }}
+  {{- with .Values.server.frontend.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.server.frontend.httpRoute.parentRefs | nindent 4 }}
+  hostnames:
+    {{- toYaml .Values.server.frontend.httpRoute.hostnames | nindent 4 }}
+  rules:
+    - matches:
+      {{- if .Values.server.frontend.httpRoute.matches }}
+        {{- toYaml .Values.server.frontend.httpRoute.matches | nindent 8 }}
+      {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ include "temporal.fullname" $ }}-frontend
+          port: {{ $.Values.server.frontend.service.port }}
+          weight: 1
+{{- end }}

--- a/charts/temporal/templates/frontend-httproute.yaml
+++ b/charts/temporal/templates/frontend-httproute.yaml
@@ -5,28 +5,37 @@ metadata:
   name: {{ include "temporal.componentname" (list $ "frontend") }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "frontend" "") | nindent 4 }}
+    {{- with .Values.server.frontend.httpRoute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.server.frontend.httpRoute.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.server.frontend.httpRoute.parentRefs }}
   parentRefs:
-    {{- toYaml .Values.server.frontend.httpRoute.parentRefs | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.server.frontend.httpRoute.hostnames }}
   hostnames:
-    {{- toYaml .Values.server.frontend.httpRoute.hostnames | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
+    {{- range .Values.server.frontend.httpRoute.rules }}
+    {{- with .matches }}
     - matches:
-      {{- if .Values.server.frontend.httpRoute.matches }}
-        {{- toYaml .Values.server.frontend.httpRoute.matches | nindent 8 }}
-      {{- else }}
-        - path:
-            type: PathPrefix
-            value: /
-      {{- end }}
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
       backendRefs:
         - group: ""
           kind: Service
           name: {{ include "temporal.fullname" $ }}-frontend
           port: {{ $.Values.server.frontend.service.port }}
           weight: 1
+      {{- end }}
 {{- end }}

--- a/charts/temporal/templates/web-httproute.yaml
+++ b/charts/temporal/templates/web-httproute.yaml
@@ -5,28 +5,37 @@ metadata:
   name: {{ include "temporal.componentname" (list $ "web") }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
+    {{- with .Values.web.httpRoute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.web.httpRoute.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.web.httpRoute.parentRefs }}
   parentRefs:
-    {{- toYaml .Values.web.httpRoute.parentRefs | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.web.httpRoute.hostnames }}
   hostnames:
-    {{- toYaml .Values.web.httpRoute.hostnames | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
+    {{- range .Values.web.httpRoute.rules }}
+    {{- with .matches }}
     - matches:
-      {{- if .Values.web.httpRoute.matches }}
-        {{- toYaml .Values.web.httpRoute.matches | nindent 8 }}
-      {{- else }}
-        - path:
-            type: PathPrefix
-            value: /
-      {{- end }}
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
       backendRefs:
         - group: ""
           kind: Service
           name: {{ include "temporal.fullname" $ }}-web
           port: {{ $.Values.web.service.port }}
           weight: 1
+      {{- end }}
 {{- end }}

--- a/charts/temporal/templates/web-httproute.yaml
+++ b/charts/temporal/templates/web-httproute.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.web.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "temporal.componentname" (list $ "web") }}
+  labels:
+    {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
+  {{- with .Values.web.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.web.httpRoute.parentRefs | nindent 4 }}
+  hostnames:
+    {{- toYaml .Values.web.httpRoute.hostnames | nindent 4 }}
+  rules:
+    - matches:
+      {{- if .Values.web.httpRoute.matches }}
+        {{- toYaml .Values.web.httpRoute.matches | nindent 8 }}
+      {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ include "temporal.fullname" $ }}-web
+          port: {{ $.Values.web.service.port }}
+          weight: 1
+{{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -290,9 +290,10 @@ server:
       #      - chart-example.local
     httpRoute:
       enabled: false
+      labels: {}
       annotations: {}
       hostnames: []
-      parentRefs: {}
+      parentRefs: []
       matches: []
     metrics:
       annotations:
@@ -517,9 +518,10 @@ web:
     #      - chart-example.local
   httpRoute:
     enabled: false
+    labels: {}
     annotations: {}
     hostnames: []
-    parentRefs: {}
+    parentRefs: []
     matches: []
   deploymentLabels: {}
   deploymentAnnotations: {}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -288,6 +288,12 @@ server:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+    httpRoute:
+      enabled: false
+      annotations: {}
+      hostnames: []
+      parentRefs: {}
+      matches: []
     metrics:
       annotations:
         enabled: true
@@ -509,6 +515,12 @@ web:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+  httpRoute:
+    enabled: false
+    annotations: {}
+    hostnames: []
+    parentRefs: {}
+    matches: []
   deploymentLabels: {}
   deploymentAnnotations: {}
   deploymentStrategy: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added support for Gateway API, allowing the chart to create an HTTPRoute resource as an alternative to the existing Ingress configuration.

## Why?
<!-- Tell your future self why have you made these changes -->
Gateway API is becoming the standard way to manage ingress traffic in Kubernetes. With the deprecation of [ingress-nginx](https://github.com/kubernetes/ingress-nginx) in March 2026, many engineers have moved to [Envoy Gateway](https://gateway.envoyproxy.io/), which only supports the Gateway API — so charts would need to support it in order to not have the engineers manually add the manifests themself.
## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/helm-charts/issues/928

2. How was this tested:
Ran `helm template` locally to verify the rendered manifest.

3. Any docs updates needed?
Don't think so as I did not find equivalent doc for Ingress, but I can add it if wanted.
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
