### PR TITLE
temporal-proxy: Release 0.1.0

### DIFF
--- a/charts/temporal-proxy/Chart.yaml
+++ b/charts/temporal-proxy/Chart.yaml
@@ -4,8 +4,8 @@ description: The Temporal proxy handles routing between clusters, namespace tran
 icon: https://raw.githubusercontent.com/temporalio/temporal-proxy/refs/heads/main/temporal-proxy-small.png
 
 type: application
-version: 0.1.0-alpha1
-appVersion: v0.1.0-alpha.20260716
+version: 0.1.0
+appVersion: v0.1.0
 
 keywords:
   - temporal

--- a/charts/temporal-proxy/README.md
+++ b/charts/temporal-proxy/README.md
@@ -6,25 +6,19 @@ clusters, namespace translation, encryption, and more.
 The chart deploys the proxy as a single Deployment fronted by a ClusterIP Service, with its runtime configuration
 supplied through a ConfigMap.
 
-> This chart is in alpha. The configuration surface and defaults may change between releases.
-
 ## Installation
 
 The chart is published to the Temporal Helm repo at `https://go.temporal.io/helm-charts`.
 
-Because releases are currently pre-release (alpha) versions, Helm will not select them unless you opt in with `--devel`
-or pin an explicit `--version`:
-
 ```bash
-# Install the latest pre-release
+# Install the latest release
 helm install temporal-proxy temporal-proxy \
-  --repo https://go.temporal.io/helm-charts \
-  --devel
+  --repo https://go.temporal.io/helm-charts
 
 # Or pin a specific version
 helm install temporal-proxy temporal-proxy \
   --repo https://go.temporal.io/helm-charts \
-  --version 0.1.0-alpha1
+  --version 0.1.0
 ```
 
 To install from a local checkout of this repo instead (useful when testing chart changes), run the following from the


### PR DESCRIPTION
Promote the chart from pre-release to a stable 0.1.0 release, bumping both the chart version and appVersion off the alpha suffix.

Update the README to match: drop the alpha disclaimer and the --devel installation instructions, since Helm now selects 0.1.0 by default without opting into pre-releases.