### PR TITLE
Make the release commit/tag step idempotent

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -96,11 +96,39 @@ jobs:
     
       - name: Commit changes
         working-directory: charts/temporal
+        env:
+          VERSION: ${{ steps.chart-version.outputs.chart_version }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          git commit -m "Update Chart to ${{ steps.chart-version.outputs.chart_version }}." Chart.yaml values.yaml
-          git tag -a "temporal-${{ steps.chart-version.outputs.chart_version }}" -m "Release Chart: ${{ steps.chart-version.outputs.chart_version }}"
+          TAG="temporal-${VERSION}"
 
-          git push --tags origin ${{ github.ref_name }}
+          # Fail fast with a clear message if this version is already fully released,
+          # rather than dying later with a confusing "tag already exists" error.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1 \
+             && gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "::error::${TAG} is already released — bump to a new version instead of retrying."
+            exit 1
+          fi
+
+          # Each step below is idempotent so a re-run after a transient failure
+          # skips the work already done and proceeds to chart-releaser.
+
+          # Commit the bump only if there is something to commit.
+          if git diff --quiet Chart.yaml values.yaml; then
+            echo "Chart already bumped; nothing to commit."
+          else
+            git commit -m "Update Chart to ${VERSION}." Chart.yaml values.yaml
+          fi
+
+          # Create the tag only if it does not already exist.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists; reusing it."
+          else
+            git tag -a "${TAG}" -m "Release Chart: ${VERSION}"
+          fi
+
+          # Push the branch and this single tag atomically; "already up to date" is success.
+          git push --atomic origin "${{ github.ref_name }}" "refs/tags/${TAG}"
 
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5


### PR DESCRIPTION
## Problem

The `Release Charts` workflow's `Commit changes` step ran a non-idempotent sequence — `git commit`, `git tag -a`, `git push --tags` — with no guard for work already done. When a *later* step failed transiently (e.g. `chart-releaser` or `Install Helm`), a re-run re-executed these same commands and died immediately at `git tag -a` with `fatal: tag '...' already exists`, and could never reach the publish step.

This happened on [run 29032639144](https://github.com/temporalio/helm-charts/actions/runs/29032639144/job/86169188218): attempt 1 pushed the `temporal-1.6.0` commit + tag then failed in a later step, and the retry died on the existing tag. Net result: `temporal-1.6.0` has a commit and tag but **no GitHub Release and no `index.yaml` entry** — i.e. it is not installable.

## Change

Rework `Commit changes` so re-runs are safe:

- **Fail fast** with a clear message if the version is already fully released (remote tag *and* a GitHub Release exist), instead of a confusing mid-run `tag already exists`.
- **Commit only if there is something to commit** (`git diff --quiet`).
- **Tag only if the tag doesn't already exist** (`git rev-parse --verify`); otherwise reuse it.
- **Push branch + this single tag atomically** (`git push --atomic`), instead of `git push --tags` which pushes *every* local tag. "Already up to date" is treated as success.

A re-run after a transient failure now skips the work already done and proceeds to `chart-releaser`, which is itself idempotent (skips existing releases, fills in the missing Release + index entry).

## Recovering 1.6.0

Once merged, dispatch the workflow with `force_version: 1.6.0` and the original image versions (`server 1.31.2`, `admintools 1.31.2`, `ui 2.52.0`). Everything before `chart-releaser` is a no-op; `chart-releaser` creates the missing `temporal-1.6.0` Release and index entry.

## Note

The manual `git tag -a` may be redundant — `cr upload` creates the GitHub Release and, with it, the tag. It's left in place here (annotated tag, minimal behavior change); removing it is optional cleanup best validated against a live release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)