### PR TITLE
feat: add global.imageRegistry support

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -102,6 +102,16 @@ Define the AppVersion
 {{- end -}}
 
 {{/*
+Render global image registry.
+*/}}
+{{- define "temporal.imageRegistry" -}}
+{{- $registry := (.Values.global.imageRegistry | default "") -}}
+{{- if $registry -}}
+{{- print (trimSuffix "/" $registry) "/" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the annotations for all resources
 */}}
 {{- define "temporal.resourceAnnotations" -}}

--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
       containers:
         - name: admin-tools
-          image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
+          image: "{{ include "temporal.imageRegistry" . }}{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
           imagePullPolicy: {{ .Values.admintools.image.pullPolicy }}
           env:
             # TEMPORAL_CLI_ADDRESS is deprecated, use TEMPORAL_ADDRESS instead

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ $.Chart.Name }}-{{ $service }}
-          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          image: "{{ include "temporal.imageRegistry" $ }}{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           env:
             - name: POD_IP

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -42,7 +42,7 @@ spec:
         {{- range $_, $store := (include "temporal.persistence.eachStore" $ | fromYaml) }}
           {{- if $store.config.createDatabase }}
         - name: create-{{ $store.name }}-store
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ include "temporal.imageRegistry" $ }}{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
             {{- if eq $store.driver "cassandra" }}
           command: ['temporal-cassandra-tool', 'create', '-k', '{{ $store.config.keyspace }}', '--replication-factor', '{{ $store.config.replicationFactor | default 1 }}'{{- if $store.config.datacenter }}, '--datacenter', '{{ $store.config.datacenter }}'{{- end }}]
@@ -83,7 +83,7 @@ spec:
           {{- if $store.config.manageSchema }}
             {{- $schema := include "temporal.persistence.schema" $store }}
         - name: manage-schema-{{ $store.name }}-store
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ include "temporal.imageRegistry" $ }}{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c']
           args:
@@ -138,7 +138,7 @@ spec:
 
       containers:
         - name: done
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ include "temporal.imageRegistry" $ }}{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'echo "Store setup completed"']
             {{- with $.Values.schema.resources }}

