### PR TITLE
feat(temporal-proxy): add PodDisruptionBudget and extraObjects support

### DIFF
--- a/charts/temporal-proxy/templates/extra-objects.yaml
+++ b/charts/temporal-proxy/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl . $ }}
+{{- end }}

--- a/charts/temporal-proxy/templates/pdb.yaml
+++ b/charts/temporal-proxy/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "temporal-proxy.fullname" . }}
+  namespace: {{ include "temporal-proxy.namespace" . }}
+  labels:
+    {{- include "temporal-proxy.labels" . | nindent 4 }}
+spec:
+  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "temporal-proxy.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/temporal-proxy/tests/__snapshot__/pdb_test.yaml.snap
+++ b/charts/temporal-proxy/tests/__snapshot__/pdb_test.yaml.snap
@@ -1,0 +1,19 @@
+renders defaults:
+  1: |
+    apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        app.kubernetes.io/instance: temporal-proxy
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: temporal-proxy
+        app.kubernetes.io/version: 1.0.0
+        helm.sh/chart: temporal-proxy-1.0.0
+      name: temporal-proxy
+      namespace: temporal-proxy
+    spec:
+      minAvailable: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: temporal-proxy
+          app.kubernetes.io/name: temporal-proxy

--- a/charts/temporal-proxy/tests/extra_objects_test.yaml
+++ b/charts/temporal-proxy/tests/extra_objects_test.yaml
@@ -1,0 +1,75 @@
+suite: extraObjects test
+templates:
+  - extra-objects.yaml
+chart:
+  version: 1.0.0
+  appVersion: 1.0.0
+release:
+  name: temporal-proxy
+  namespace: temporal-proxy
+tests:
+  - it: does not render anything when extraObjects is empty
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a ConfigMap from a string entry
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-config
+          data:
+            key: value
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - equal:
+          path: metadata.name
+          value: test-config
+
+  - it: renders an ExternalSecret from a string entry
+    set:
+      extraObjects:
+        - |
+          apiVersion: external-secrets.io/v1beta1
+          kind: ExternalSecret
+          metadata:
+            name: test-secret
+          spec:
+            secretStoreRef:
+              name: test-store
+              kind: SecretStore
+            target:
+              name: test-target
+            data:
+            - secretKey: password
+              remoteRef:
+                key: test/key
+                property: password
+    asserts:
+      - containsDocument:
+          kind: ExternalSecret
+          apiVersion: external-secrets.io/v1beta1
+      - equal:
+          path: metadata.name
+          value: test-secret
+
+  - it: supports Go templating within entries
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ .Release.Name }}-config
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - equal:
+          path: metadata.name
+          value: temporal-proxy-config

--- a/charts/temporal-proxy/tests/extra_objects_test.yaml
+++ b/charts/temporal-proxy/tests/extra_objects_test.yaml
@@ -73,3 +73,32 @@ tests:
       - equal:
           path: metadata.name
           value: temporal-proxy-config
+
+  - it: renders multiple extra objects
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-config-1
+          data:
+            key: value1
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-config-2
+          data:
+            key: value2
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-config-1
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-config-2
+        documentIndex: 1

--- a/charts/temporal-proxy/tests/pdb_test.yaml
+++ b/charts/temporal-proxy/tests/pdb_test.yaml
@@ -1,0 +1,67 @@
+suite: PodDisruptionBudget test
+templates:
+  - pdb.yaml
+chart:
+  version: 1.0.0
+  appVersion: 1.0.0
+release:
+  name: temporal-proxy
+  namespace: temporal-proxy
+tests:
+  - it: skips manifest when podDisruptionBudget is unset
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: skips manifest when podDisruptionBudget is empty
+    set:
+      podDisruptionBudget: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders defaults
+    set:
+      podDisruptionBudget:
+        minAvailable: 1
+    asserts:
+      - matchSnapshot: {}
+
+  - it: renders with correct spec and selector
+    set:
+      namespace: testing
+      podDisruptionBudget:
+        minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - isAPIVersion:
+          of: policy/v1
+      - equal:
+          path: metadata.name
+          value: temporal-proxy
+      - equal:
+          path: metadata.namespace
+          value: testing
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: temporal-proxy
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: temporal-proxy
+
+  - it: renders multi-key pdb specs as valid YAML
+    set:
+      podDisruptionBudget:
+        maxUnavailable: 1
+        unhealthyPodEvictionPolicy: AlwaysAllow
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: AlwaysAllow

