### PR TITLE
feat(temporal-proxy): Add config model with secret and TLS wiring

### DIFF
--- a/charts/temporal-proxy/Chart.yaml
+++ b/charts/temporal-proxy/Chart.yaml
@@ -4,8 +4,8 @@ description: The Temporal proxy handles routing between clusters, namespace tran
 icon: https://raw.githubusercontent.com/temporalio/temporal-proxy/refs/heads/main/temporal-proxy-small.png
 
 type: application
-version: 0.1.0
-appVersion: v0.1.0
+version: 0.2.0
+appVersion: v0.2.0
 
 keywords:
   - temporal

--- a/charts/temporal-proxy/README.md
+++ b/charts/temporal-proxy/README.md
@@ -31,5 +31,160 @@ helm install temporal-proxy ./charts/temporal-proxy
 ## Configuration
 
 The proxy's runtime configuration is set under `config` in `values.yaml` and rendered into a ConfigMap mounted at
-`/etc/temporal-proxy/config.yaml`. Values are treated as templates, so they can reference other values. See
-[`values.yaml`](./values.yaml) for the full set of options and their defaults.
+`/etc/temporal-proxy/config.yaml`. See [`values.yaml`](./values.yaml) for the full set of options and their defaults.
+
+## Supplying configuration
+
+### Inline config
+
+`config` mirrors the [temporal-proxy config schema](https://github.com/temporalio/temporal-proxy) directly; whatever you
+put under `config` in `values.yaml` is what ends up in the ConfigMap. The chart does not run this through Helm's `tpl`
+function, so the proxy's own per-request templates (for example `{{ .RemoteNamespace }}` in an upstream `hostPort`) pass
+through untouched and are evaluated by the proxy itself at request time, not by Helm.
+
+If `config.hostPort` (the gateway's listen address) is left unset, it defaults to `:<service.port>`.
+
+```yaml
+config:
+  routing:
+    default: default
+  upstreams:
+    - name: default
+      hostPort: localhost:7233
+```
+
+### Secret-aware credentials
+
+Two fields accept either a plain string or a `secretKeyRef` object, so the ConfigMap never has to hold a secret in
+plaintext:
+
+- `upstreams[].credentials.static.apiKey`
+- `auth.staticToken.token`
+
+When you use the `secretKeyRef` form, the chart adds an environment variable to the proxy container sourced from that
+Secret, and rewrites the config value to `${VAR}` so the proxy substitutes it at startup. The generated variable names
+are:
+
+- `TP_UPSTREAM_<NAME>_API_KEY` for `upstreams[].credentials.static.apiKey`, where `<NAME>` is the upstream's `name`
+  upper-cased (non-alphanumeric characters become `_`)
+- `TP_AUTH_STATIC_TOKEN` for `auth.staticToken.token`
+
+```yaml
+config:
+  upstreams:
+    - name: cloud
+      hostPort: localhost:7233
+      credentials:
+        static:
+          apiKey:
+            secretKeyRef:
+              name: temporal-cloud
+              key: api-key
+```
+
+renders a ConfigMap with `apiKey: ${TP_UPSTREAM_CLOUD_API_KEY}` and adds a matching `TP_UPSTREAM_CLOUD_API_KEY`
+environment variable to the container, backed by the `temporal-cloud`/`api-key` Secret.
+
+### TLS
+
+The gateway's `config.tls` block and each `upstreams[].tls` block accept a `secretName`. When set, the chart mounts that
+Secret at `/etc/temporal-proxy/certs/gateway` (for `config.tls`) or `/etc/temporal-proxy/certs/upstream-<name>` (for an
+upstream's `tls`), and sets:
+
+- `cert` to `<mount>/tls.crt` by default, or `<mount>/<certKey>` if `certKey` is set
+- `key` to `<mount>/tls.key` by default, or `<mount>/<keyKey>` if `keyKey` is set
+- `ca` only when `caKey` is set, to `<mount>/<caKey>`
+
+`ca` is opt-in: it is only written when `caKey` is provided. Setting a `ca` on the gateway's `config.tls` enables
+mTLS/client-cert enforcement for inbound connections, so only set it when you intend to require client certificates.
+
+Note: keep upstream `name` values DNS-safe (lowercase alphanumeric characters and `-`), since they are used to build the
+generated volume name (`certs-upstream-<name>`).
+
+This mounting scheme lines up with how [cert-manager](https://cert-manager.io/) issues Secrets (a `tls.crt`/`tls.key`
+pair, plus `ca.crt` when using `Certificate.spec.additionalOutputFormats` or a CA issuer), but cert-manager is not
+required; any Secret with the right keys works, and `certKey`/`keyKey`/`caKey` let you point at whatever keys your
+Secret actually uses.
+
+```yaml
+config:
+  tls:
+    secretName: temporal-proxy-server-tls
+  upstreams:
+    - name: cloud
+      hostPort: "{{ .RemoteNamespace }}.tmprl.cloud:7233"
+      tls:
+        secretName: temporal-cloud-client-tls
+        caKey: ca.crt
+```
+
+If you'd rather manage certificate files yourself, skip `secretName` and use the chart's generic `volumes` /
+`volumeMounts` values to mount them at whatever path you set `cert`/`key`/`ca` to.
+
+### env / envFrom passthrough
+
+`env` and `envFrom` on the Deployment let you supply arbitrary environment variables the config references with `${VAR}`
+syntax, such as a Temporal Cloud account id or KMS credentials. Chart-generated secret env vars (from the secret-aware
+fields above) are merged in automatically alongside anything you set in `.Values.env`.
+
+```yaml
+env:
+  - name: TEMPORAL_ACCOUNT
+    value: a1b2c
+
+envFrom:
+  - secretRef:
+      name: proxy-kms-credentials
+```
+
+### Full example: Temporal Cloud
+
+Putting the pieces above together, an upstream routing to Temporal Cloud with the API key sourced from a Secret and the
+namespace derived from the proxy's own per-request template:
+
+```yaml
+env:
+  - name: TEMPORAL_ACCOUNT
+    value: a1b2c
+  - name: TEMPORAL_NAMESPACE
+    value: testing
+
+extraObjects:
+  # Typically not created like this to avoid putting your API key in plain text.
+  # Demo purposes only.
+  - |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: temporal-cloud
+    type: Opaque
+    stringData:
+      api-key: <YOUR_API_KEY>
+
+config:
+  routing:
+    default: cloud
+    system: system
+  upstreams:
+    - name: cloud
+      hostPort: "{{ .RemoteNamespace }}.tmprl.cloud:7233"
+      namespaces:
+        rules:
+          suffix: .$TEMPORAL_ACCOUNT
+      tls: {}
+      credentials:
+        static:
+          apiKey:
+            secretKeyRef:
+              name: temporal-cloud
+              key: api-key
+    - name: system
+      hostPort: "$TEMPORAL_NAMESPACE.$TEMPORAL_ACCOUNT.tmprl.cloud:7233"
+      tls: {}
+      credentials:
+        static:
+          apiKey:
+            secretKeyRef:
+              name: temporal-cloud
+              key: api-key
+```

--- a/charts/temporal-proxy/templates/_helpers.tpl
+++ b/charts/temporal-proxy/templates/_helpers.tpl
@@ -71,3 +71,108 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Rewrite a secret-bearing config field into a ${VAR} reference.
+
+If holder[field] is a { secretKeyRef: {...} } map, replace it with "${var}"
+and append a container env var (name=var, valueFrom.secretKeyRef=ref) to
+acc.env. A plain string value is left untouched. Any other map fails the
+render, since a near-miss key such as secretRef would otherwise land in the
+ConfigMap verbatim and only surface as an unmarshalling error at proxy
+startup. Mutates holder and acc in place and emits no output.
+
+Args (dict): holder, field, var, acc, path (config path, for error messages).
+*/}}
+{{- define "temporal-proxy.secretRef" -}}
+{{- $val := index .holder .field -}}
+{{- if kindIs "map" $val -}}
+{{- if not (hasKey $val "secretKeyRef") -}}
+{{- fail (printf "%s must be a string or a secretKeyRef" .path) -}}
+{{- end -}}
+{{- $_ := set .holder .field (printf "${%s}" .var) -}}
+{{- $_ := set .acc "env" (append .acc.env (dict "name" .var "valueFrom" (dict "secretKeyRef" $val.secretKeyRef))) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Turn a tls block that references a Secret into mounted file paths.
+
+Sets cert/key (and ca, only when caKey is given) to files under
+/etc/temporal-proxy/certs/<slot>, appends the matching volume and volumeMount
+to acc, and removes the chart-only keys (secretName, certKey, keyKey, caKey).
+Key names default to the cert-manager layout (tls.crt / tls.key). An explicit
+cert or key alongside secretName fails the render rather than being silently
+overwritten with the mount path. Mutates tls and acc in place and emits no
+output.
+
+Args (dict): tls, slot, acc.
+*/}}
+{{- define "temporal-proxy.tlsMount" -}}
+{{- $tls := .tls -}}
+{{- if or (hasKey $tls "cert") (hasKey $tls "key") -}}
+{{- fail (printf "tls for %s sets both secretName and cert/key; use certKey/keyKey to point at other keys in the Secret, or drop secretName and mount the files yourself" .slot) -}}
+{{- end -}}
+{{- if and (hasKey $tls "ca") (hasKey $tls "caKey") -}}
+{{- fail (printf "tls for %s sets both ca and caKey; use either ca or caKey" .slot) -}}
+{{- end -}}
+{{- $mount := printf "/etc/temporal-proxy/certs/%s" .slot -}}
+{{- $name := printf "certs-%s" .slot -}}
+{{- $_ := set $tls "cert" (printf "%s/%s" $mount (default "tls.crt" $tls.certKey)) -}}
+{{- $_ := set $tls "key" (printf "%s/%s" $mount (default "tls.key" $tls.keyKey)) -}}
+{{- if $tls.caKey -}}
+{{- $_ := set $tls "ca" (printf "%s/%s" $mount $tls.caKey) -}}
+{{- end -}}
+{{- $_ := set .acc "volumes" (append .acc.volumes (dict "name" $name "secret" (dict "secretName" $tls.secretName))) -}}
+{{- $_ := set .acc "volumeMounts" (append .acc.volumeMounts (dict "name" $name "mountPath" $mount "readOnly" true)) -}}
+{{- $_ := unset $tls "secretName" -}}
+{{- $_ := unset $tls "certKey" -}}
+{{- $_ := unset $tls "keyKey" -}}
+{{- $_ := unset $tls "caKey" -}}
+{{- end -}}
+
+{{/*
+Render the proxy config plus its Kubernetes wiring.
+Returns a YAML dict: { config, env, volumes, volumeMounts }.
+Consumers parse with `include "temporal-proxy.rendered" . | fromYaml`.
+
+Secret-bearing fields (upstream apiKey, static token) become ${VAR} env
+references, and tls blocks with a secretName become mounted files, via the
+temporal-proxy.secretRef and temporal-proxy.tlsMount helpers.
+*/}}
+{{- define "temporal-proxy.rendered" -}}
+{{- $cfg := deepCopy .Values.config -}}
+{{- $acc := dict "env" (list) "volumes" (list) "volumeMounts" (list) -}}
+{{- if not $cfg.hostPort -}}
+{{- $_ := set $cfg "hostPort" (printf ":%v" .Values.service.port) -}}
+{{- end -}}
+{{- /* Gateway tls runs before the upstream loop so its volume/mount sort first. */ -}}
+{{- if and $cfg.tls (hasKey $cfg.tls "secretName") -}}
+{{- $_ := include "temporal-proxy.tlsMount" (dict "tls" $cfg.tls "slot" "gateway" "acc" $acc) -}}
+{{- end -}}
+{{- range $i, $up := (default (list) $cfg.upstreams) -}}
+{{- /* Wiring derives an env var name, a volume name and a mount path from the
+upstream name, so an unnamed upstream cannot be wired. Identify it by index,
+since there is no name to quote. */ -}}
+{{- $wired := or (and $up.credentials $up.credentials.static) (and $up.tls (hasKey $up.tls "secretName")) -}}
+{{- if and $wired (not $up.name) -}}
+{{- fail (printf "upstreams[%d] must have a name to wire its credentials or tls secret" $i) -}}
+{{- end -}}
+{{- if and $up.credentials $up.credentials.static -}}
+{{- $var := printf "TP_UPSTREAM_%s_API_KEY" (upper (regexReplaceAll "[^A-Za-z0-9]" $up.name "_")) -}}
+{{- $path := printf "upstreams[%s].credentials.static.apiKey" $up.name -}}
+{{- $_ := include "temporal-proxy.secretRef" (dict "holder" $up.credentials.static "field" "apiKey" "var" $var "acc" $acc "path" $path) -}}
+{{- end -}}
+{{- if and $up.tls (hasKey $up.tls "secretName") -}}
+{{- if not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $up.name) -}}
+{{- fail (printf "upstream name %q must be DNS-1123 safe (lowercase alphanumeric and '-') to mount a tls secret" $up.name) -}}
+{{- end -}}
+{{- $_ := include "temporal-proxy.tlsMount" (dict "tls" $up.tls "slot" (printf "upstream-%s" $up.name) "acc" $acc) -}}
+{{- end -}}
+{{- end -}}
+{{- if and $cfg.auth $cfg.auth.staticToken -}}
+{{- $_ := include "temporal-proxy.secretRef" (dict "holder" $cfg.auth.staticToken "field" "token" "var" "TP_AUTH_STATIC_TOKEN" "acc" $acc "path" "auth.staticToken.token") -}}
+{{- end -}}
+{{- $result := dict "config" $cfg "env" $acc.env "volumes" $acc.volumes "volumeMounts" $acc.volumeMounts -}}
+{{- $result | toYaml -}}
+{{- end -}}