--- a/charts/temporal/templates/server-namespace-job.yaml
+++ b/charts/temporal/templates/server-namespace-job.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
         {{- range $namespace := $.Values.server.config.namespaces.namespace }}
         - name: create-{{ $namespace.name }}-namespace
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ include "temporal.imageRegistry" $ }}{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['/bin/sh', '-c']
           args: ['temporal operator namespace describe -n {{ $namespace.name }} || temporal operator namespace create -n {{ $namespace.name }}{{- if hasKey $namespace "retention" }} --retention {{ $namespace.retention }}{{- end }}']
@@ -101,7 +101,7 @@ spec:
         {{- end }}
       containers:
         - name: done
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: "{{ include "temporal.imageRegistry" $ }}{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'echo "Namespace setup completed"']
           {{- with $.Values.schema.resources }}

--- a/charts/temporal/templates/test.yaml
+++ b/charts/temporal/templates/test.yaml
@@ -19,7 +19,7 @@ spec:
   {{ include "temporal.serviceAccount" . }}
   containers:
   - name: cluster-health
-    image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
+    image: "{{ include "temporal.imageRegistry" . }}{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
     imagePullPolicy: {{ .Values.admintools.image.pullPolicy }}
     command: ["temporal", "operator", "cluster", "health"]
     env:

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-web
-          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          image: "{{ include "temporal.imageRegistry" . }}{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: TEMPORAL_ADDRESS

--- a/charts/temporal/tests/admintools_deployment_test.yaml
+++ b/charts/temporal/tests/admintools_deployment_test.yaml
@@ -182,3 +182,14 @@ tests:
       - equal:
           path: spec.template.spec.priorityClassName
           value: my-priority-class
+  - it: prefixes admintools image with global.imageRegistry when set
+    set:
+      global:
+        imageRegistry: registry.example.com
+      admintools:
+        image:
+          tag: test-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.example.com/temporalio/admin-tools:test-tag"

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -64,6 +64,21 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: 200m
+  - it: prefixes server image with global.imageRegistry when set
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    set:
+      global:
+        imageRegistry: registry.example.com
+      server:
+        image:
+          tag: test-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.example.com/temporalio/server:test-tag"
   - it: includes additional init containers
     template: templates/server-deployment.yaml
     documentSelector:

--- a/charts/temporal/tests/server_job_test.yaml
+++ b/charts/temporal/tests/server_job_test.yaml
@@ -191,6 +191,34 @@ tests:
       - equal:
           path: spec.template.spec.volumes[0].name
           value: my-volume
+  - it: prefixes schema job images with global.imageRegistry when set
+    set:
+      global:
+        imageRegistry: registry.example.com
+      admintools:
+        image:
+          tag: test-tag
+      server:
+        config:
+          persistence:
+            datastores:
+              default:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-persistence:3306"
+                  databaseName: temporal
+              visibility:
+                sql:
+                  pluginName: mysql8
+                  connectAddr: "temporal-visibility:3306"
+                  databaseName: temporal_visibility
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "registry.example.com/temporalio/admin-tools:test-tag"
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.example.com/temporalio/admin-tools:test-tag"
   - it: includes additional volume mounts
     set:
       server:

--- a/charts/temporal/tests/server_namespace_job_test.yaml
+++ b/charts/temporal/tests/server_namespace_job_test.yaml
@@ -24,6 +24,26 @@ tests:
       - containsDocument:
           kind: Job
           apiVersion: batch/v1
+  - it: prefixes namespace job images with global.imageRegistry when set
+    set:
+      global:
+        imageRegistry: registry.example.com
+      admintools:
+        image:
+          tag: test-tag
+      server:
+        config:
+          namespaces:
+            create: true
+            namespace:
+              - name: default
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "registry.example.com/temporalio/admin-tools:test-tag"
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.example.com/temporalio/admin-tools:test-tag"
   - it: uses a fixed job name when useHelmHooks is true
     release:
       name: test

--- a/charts/temporal/tests/test_pod_test.yaml
+++ b/charts/temporal/tests/test_pod_test.yaml
@@ -60,6 +60,17 @@ tests:
       - equal:
           path: spec.imagePullSecrets[0].name
           value: my-registry-secret
+  - it: prefixes test pod image with global.imageRegistry when set
+    set:
+      global:
+        imageRegistry: registry.example.com
+      admintools:
+        image:
+          tag: test-tag
+    asserts:
+      - equal:
+          path: spec.containers[0].image
+          value: "registry.example.com/temporalio/admin-tools:test-tag"
   - it: does not set custom pod labels by default
     asserts:
       - notExists:

--- a/charts/temporal/tests/web_deployment_test.yaml
+++ b/charts/temporal/tests/web_deployment_test.yaml
@@ -26,3 +26,14 @@ tests:
       - equal:
           path: spec.template.spec.priorityClassName
           value: my-priority-class
+  - it: prefixes web image with global.imageRegistry when set
+    set:
+      global:
+        imageRegistry: registry.example.com
+      web:
+        image:
+          tag: test-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.example.com/temporalio/ui:test-tag"

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -3,6 +3,10 @@ fullnameOverride: ""
 # Chart debug mode
 # (eg. disable helm hook delete policy)
 debug: false
+global:
+  # Prefix all chart images with this registry, for example: registry.example.com
+  # When empty, image repositories are used as defined under each component.
+  imageRegistry: ""
 imagePullSecrets: []
 # Custom Service account management
 serviceAccount:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR adds support for configuring a global image registry via:
```yaml
global:
  imageRegistry: <registry>
 ```
When set, this value is used as a prefix for all Temporal chart container images.
When unset/empty, image rendering remains unchanged from current behavior.
## Why?
<!-- Tell your future self why have you made these changes -->

Today, using a private/mirrored registry requires overriding multiple repositories separately, which is repetitive and error-prone.
A global registry setting is a common Helm pattern and simplifies installation, especially for air-gapped/private registry environments/dependency-chart use-cases where we'd want one registry override in one place
This change is backward-compatible and non-breaking:

if global.imageRegistry is not set, behavior is exactly as before.


## Checklist
<!--- add/delete as needed --->

1. Closes #967

2. How was this tested:
Helm unit tests:
helm unittest charts/temporal
Result: all suites pass (15/15), all tests pass (188/188)
Render checks with valid chart values:
Without global.imageRegistry: images render as current defaults (temporalio/...)
With global.imageRegistry=registry.example.com: all chart images render with registry.example.com/ prefix

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
values.yaml was updated to include and describe global.imageRegistry.
A README values table update could be added as a follow-up.