--- a/charts/temporal-proxy/values.yaml
+++ b/charts/temporal-proxy/values.yaml
@@ -127,3 +127,8 @@ volumeMounts: []
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# This is for setting up a PodDisruptionBudget more information can be found here:
+# https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+podDisruptionBudget: {}
+  # minAvailable: 1

--- a/charts/temporal-proxy/values.yaml
+++ b/charts/temporal-proxy/values.yaml
@@ -132,3 +132,6 @@ affinity: {}
 # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
 podDisruptionBudget: {}
   # minAvailable: 1
+
+# Array of extra K8s manifests to deploy, e.g. an ExternalSecret for upstream mTLS credentials.
+extraObjects: []

--- a/charts/temporal-proxy/values.yaml
+++ b/charts/temporal-proxy/values.yaml
@@ -134,4 +134,6 @@ podDisruptionBudget: {}
   # minAvailable: 1
 
 # Array of extra K8s manifests to deploy, e.g. an ExternalSecret for upstream mTLS credentials.
+# Note: unlike the chart's other templates, these objects are rendered as-is and do not
+# automatically inherit the release namespace, labels, or other chart-wide values.
 extraObjects: []


### PR DESCRIPTION
Closes #952

## What

Adds two small, additive templates to `charts/temporal-proxy`, mirroring patterns already proven on the main `charts/temporal` chart:

- `templates/pdb.yaml` — an optional `PodDisruptionBudget`, gated purely on `.Values.podDisruptionBudget` truthiness (no brittle `replicaCount` comparison), using the chart's existing `temporal-proxy.fullname`/`namespace`/`labels`/`selectorLabels` helpers.
- `templates/extra-objects.yaml` — a verbatim copy of the main chart's generic escape hatch (`{{- range .Values.extraObjects }} --- {{ tpl . $ }} {{- end }}`) for injecting arbitrary manifests (e.g. `ExternalSecret`/`SealedSecret` for upstream mTLS credentials, `NetworkPolicy`) via GitOps without forking the chart.
- Corresponding `values.yaml` keys: `podDisruptionBudget: {}` and `extraObjects: []`.
- `helm-unittest` coverage for both, following this chart's existing test conventions (`charts/temporal-proxy/tests/`).

## Why

`temporal-proxy` sits in front of every SDK client/worker/UI connection to one-or-more upstream Temporal clusters (including Temporal Cloud), making it a network chokepoint. Despite that, it currently has none of the production-readiness patterns already established on the mature `charts/temporal` chart in this repo — operators can't protect it with a PDB during node drains/rolling upgrades, nor inject GitOps-managed secrets (e.g. mTLS client credentials) without forking the chart.

## How tested

- `helm lint charts/temporal-proxy` — clean
- `helm template charts/temporal-proxy` — renders neither resource by default (no-op)
- `helm template charts/temporal-proxy --set podDisruptionBudget.minAvailable=1` — PDB renders with correct `spec`/`selector`
- `helm template charts/temporal-proxy` with an `extraObjects` entry — renders the arbitrary manifest with `tpl` templating applied
- `helm unittest charts/temporal-proxy` — all suites pass, including two new ones (`pdb_test.yaml`, `extra_objects_test.yaml`)
- `helm unittest charts/*` — full repo test suite passes (21 suites, 188 tests)
- Verified each commit is independently valid (lints and passes tests in isolation)

## Risks

Purely additive — both new templates are no-ops unless explicitly configured, so this carries no risk to existing `temporal-proxy` installations.