### PR TITLE
fix: PDB templates break on multi-key specs and ignore global replicaCount

### DIFF
--- a/charts/temporal/templates/server-pdb.yaml
+++ b/charts/temporal/templates/server-pdb.yaml
@@ -1,7 +1,8 @@
 {{- if $.Values.server.enabled }}
 {{- range $service := (list "frontend" "internal-frontend" "history" "matching" "worker") }}
 {{- $serviceValues := index $.Values.server $service }}
-{{- if and $serviceValues.enabled (gt ($serviceValues.replicaCount | int) 0) ($serviceValues.podDisruptionBudget) }}
+{{- $replicaCount := ternary $serviceValues.replicaCount $.Values.server.replicaCount (hasKey $serviceValues "replicaCount") }}
+{{- if and $serviceValues.enabled (gt ($replicaCount | int) 0) ($serviceValues.podDisruptionBudget) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -9,13 +10,13 @@ metadata:
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
 spec:
-  {{ toYaml $serviceValues.podDisruptionBudget }}
+  {{- toYaml $serviceValues.podDisruptionBudget | nindent 2 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "temporal.name" $ }}
       app.kubernetes.io/instance: {{ $.Release.Name }}
       app.kubernetes.io/component: {{ $service }}
-{{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/temporal/templates/web-pdb.yaml
+++ b/charts/temporal/templates/web-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}
 spec:
-  {{ toYaml $.Values.web.podDisruptionBudget }}
+  {{- toYaml $.Values.web.podDisruptionBudget | nindent 2 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "temporal.name" $ }}

--- a/charts/temporal/tests/server_pdb_test.yaml
+++ b/charts/temporal/tests/server_pdb_test.yaml
@@ -6,9 +6,24 @@ set:
     enabled: true
     frontend:
       enabled: true
-      replicaCount: 1
 tests:
   - it: creates pdb when specified
+    template: templates/server-pdb.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend-pdb")].kind'
+      value: PodDisruptionBudget
+      matchMany: true
+    set:
+      server:
+        frontend:
+          replicaCount: 1
+          podDisruptionBudget:
+            maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+  - it: creates pdb when relying on the global server replicaCount
     template: templates/server-pdb.yaml
     documentSelector:
       path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend-pdb")].kind'
@@ -23,6 +38,25 @@ tests:
       - equal:
           path: spec.maxUnavailable
           value: 1
+  - it: renders multi-key pdb specs as valid YAML
+    template: templates/server-pdb.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-frontend-pdb")].kind'
+      value: PodDisruptionBudget
+      matchMany: true
+    set:
+      server:
+        frontend:
+          podDisruptionBudget:
+            minAvailable: 1
+            unhealthyPodEvictionPolicy: AlwaysAllow
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: AlwaysAllow
   - it: doesn't create pdb when replica count is 0
     set:
       server:


### PR DESCRIPTION
## What was changed

Fixed two rendering bugs in the temporal chart's PodDisruptionBudget templates, plus a cosmetic cleanup:

  - **`server-pdb.yaml` / `web-pdb.yaml`**: replaced `spec:` + `  {{ toYaml .podDisruptionBudget }}` with `{{- toYaml ... | nindent 2 }}`. The old form only indented the first line of the rendered spec, so any PDB config with more than one key (e.g., `minAvailable` + `unhealthyPodEvictionPolicy`) produced invalid YAML: `Error: YAML parse error ... mapping values are not allowed in this context`.
  - **`server-pdb.yaml`**: the creation guard reads only the per-service `replicaCount`, while deployments fall back to the global `server.replicaCount` (`server-deployment.yaml`). With the default config (no per-service `replicaCount`), `nil | int` → `0` and server PDBs were silently never rendered. The guard now resolves replicas with the same global fallback via a `hasKey`-guarded ternary, so an explicit `replicaCount: 0` still suppresses the PDB.
  - Moved the `---` document separator inside the conditional so services without a PDB no longer emit empty YAML documents.
  - `tests/server_pdb_test.yaml`: added regression tests for the global-fallback and multi-key cases, and moved the suite-level `replicaCount: 1` (which masked the fallback bug) into the only test that needs it.

## Why?

Anyone setting `server.<service>.podDisruptionBudget` without also explicitly setting a per-service `replicaCount` got **no PDB at all** — silently, since the template just skips rendering. And any PDB spec with more than one key broke `helm template`/`helm install` outright. Both made the `podDisruptionBudget` values effectively unusable in their most common configurations, with no signal in the first case.

## Checklist

  1. How was this tested?
     - `helm unittest .` — 13 suites, 135 tests passed, including the new regression tests.
     - `helm template .` with each of the four `ci/*.yaml` configs renders cleanly.
     - Manual renders with multi-key PDB values for both server `frontend` and `web` confirmed valid output.
     - `helm lint` passes.

  2. Any docs updates needed?
     - Nope