### PR TITLE
feat: add schedulerName, runtimeClassName and priorityClassName to pod specs

### DIFF
--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -106,4 +106,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.admintools.schedulerName }}
+      schedulerName: {{ . }}
+    {{- end }}
+    {{- with .Values.admintools.runtimeClassName }}
+      runtimeClassName: {{ . }}
+    {{- end }}
+    {{- with .Values.admintools.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
 {{- end }}

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -193,6 +193,15 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with (default $.Values.server.schedulerName $serviceValues.schedulerName) }}
+      schedulerName: {{ . }}
+    {{- end }}
+    {{- with (default $.Values.server.runtimeClassName $serviceValues.runtimeClassName) }}
+      runtimeClassName: {{ . }}
+    {{- end }}
+    {{- with (default $.Values.server.priorityClassName $serviceValues.priorityClassName) }}
+      priorityClassName: {{ . }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ default $.Values.server.terminationGracePeriodSeconds $serviceValues.terminationGracePeriodSeconds }}
 ---
 {{- end }}

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -104,4 +104,13 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.web.schedulerName }}
+      schedulerName: {{ . }}
+    {{- end }}
+    {{- with .Values.web.runtimeClassName }}
+      runtimeClassName: {{ . }}
+    {{- end }}
+    {{- with .Values.web.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
   {{- end }}

--- a/charts/temporal/tests/admintools_deployment_test.yaml
+++ b/charts/temporal/tests/admintools_deployment_test.yaml
@@ -64,3 +64,27 @@ tests:
           content:
             name: TEMPORAL_ADDRESS
             value: RELEASE-NAME-temporal-frontend:7233
+  - it: schedulerName, runtimeClassName and priorityClassName are unset by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.schedulerName
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+      - notExists:
+          path: spec.template.spec.priorityClassName
+  - it: sets schedulerName, runtimeClassName and priorityClassName when configured
+    set:
+      admintools:
+        schedulerName: my-scheduler
+        runtimeClassName: my-runtime-class
+        priorityClassName: my-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.schedulerName
+          value: my-scheduler
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: my-runtime-class
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: my-priority-class

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -416,3 +416,64 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: TEMPORAL_SECONDARY_VISIBILITY_STORE_PASSWORD
+
+  - it: schedulerName, runtimeClassName and priorityClassName are unset by default
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: .kind
+      value: Deployment
+      matchMany: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.schedulerName
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: schedulerName, runtimeClassName and priorityClassName default to service wide values
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: .kind
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        schedulerName: my-scheduler
+        runtimeClassName: my-runtime-class
+        priorityClassName: my-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.schedulerName
+          value: my-scheduler
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: my-runtime-class
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: my-priority-class
+
+  - it: schedulerName, runtimeClassName and priorityClassName favour service specific values
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    set:
+      server:
+        schedulerName: my-scheduler
+        runtimeClassName: my-runtime-class
+        priorityClassName: my-priority-class
+        frontend:
+          schedulerName: frontend-scheduler
+          runtimeClassName: frontend-runtime-class
+          priorityClassName: frontend-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.schedulerName
+          value: frontend-scheduler
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: frontend-runtime-class
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: frontend-priority-class

--- a/charts/temporal/tests/web_deployment_test.yaml
+++ b/charts/temporal/tests/web_deployment_test.yaml
@@ -1,0 +1,28 @@
+suite: test web deployment
+templates:
+  - web-deployment.yaml
+tests:
+  - it: schedulerName, runtimeClassName and priorityClassName are unset by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.schedulerName
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+      - notExists:
+          path: spec.template.spec.priorityClassName
+  - it: sets schedulerName, runtimeClassName and priorityClassName when configured
+    set:
+      web:
+        schedulerName: my-scheduler
+        runtimeClassName: my-runtime-class
+        priorityClassName: my-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.schedulerName
+          value: my-scheduler
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: my-runtime-class
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: my-priority-class

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -84,6 +84,10 @@ server:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Default scheduling values for all server services. Each service can override these below.
+  schedulerName: ""
+  runtimeClassName: ""
+  priorityClassName: ""
   minReadySeconds: 0
   terminationGracePeriodSeconds: null
   additionalVolumes: []
@@ -309,6 +313,9 @@ server:
     additionalEnv: []
     containerSecurityContext: {}
     topologySpreadConstraints: []
+    schedulerName: ""
+    runtimeClassName: ""
+    priorityClassName: ""
     podDisruptionBudget: {}
   internal-frontend:
     # Enable this to create internal-frontend
@@ -350,6 +357,9 @@ server:
     additionalEnv: []
     containerSecurityContext: {}
     topologySpreadConstraints: []
+    schedulerName: ""
+    runtimeClassName: ""
+    priorityClassName: ""
     podDisruptionBudget: {}
   history:
     enabled: true
@@ -380,6 +390,9 @@ server:
     additionalEnv: []
     containerSecurityContext: {}
     topologySpreadConstraints: []
+    schedulerName: ""
+    runtimeClassName: ""
+    priorityClassName: ""
     podDisruptionBudget: {}
   matching:
     enabled: true
@@ -410,6 +423,9 @@ server:
     additionalEnv: []
     containerSecurityContext: {}
     topologySpreadConstraints: []
+    schedulerName: ""
+    runtimeClassName: ""
+    priorityClassName: ""
     podDisruptionBudget: {}
   worker:
     enabled: true
@@ -440,6 +456,9 @@ server:
     additionalEnv: []
     containerSecurityContext: {}
     topologySpreadConstraints: []
+    schedulerName: ""
+    runtimeClassName: ""
+    priorityClassName: ""
     podDisruptionBudget: {}
 admintools:
   enabled: true
@@ -459,6 +478,9 @@ admintools:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  schedulerName: ""
+  runtimeClassName: ""
+  priorityClassName: ""
   additionalVolumes: []
   additionalVolumeMounts: []
   additionalEnv: []
@@ -544,6 +566,9 @@ web:
   containerSecurityContext: {}
   securityContext: {}
   topologySpreadConstraints: []
+  schedulerName: ""
+  runtimeClassName: ""
+  priorityClassName: ""
   minReadySeconds: 0
   podDisruptionBudget: {}
 schema:


### PR DESCRIPTION
This adds three optional, opt-in pod fields (schedulerName, runtimeClassName, priorityClassName) to the server, web and admintools workloads, mirroring the nodeSelector/affinity/tolerations/topologySpreadConstraints knobs already present on these pods.

- server: server-wide value with per-service override, using the same `default $.Values.server.<field> $serviceValues.<field>` pattern as nodeSelector/affinity/tolerations
- web and admintools: `.Values.<component>.<field>`

All three default to "", so the rendered output is byte-identical for existing users (no behavior change).

CONTRIBUTING lists "scheduling constraints required by platform policies" as an accepted change. These fields are commonly needed for sandboxed/GPU runtimes (runtimeClassName), custom schedulers, and priority-based preemption.

Validation (run locally):
- helm unittest . -> 152 passed. Added coverage in server_deployment_test.yaml and admintools_deployment_test.yaml, plus a new web_deployment_test.yaml (default renders nothing, set values render, server per-service overrides the server-wide default).
- ct lint --check-version-increment=false -> all charts linted successfully across the mysql / postgres-es / postgres ci value files.
- helm template default render diff vs main is empty (byte-identical); with the fields set they render on every enabled workload.

I did not run the kind ct install scenario since the ci/*-values.yaml files do not set these fields and the default render is unchanged, so it would exercise nothing new. Happy to add a ci scenario if you prefer.