### PR TITLE
feat(server): add server.publicClientHostPort to override publicClient.hostPort

### DIFF
--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -128,7 +128,10 @@ data:
       {{- toYaml . | nindent 6 }}
     {{- end }}
 
-    {{- if not (index $.Values.server "internal-frontend").enabled }}
+    {{- if $.Values.server.publicClientHostPort }}
+    publicClient:
+      hostPort: "{{ $.Values.server.publicClientHostPort }}"
+    {{- else if not (index $.Values.server "internal-frontend").enabled }}
     publicClient:
       hostPort: "{{ include "temporal.componentname" (list $ "frontend") }}:{{ $server.frontend.service.port }}"
     {{- end }}

--- a/charts/temporal/tests/server_configmap_test.yaml
+++ b/charts/temporal/tests/server_configmap_test.yaml
@@ -191,6 +191,79 @@ tests:
           path: data['config_template.yaml']
           pattern: 'visibility: temporal_visibility_v1_secondary'
 
+  - it: uses server.publicClientHostPort when set
+    set:
+      server:
+        publicClientHostPort: "temporal-frontend.mesh.svc:7233"
+        config:
+          persistence:
+            defaultStore: default
+            visibilityStore: visibility
+            datastores:
+              default:
+                sql:
+                  password: "secret"
+              visibility:
+                sql:
+                  password: "secret"
+    template: templates/server-configmap.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-config
+    asserts:
+      - matchRegex:
+          path: data['config_template.yaml']
+          pattern: 'hostPort: "temporal-frontend.mesh.svc:7233"'
+
+  - it: falls back to default publicClient when server.publicClientHostPort is not set
+    set:
+      server:
+        config:
+          persistence:
+            defaultStore: default
+            visibilityStore: visibility
+            datastores:
+              default:
+                sql:
+                  password: "secret"
+              visibility:
+                sql:
+                  password: "secret"
+    template: templates/server-configmap.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-config
+    asserts:
+      - matchRegex:
+          path: data['config_template.yaml']
+          pattern: 'hostPort: "RELEASE-NAME-temporal-frontend:7233"'
+
+  - it: server.publicClientHostPort overrides even when internal-frontend is enabled
+    set:
+      server:
+        publicClientHostPort: "temporal-frontend.mesh.svc:7233"
+        internal-frontend:
+          enabled: true
+        config:
+          persistence:
+            defaultStore: default
+            visibilityStore: visibility
+            datastores:
+              default:
+                sql:
+                  password: "secret"
+              visibility:
+                sql:
+                  password: "secret"
+    template: templates/server-configmap.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-config
+    asserts:
+      - matchRegex:
+          path: data['config_template.yaml']
+          pattern: 'hostPort: "temporal-frontend.mesh.svc:7233"'
+
   - it: handles metrics config
     set:
       server:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -93,6 +93,7 @@ server:
   additionalEnvConfigMapName: ""
   # for sidecar containers, add containers here with restartPolicy: Always
   additionalInitContainers: []
+  # publicClientHostPort: "temporal-frontend.example.svc:7233"
   securityContext:
     fsGroup: 1000
     runAsUser: 1000


### PR DESCRIPTION
## What changed?

Added `server.publicClientHostPort` — an optional value to override the `publicClient.hostPort` field in the server configmap, which is mounted into all four server services (frontend, history, matching, worker).

## Why?

The `publicClient.hostPort` is currently hardcoded to the raw Kubernetes service name (`temporal-frontend:7233`). In service mesh setups like Istio multi-cluster, raw k8s service names can route traffic across regions unexpectedly. Users need to specify a mesh-aware hostname to ensure traffic stays within the same region.

Requested in #915 (comment) by @yijiewu-mg.

## How?

Follows the same pattern as `web.temporalAddress` and `admintools.temporalAddress` from #915:
- When `server.publicClientHostPort` is set, it is used directly
- When unset, existing behavior is preserved: defaults to the frontend service address when `internal-frontend` is disabled, omitted when `internal-frontend` is enabled
- The override works regardless of whether `internal-frontend` is enabled

## How did you test it?

- [x] Three new test cases in `tests/server_configmap_test.yaml`:
  - Override is used when `server.publicClientHostPort` is set
  - Falls back to default when unset
  - Override works even when `internal-frontend` is enabled
