### PR TITLE
Bump appVersion in temporal-proxy

### DIFF
--- a/charts/temporal-proxy/Chart.yaml
+++ b/charts/temporal-proxy/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/temporalio/temporal-proxy/refs/heads/mai
 
 type: application
 version: 0.2.1
-appVersion: v0.4.1
+appVersion: v0.5.0
 
 keywords:
   - temporal

--- a/charts/temporal-proxy/Chart.yaml
+++ b/charts/temporal-proxy/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/temporalio/temporal-proxy/refs/heads/mai
 
 type: application
 version: 0.2.1
-appVersion: v0.4.0
+appVersion: v0.4.1
 
 keywords:
   - temporal

--- a/charts/temporal-proxy/Chart.yaml
+++ b/charts/temporal-proxy/Chart.yaml
@@ -4,8 +4,8 @@ description: The Temporal proxy handles routing between clusters, namespace tran
 icon: https://raw.githubusercontent.com/temporalio/temporal-proxy/refs/heads/main/temporal-proxy-small.png
 
 type: application
-version: 0.2.0
-appVersion: v0.2.0
+version: 0.2.1
+appVersion: v0.4.0
 
 keywords:
   - temporal


### PR DESCRIPTION
Bumping the appVersion to the latest release.

Release: <https://github.com/temporalio/temporal-proxy/releases/tag/v0.5.0>