--- a/charts/temporal-proxy/templates/configmap.yaml
+++ b/charts/temporal-proxy/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- $rendered := include "temporal-proxy.rendered" . | fromYaml }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +8,4 @@ metadata:
     {{- include "temporal-proxy.labels" . | nindent 4 }}
 data:
   config.yaml: |
-{{ tpl (toYaml .Values.config) . | indent 4 }}
+{{ $rendered.config | toYaml | indent 4 }}

--- a/charts/temporal-proxy/templates/deployment.yaml
+++ b/charts/temporal-proxy/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $rendered := include "temporal-proxy.rendered" . | fromYaml }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +47,16 @@ spec:
           env:
             - name: PROXY_CONFIG
               value: /etc/temporal-proxy/config.yaml
+            {{- with $rendered.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -65,6 +76,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/temporal-proxy
+          {{- with $rendered.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -72,6 +86,9 @@ spec:
         - name: config
           configMap:
             name: {{ include "temporal-proxy.fullname" . }}
+      {{- with $rendered.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/temporal-proxy/tests/configmap_test.yaml
+++ b/charts/temporal-proxy/tests/configmap_test.yaml
@@ -35,15 +35,6 @@ tests:
           path: data["config.yaml"]
           pattern: "hostPort: localhost:7233"
 
-  - it: templates config against other values
-    set:
-      service:
-        port: 9999
-    asserts:
-      - matchRegex:
-          path: data["config.yaml"]
-          pattern: "hostPort: :9999"
-
   - it: renders custom values
     set:
       namespace: testing
@@ -70,3 +61,324 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: "default: primary"
+
+  - it: passes proxy per-request templates through verbatim
+    set:
+      config:
+        upstreams:
+          - name: cloud
+            hostPort: "{{ .RemoteNamespace }}.tmprl.cloud:7233"
+        routing:
+          default: cloud
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "\\{\\{ .RemoteNamespace \\}\\}.tmprl.cloud:7233"
+
+  - it: defaults hostPort from the service port when unset
+    set:
+      service:
+        port: 7233
+      config:
+        upstreams:
+          - name: default
+            hostPort: localhost:7233
+        routing:
+          default: default
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "hostPort: :7233"
+
+  - it: fails when a static auth token is a map that is not a secretKeyRef
+    set:
+      config:
+        auth:
+          staticToken:
+            token:
+              secretRef:
+                name: proxy-auth
+                key: token
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+        routing:
+          default: cloud
+    asserts:
+      - failedTemplate:
+          errorMessage: "auth.staticToken.token must be a string or a secretKeyRef"
+
+  - it: replaces an apiKey secret ref with an env var expansion
+    set:
+      config:
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+            credentials:
+              static:
+                apiKey:
+                  secretKeyRef:
+                    name: temporal-cloud
+                    key: api-key
+        routing:
+          default: cloud
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "apiKey: \\$\\{TP_UPSTREAM_CLOUD_API_KEY\\}"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "secretKeyRef"
+
+  - it: leaves a literal apiKey string untouched
+    set:
+      config:
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+            credentials:
+              static:
+                apiKey: "$MY_OWN_VAR"
+        routing:
+          default: cloud
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "apiKey: \\$MY_OWN_VAR"
+
+  - it: rewrites gateway tls secretName to mounted file paths
+    set:
+      config:
+        tls:
+          secretName: proxy-gateway-tls
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+        routing:
+          default: cloud
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "cert: /etc/temporal-proxy/certs/gateway/tls.crt"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "key: /etc/temporal-proxy/certs/gateway/tls.key"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "secretName"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "ca: /etc/temporal-proxy/certs/gateway"
+
+  - it: sets the ca path only when a caKey is provided
+    set:
+      config:
+        tls:
+          secretName: proxy-gateway-tls
+          caKey: ca.crt
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+        routing:
+          default: cloud
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "ca: /etc/temporal-proxy/certs/gateway/ca.crt"
+
+  - it: fails when both ca and caKey are provided with a tls block
+    set:
+      config:
+        tls:
+          secretName: proxy-gateway-tls
+          ca: /some/file.crt
+          caKey: ca.crt
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+        routing:
+          default: cloud
+    asserts:
+      - failedTemplate:
+          errorMessage: "tls for gateway sets both ca and caKey; use either ca or caKey"
+
+  - it: fails when an upstream with a tls secret has a DNS-unsafe name
+    set:
+      config:
+        upstreams:
+          - name: Bad_Name
+            hostPort: cloud.example.com:7233
+            tls:
+              secretName: cloud-mtls
+        routing:
+          default: Bad_Name
+    asserts:
+      - failedTemplate:
+          errorMessage: 'upstream name "Bad_Name" must be DNS-1123 safe (lowercase alphanumeric and ''-'') to mount a tls secret'
+
+  - it: fails when an apiKey is a map that is not a secretKeyRef
+    set:
+      config:
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+            credentials:
+              static:
+                apiKey:
+                  secretRef:
+                    name: temporal-cloud
+                    key: api-key
+        routing:
+          default: cloud
+    asserts:
+      - failedTemplate:
+          errorMessage: "upstreams[cloud].credentials.static.apiKey must be a string or a secretKeyRef"
+
+  - it: fails clearly when an upstream with a secret ref has no name
+    set:
+      config:
+        upstreams:
+          - hostPort: cloud.example.com:7233
+            credentials:
+              static:
+                apiKey:
+                  secretKeyRef:
+                    name: temporal-cloud
+                    key: api-key
+        routing:
+          default: cloud
+    asserts:
+      - failedTemplate:
+          errorMessage: "upstreams[0] must have a name to wire its credentials or tls secret"
+
+  - it: honours certKey and keyKey overrides
+    set:
+      config:
+        tls:
+          secretName: proxy-gateway-tls
+          certKey: server.pem
+          keyKey: server-key.pem
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+        routing:
+          default: cloud
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "cert: /etc/temporal-proxy/certs/gateway/server.pem"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "key: /etc/temporal-proxy/certs/gateway/server-key.pem"
+
+  - it: sets the ca path on an upstream tls when a caKey is provided
+    set:
+      config:
+        upstreams:
+          - name: onprem
+            hostPort: temporal-frontend.temporal.svc:7233
+            tls:
+              secretName: onprem-client-tls
+              caKey: ca.crt
+        routing:
+          default: onprem
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "ca: /etc/temporal-proxy/certs/upstream-onprem/ca.crt"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "cert: /etc/temporal-proxy/certs/upstream-onprem/tls.crt"
+
+  - it: strips chart-only tls keys from an upstream tls block
+    set:
+      config:
+        upstreams:
+          - name: onprem
+            hostPort: temporal-frontend.temporal.svc:7233
+            tls:
+              secretName: onprem-client-tls
+              certKey: server.pem
+              keyKey: server-key.pem
+              caKey: ca.crt
+        routing:
+          default: onprem
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "secretName"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "certKey"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "keyKey"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "caKey"
+
+  - it: preserves tls fields the chart does not manage
+    set:
+      config:
+        tls:
+          secretName: proxy-gateway-tls
+          serverName: proxy.example.com
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+        routing:
+          default: cloud
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "serverName: proxy.example.com"
+
+  - it: fails when a tls block sets both secretName and an explicit cert
+    set:
+      config:
+        tls:
+          secretName: proxy-gateway-tls
+          cert: /my/own/cert.pem
+          key: /my/own/key.pem
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+        routing:
+          default: cloud
+    asserts:
+      - failedTemplate:
+          errorMessage: "tls for gateway sets both secretName and cert/key; use certKey/keyKey to point at other keys in the Secret, or drop secretName and mount the files yourself"
+
+  - it: sanitizes an upstream apiKey env var name with underscores and uppercase
+    set:
+      config:
+        upstreams:
+          - name: My_Upstream
+            hostPort: cloud.example.com:7233
+            credentials:
+              static:
+                apiKey:
+                  secretKeyRef:
+                    name: temporal-cloud
+                    key: api-key
+        routing:
+          default: My_Upstream
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "apiKey: \\$\\{TP_UPSTREAM_MY_UPSTREAM_API_KEY\\}"
+
+  - it: leaves a literal static token string untouched
+    set:
+      config:
+        auth:
+          staticToken:
+            token: "$MY_OWN_TOKEN_VAR"
+            header: Authorization
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "token: \\$MY_OWN_TOKEN_VAR"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "TP_AUTH_STATIC_TOKEN"

--- a/charts/temporal-proxy/tests/deployment_test.yaml
+++ b/charts/temporal-proxy/tests/deployment_test.yaml
@@ -153,3 +153,225 @@ tests:
       - equal:
           path: spec.template.spec.nodeSelector.disktype
           value: ssd
+
+  - it: appends extra env vars to the container
+    set:
+      env:
+        - name: TEMPORAL_ACCOUNT
+          value: a1b2c
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEMPORAL_ACCOUNT
+            value: a1b2c
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROXY_CONFIG
+            value: /etc/temporal-proxy/config.yaml
+
+  - it: wires envFrom sources
+    set:
+      envFrom:
+        - secretRef:
+            name: proxy-env
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: proxy-env
+
+  - it: injects an env var for an apiKey secret ref
+    set:
+      config:
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+            credentials:
+              static:
+                apiKey:
+                  secretKeyRef:
+                    name: temporal-cloud
+                    key: api-key
+        routing:
+          default: cloud
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TP_UPSTREAM_CLOUD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: temporal-cloud
+                key: api-key
+
+  - it: injects an env var for a static token secret ref
+    set:
+      config:
+        auth:
+          staticToken:
+            token:
+              secretKeyRef:
+                name: proxy-auth
+                key: token
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TP_AUTH_STATIC_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: proxy-auth
+                key: token
+
+  - it: mounts a gateway tls secret as files
+    set:
+      config:
+        tls:
+          secretName: proxy-gateway-tls
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+        routing:
+          default: cloud
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: certs-gateway
+            secret:
+              secretName: proxy-gateway-tls
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: certs-gateway
+            mountPath: /etc/temporal-proxy/certs/gateway
+            readOnly: true
+
+  - it: sanitizes an upstream apiKey env var name with underscores and uppercase
+    set:
+      config:
+        upstreams:
+          - name: My_Upstream
+            hostPort: cloud.example.com:7233
+            credentials:
+              static:
+                apiKey:
+                  secretKeyRef:
+                    name: temporal-cloud
+                    key: api-key
+        routing:
+          default: My_Upstream
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TP_UPSTREAM_MY_UPSTREAM_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: temporal-cloud
+                key: api-key
+
+  - it: mounts an upstream tls secret under an upstream slot
+    set:
+      config:
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+            tls:
+              secretName: cloud-mtls
+        routing:
+          default: cloud
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: certs-upstream-cloud
+            secret:
+              secretName: cloud-mtls
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: certs-upstream-cloud
+            mountPath: /etc/temporal-proxy/certs/upstream-cloud
+            readOnly: true
+
+  - it: orders the gateway tls volume before upstream tls volumes
+    set:
+      config:
+        tls:
+          secretName: gw-tls
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+            tls:
+              secretName: cloud-mtls
+        routing:
+          default: cloud
+    asserts:
+      # index 0 is the config volume; gateway certs must precede upstream certs
+      # so the rendered manifest stays stable (no spurious GitOps diffs).
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: certs-gateway
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: certs-upstream-cloud
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: certs-gateway
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].name
+          value: certs-upstream-cloud
+
+  - it: emits generated secret env vars before .Values.env
+    set:
+      env:
+        - name: TP_UPSTREAM_CLOUD_API_KEY
+          value: my-own-literal
+      config:
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+            credentials:
+              static:
+                apiKey:
+                  secretKeyRef:
+                    name: temporal-cloud
+                    key: api-key
+        routing:
+          default: cloud
+    asserts:
+      # PROXY_CONFIG, then the generated var, and finally the user's override.
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: TP_UPSTREAM_CLOUD_API_KEY
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: temporal-cloud
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: TP_UPSTREAM_CLOUD_API_KEY
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: my-own-literal
+
+  - it: mounts only the config volume when no tls secret is set
+    set:
+      config:
+        tls: {}
+        upstreams:
+          - name: cloud
+            hostPort: cloud.example.com:7233
+            tls: {}
+        routing:
+          default: cloud
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 1

--- a/charts/temporal-proxy/values.yaml
+++ b/charts/temporal-proxy/values.yaml
@@ -1,16 +1,33 @@
 # Default values for temporal-proxy.
 
-# Raw configuration for the proxy.
-# Values are templates so you can reference other values as needed.
+# Proxy configuration, matching the temporal-proxy config schema.
+# See charts/temporal-proxy/README.md for the config supply model.
 config:
-  hostPort: :{{ .Values.service.port }}
-
   upstreams:
     - name: default
       hostPort: localhost:7233
 
   routing:
     default: default
+
+# Extra environment variables for the proxy container. Use these to supply
+# values referenced with ${VAR} in the config (e.g. Temporal Cloud account id,
+# KMS credentials). Chart-generated secret env vars are merged in automatically.
+env: []
+  # - name: TEMPORAL_ACCOUNT
+  #   value: a1b2c
+  # - name: TEMPORAL_API_KEY
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: temporal-cloud
+  #       key: api-key
+
+# Populate environment variables from Secrets or ConfigMaps.
+envFrom: []
+  # - configMapRef:
+  #     name: my-configmap
+  # - secretRef:
+  #     name: proxy-env
 
 # This will set the replicaset count more information can be found here:
 # https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/


### PR DESCRIPTION
The chart supplied config through a single `.Values.config` map rendered into a ConfigMap. That left no clean path for secrets (they landed in a plaintext ConfigMap), no first-class TLS/cert file handling, and a latent break: `tpl` ran over the config but the proxy uses the same `{{ }}` delimiters for its own per-request templates, so the official cloud example failed to render.

`.Values.config` now stays a faithful passthrough of the proxy schema, rendered by a _temporal-proxy.rendered_ helper rather than `tpl`, so proxy templates like `{{ .RemoteNamespace }}` pass through verbatim while hostPort still defaults to the service port. The few secret- and cert-bearing fields become chart-aware:

- `upstreams[].credentials.static.apiKey` and `auth.staticToken.token` accept a _secretKeyRef_; the chart injects a container env var (`TP_UPSTREAM_<NAME>_API_KEY` or `TP_AUTH_STATIC_TOKEN`) and substitutes `${VAR}` into the config, so the ConfigMap never holds a secret.
- gateway `config.tls` and each `upstreams[].tls` accept a _secretName_; the chart mounts that Secret at `/etc/temporal-proxy/certs/<slot>` and fills cert/key (and ca only when caKey is set) with the file paths. This works with cert-manager without requiring it. Upstream names that would produce an invalid DNS-1123 volume name fail the render up front.
- `env` / `envFrom` passthrough is added for values referenced with `${VAR}` in the config (e.g. `TEMPORAL_ACCOUNT`, or KMS credentials).