### PR TITLE
fix: remove unresolvable grpc-rpc port from worker headless service

### DIFF
--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -78,11 +78,16 @@ spec:
   # The other ports are listed here solely to allow Istio to configure itself to intercept traffic.
   # https://istio.io/latest/docs/ops/configuration/traffic-management/traffic-routing/#headless-services
   ports:
+    {{- /* The worker role serves no gRPC API and its pods declare no `rpc`
+         container port (see server-deployment.yaml), so a `grpc-rpc` port here
+         would never resolve to an endpoint. */}}
+    {{- if ne $service "worker" }}
     - port: {{ $serviceValues.service.port }}
       targetPort: rpc
       appProtocol: {{ $serviceValues.service.appProtocol }}
       protocol: TCP
       name: grpc-rpc
+    {{- end }}
     - port: {{ $serviceValues.service.membershipPort }}
       targetPort: membership
       appProtocol: {{ $serviceValues.service.membershipAppProtocol }}

--- a/charts/temporal/tests/server_service_test.yaml
+++ b/charts/temporal/tests/server_service_test.yaml
@@ -280,19 +280,13 @@ tests:
       value: Service
       matchMany: true
     asserts:
+      # No grpc-rpc port: the worker serves no gRPC API and its pods declare
+      # no `rpc` container port, so that service port could never resolve.
       - lengthEqual:
           path: spec.ports
-          count: 3
+          count: 2
       - equal:
           path: spec.ports[0]
-          value:
-            appProtocol: tcp
-            name: grpc-rpc
-            port: 7239
-            protocol: TCP
-            targetPort: rpc
-      - equal:
-          path: spec.ports[1]
           value:
             appProtocol: tcp
             name: grpc-membership
@@ -300,7 +294,7 @@ tests:
             protocol: TCP
             targetPort: membership
       - equal:
-          path: spec.ports[2]
+          path: spec.ports[1]
           value:
             appProtocol: http
             name: metrics
@@ -546,17 +540,9 @@ tests:
     asserts:
       - lengthEqual:
           path: spec.ports
-          count: 3
+          count: 2
       - equal:
           path: spec.ports[0]
-          value:
-            appProtocol: grpc
-            name: grpc-rpc
-            port: 7239
-            protocol: TCP
-            targetPort: rpc
-      - equal:
-          path: spec.ports[1]
           value:
             appProtocol: tls
             name: grpc-membership
@@ -564,7 +550,7 @@ tests:
             protocol: TCP
             targetPort: membership
       - equal:
-          path: spec.ports[2]
+          path: spec.ports[1]
           value:
             appProtocol: http
             name: metrics


### PR DESCRIPTION
## What

Fixes #959.

The `<release>-temporal-worker-headless` Service publishes a `grpc-rpc` port that can never resolve to an endpoint. This PR removes it, mirroring the guard that `server-deployment.yaml` already applies to the worker role.

## The mismatch

Two templates disagree about the worker role:

- `server-deployment.yaml` deliberately **omits** the `rpc` container port for the worker (`{{- if ne $service "worker" }}` around the port, and again around the rpc-based liveness/readiness probes) — the worker is an internal background role that serves no gRPC API.
- `server-service.yaml` renders the headless Service for all five roles with the **same three ports**, including `grpc-rpc` → `targetPort: rpc`.

The chart's own server config agrees: the `services.worker.rpc` block in `server-configmap.yaml` sets only `membershipPort` — no `grpcPort` — so the worker process never opens an rpc listener at all.

Since Kubernetes resolves named targetPorts against the ports declared on the selected pods, and no worker pod declares a port named `rpc`, the `grpc-rpc` entry on the worker headless Service is permanently endpoint-less. Observable on any install:

```console
$ kubectl get endpointslices -l kubernetes.io/service-name=temporal-worker-headless -o jsonpath='{.items[*].ports}'
[{"name":"metrics","port":9090,...},{"name":"grpc-membership","port":6939,...}]   # no grpc-rpc
```

There is no functional breakage — nothing can have been connecting through that port since it never had endpoints — but cluster-hygiene / observability tools flag it as a warning (e.g. "Unresolved named targetPort: rpc — no selected pod declares a container port with this name"), which is how we found it.

## The fix

Wrap the `grpc-rpc` block in the headless-service loop with the same `{{- if ne $service "worker" }}` condition the deployment template uses. Rendered result (`helm template` with `values/values.postgresql.yaml`):

| Headless Service | Before | After |
|---|---|---|
| frontend / matching / history | grpc-rpc, grpc-membership, metrics | unchanged |
| worker | grpc-rpc, grpc-membership, metrics | grpc-membership, metrics |

The Istio comment in the template says the non-metrics ports are listed "solely to allow Istio to configure itself to intercept traffic" — for the worker there is no rpc listener to intercept, so dropping the port is safe there too.

## Testing

- Updated the two worker-headless cases in `tests/server_service_test.yaml` to assert the port is gone (2 ports, membership + metrics) — these now act as regression tests.
- `helm unittest charts/temporal`: 14 suites, 154 tests passed.
- `helm template` against `values/values.postgresql.yaml` verified per the table above; no other role's Service changes.

## Known limitations

`server.worker.service.port` (7239) remains in `values.yaml` but is no longer referenced by any rendered worker resource. Left in place to avoid a values-schema change; happy to deprecate it here if you prefer.