### PR TITLE
support optional lifecycle config in each of the services

### DIFF
--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -78,6 +78,12 @@ spec:
                 name: {{ . }}
           {{- end }}
           {{- end }}
+          {{- if .Values.admintools.lifecycle }}
+          lifecycle:
+          {{- with .Values.admintools.lifecycle }}
+            {{ . | nindent 12 }}
+          {{- end }}
+          {{- end }}
           livenessProbe:
               exec:
                 command:

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -119,6 +119,12 @@ spec:
               containerPort: 9090
               protocol: TCP
           {{- if ne $service "worker" }}
+          {{- if $serviceValues.lifecycle }}
+          lifecycle:
+          {{- with $serviceValues.lifecycle -}}
+            {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
           livenessProbe:
             initialDelaySeconds: 150
             tcpSocket:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -310,6 +310,7 @@ server:
           retention: 3d
   frontend:
     enabled: true
+    lifecycle: {}
     service:
       # Evaluated as template
       annotations: {}
@@ -369,6 +370,7 @@ server:
   internal-frontend:
     # Enable this to create internal-frontend
     enabled: false
+    lifecycle: {}
     service:
       # Evaluated as template
       annotations: {}
@@ -412,6 +414,7 @@ server:
     podDisruptionBudget: {}
   history:
     enabled: true
+    lifecycle: {}
     service:
       # type: ClusterIP
       port: 7234
@@ -445,6 +448,7 @@ server:
     podDisruptionBudget: {}
   matching:
     enabled: true
+    lifecycle: {}
     service:
       # type: ClusterIP
       port: 7235
@@ -478,6 +482,7 @@ server:
     podDisruptionBudget: {}
   worker:
     enabled: true
+    lifecycle: {}
     service:
       # type: ClusterIP
       port: 7239
@@ -511,6 +516,7 @@ server:
     podDisruptionBudget: {}
 admintools:
   enabled: true
+  lifecycle: {}
   # By default the admin tools connect to the internal-frontend when it is
   # enabled, which grants admin access without an external Authorizer. Set this
   # to true to connect through the external frontend instead (e.g. when the
@@ -559,6 +565,7 @@ web:
     repository: temporalio/ui
     tag: 2.52.0
     pullPolicy: IfNotPresent
+  lifecycle: {}
   service:
     # set type to NodePort if access to web needs access from outside the cluster
     # for more info see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
support optional lifecycle config in each of the services

## Why?
i'd like to be able to set `preStop` in each of the containers

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
* default (with `lifecycle: {}`) -- no changes to rendered chart
* with `lifecycle` set -- lifecycle is correctly set in each Deployment podspec

3. Any docs updates needed?
none