### PR TITLE
Default shims off

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -254,15 +254,15 @@ admintools:
   additionalEnvConfigMapName: my-configmap
 ```
 
-#### Disable Shims
-- `shims.dockerize` - Enable compatibility with Temporal 1.29 images (default: `true`). Set to `false` if using Temporal 1.30 or higher.
-- `shims.elasticsearchTool` - Enable compatibility with Temporal 1.29 images (default: `true`). Set to `false` if using Temporal 1.30 or higher.
+#### Enable Shims
+- `shims.dockerize` - Enable compatibility with Temporal 1.29 images (default: `false`). Set to `true` if using Temporal 1.29.
+- `shims.elasticsearchTool` - Enable compatibility with Temporal 1.29 images (default: `false`). Set to `true` if using Temporal 1.29.
 
 **Example:**
 ```yaml
 shims:
-  dockerize: false  # Disable if using Temporal 1.30+
-  elasticsearchTool: false  # Disable if using Temporal 1.30+
+  dockerize: true  # Enable if using Temporal 1.29
+  elasticsearchTool: true  # Enable if using Temporal 1.29
 ```
 
 #### Schema Job Annotations

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -254,15 +254,15 @@ admintools:
   additionalEnvConfigMapName: my-configmap
 ```
 
-#### Enable Shims
-- `shims.dockerize` - Enable compatibility with Temporal 1.29 images (default: `false`). Set to `true` if using Temporal 1.29.
-- `shims.elasticsearchTool` - Enable compatibility with Temporal 1.29 images (default: `false`). Set to `true` if using Temporal 1.29.
+#### Disable Shims
+- `shims.dockerize` - Enable compatibility with Temporal < 1.30 images (default: `true`). Set to `false` if using Temporal 1.29 or lower.
+- `shims.elasticsearchTool` - Enable compatibility with Temporal < 1.30 images (default: `true`). Set to `false` if using Temporal 1.29 or lower.
 
 **Example:**
 ```yaml
 shims:
-  dockerize: true  # Enable if using Temporal 1.29
-  elasticsearchTool: true  # Enable if using Temporal 1.29
+  dockerize: true  # Enable if using Temporal < 1.30
+  elasticsearchTool: true  # Enable if using Temporal < 1.30
 ```
 
 #### Schema Job Annotations

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -78,7 +78,7 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: my-init-container
-  - it: includes volume mounts with shim by default
+  - it: includes volume mounts without shim by default
     template: templates/server-deployment.yaml
     documentSelector:
       path: .kind
@@ -89,15 +89,15 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts[?(@.name=='config')]
       - exists:
           path: spec.template.spec.containers[0].volumeMounts[?(@.name=='dynamic-config')]
-      - exists:
+      - notExists:
           path: spec.template.spec.containers[0].volumeMounts[?(@.name=='shims')]
       - exists:
           path: spec.template.spec.volumes[?(@.name=='config')]
       - exists:
           path: spec.template.spec.volumes[?(@.name=='dynamic-config')]
-      - exists:
+      - notExists:
           path: spec.template.spec.volumes[?(@.name=='shims')]
-  - it: includes additional volumes without shim when disabled
+  - it: includes volume mounts with shim when enabled
     template: templates/server-deployment.yaml
     documentSelector:
       path: .kind
@@ -105,13 +105,13 @@ tests:
       matchMany: true
     set:
       shims:
-        dockerize: false
+        dockerize: true
     asserts:
       - exists:
           path: spec.template.spec.volumes[?(@.name=='config')]
-      - notExists:
+      - exists:
           path: spec.template.spec.volumes[?(@.name=='shims')]
-      - notExists:
+      - exists:
           path: spec.template.spec.containers[0].volumeMounts[?(@.name=='shims')]
   - it: omits prometheus annotations when disabled
     template: templates/server-deployment.yaml

--- a/charts/temporal/tests/shim_configmap_test.yaml
+++ b/charts/temporal/tests/shim_configmap_test.yaml
@@ -2,8 +2,24 @@ suite: test shim configmap
 templates:
   - shim-configmap.yaml
 tests:
+  - it: is not created by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: includes only the shims which are enabled
+    set:
+      shims:
+        dockerize: true
+        elasticsearchTool: false
+    asserts:
+      - exists:
+          path: data.dockerize
+      - notExists:
+          path: data["temporal-elasticsearch-tool"]
   - it: includes Helm hook annotations when useHelmHooks is true
     set:
+      shims:
+        dockerize: true
       schema:
         useHelmHooks: true
     asserts:
@@ -18,6 +34,8 @@ tests:
           value: "before-hook-creation"
   - it: excludes Helm hook annotations when useHelmHooks is false
     set:
+      shims:
+        dockerize: true
       schema:
         useHelmHooks: false
     asserts:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -657,9 +657,9 @@ schema:
   securityContext: {}
 shims:
   # Enable compatibility with Temporal 1.29 images. Set to false if using Temporal 1.30 or higher.
-  dockerize: true
+  dockerize: false
   # Enable compatibility with Temporal 1.29 images. Set to false if using Temporal 1.30 or higher.
-  elasticsearchTool: true
+  elasticsearchTool: false
 test:
   podAnnotations: {}
   podLabels: {}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -656,9 +656,9 @@ schema:
   containerSecurityContext: {}
   securityContext: {}
 shims:
-  # Enable compatibility with Temporal 1.29 images. Set to false if using Temporal 1.30 or higher.
+  # Enable compatibility with Temporal 1.29 images. Set to true if using Temporal 1.29.
   dockerize: false
-  # Enable compatibility with Temporal 1.29 images. Set to false if using Temporal 1.30 or higher.
+  # Enable compatibility with Temporal 1.29 images. Set to true if using Temporal 1.29.
   elasticsearchTool: false
 test:
   podAnnotations: {}


### PR DESCRIPTION
## What was changed
Default the `dockerize` and `elasticsearch-tool` shims off now.

## Why?
These haven't been needed for the last two major Temporal releases we've shipped and can cause confusion for users.

## Checklist
<!--- add/delete as needed --->

1. Closes #940.

2. How was this tested:
Tests updated.
