### PR TITLE
Run namespace creation as a post-install/post-upgrade Helm hook

### DIFF
--- a/charts/temporal/templates/server-namespace-job.yaml
+++ b/charts/temporal/templates/server-namespace-job.yaml
@@ -1,14 +1,21 @@
 {{- if $.Values.server.config.namespaces.create }}
-{{- $jobName := include "temporal.componentname" (list $ (printf "namespace-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-" | replace "+" "-")) }}
+{{- $jobName := ternary (printf "%s-namespace" (include "temporal.fullname" $)) (include "temporal.componentname" (list $ (printf "namespace-%s-%d" $.Chart.Version $.Release.Revision | replace "." "-" | replace "+" "-"))) $.Values.server.config.namespaces.useHelmHooks }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ $jobName }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
-  {{- with $.Values.schema.jobAnnotations }}
+  {{- if or $.Values.server.config.namespaces.useHelmHooks $.Values.schema.jobAnnotations }}
   annotations:
+    {{- if $.Values.server.config.namespaces.useHelmHooks }}
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+    {{- with $.Values.schema.jobAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   backoffLimit: {{ $.Values.schema.backoffLimit }}

--- a/charts/temporal/tests/server_namespace_job_test.yaml
+++ b/charts/temporal/tests/server_namespace_job_test.yaml
@@ -24,7 +24,25 @@ tests:
       - containsDocument:
           kind: Job
           apiVersion: batch/v1
-  - it: replaces build metadata separators in the namespace job name
+  - it: uses a fixed job name when useHelmHooks is true
+    release:
+      name: test
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            useHelmHooks: true
+            namespace:
+              - name: default
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-temporal-namespace
+      - equal:
+          path: spec.template.metadata.name
+          value: test-temporal-namespace
+  - it: replaces build metadata separators in the namespace job name when useHelmHooks is false
     release:
       name: test
     chart:
@@ -34,6 +52,7 @@ tests:
         config:
           namespaces:
             create: true
+            useHelmHooks: false
             namespace:
               - name: default
     asserts:
@@ -110,12 +129,31 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].envFrom[1].configMapRef.name
           value: env-configmap
-  - it: does not include Helm hook annotations
+  - it: includes Helm hook annotations by default
     set:
       server:
         config:
           namespaces:
             create: true
+            namespace:
+              - name: default
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+  - it: does not include Helm hook annotations when useHelmHooks is false
+    set:
+      server:
+        config:
+          namespaces:
+            create: true
+            useHelmHooks: false
             namespace:
               - name: default
     asserts:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -252,6 +252,10 @@ server:
     namespaces:
       # Enable this to create namespaces
       create: false
+      # Use Helm hooks to ensure namespace creation runs as a post-install/post-upgrade step,
+      # after the frontend is created, and is cleaned up automatically on the next release.
+      # Set to false if using Flux, Rancher or Terraform.
+      useHelmHooks: true
       namespace:
         - name: default
           retention: 3d


### PR DESCRIPTION
## Summary

#892 intentionally kept namespace creation out of Helm's hook system because the schema job (`server-job.yaml`) uses `pre-install,pre-upgrade` hooks. Since *all* pre-install/pre-upgrade hooks run before any other resource is applied, making the namespace job a pre-hook too would deadlock: it needs the frontend service, which doesn't exist until after hooks succeed. So the namespace job was left as a plain `Job`, named with the chart version + release revision baked in to avoid the "Job spec is immutable" problem across upgrades.

That workaround has a couple of downsides:
- A new completed `Job` object is left behind on every install/upgrade (cleaned up only via `ttlSecondsAfterFinished`, not immediately).
- It's a plain resource, so Helm doesn't wait on it by default — namespace creation is fire-and-forget rather than something the release can be said to have completed.

`post-install,post-upgrade` hooks avoid the deadlock from #892 entirely, since they run on the *other* side of that boundary — after normal resources (including the frontend Deployment/Service) are already applied. This PR switches the namespace job to use them by default, mirroring the `useHelmHooks` toggle that already exists for the schema job:

- `server.config.namespaces.useHelmHooks` (default `true`) makes the job use `helm.sh/hook: post-install,post-upgrade` with `before-hook-creation,hook-succeeded` deletion, and a stable name (`<release>-<chart>-namespace`) instead of the version/revision-suffixed one.
- Setting it to `false` preserves the exact previous behavior (plain Job, versioned name), for Flux/Rancher/Terraform users the same way `schema.useHelmHooks: false` already works.

## Test plan
- [x] `helm unittest charts/temporal` — all 147 existing tests pass, plus new/updated tests for the namespace job (13 total in that suite) covering: default hook annotations, stable job name, `useHelmHooks: false` fallback (annotations absent, versioned name preserved).
- [x] `helm template` sanity-checked against `charts/temporal/ci/postgres-values.yaml` for both `useHelmHooks: true` (default) and `useHelmHooks: false`, confirming output matches the intended behavior in each mode.
- [ ] CI's `ct install` against a kind cluster (existing coverage already exercises `server.config.namespaces.create: true` via `ci/postgres-values.yaml`).