### PR TITLE
feat(temporal): allow overriding the server livenessProbe from values

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -118,7 +118,12 @@ spec:
             - name: metrics
               containerPort: 9090
               protocol: TCP
-          {{- if ne $service "worker" }}
+          {{- /* Defaults to a tcpSocket probe with a long start-up delay; users may override per-service via server.<svc>.livenessProbe. */ -}}
+          {{- $resolvedLiveness := default $.Values.server.livenessProbe $serviceValues.livenessProbe }}
+          {{- if $resolvedLiveness }}
+          livenessProbe:
+          {{- toYaml $resolvedLiveness | nindent 12 }}
+          {{- else if ne $service "worker" }}
           livenessProbe:
             initialDelaySeconds: 150
             tcpSocket:

--- a/charts/temporal/tests/server_deployment_test.yaml
+++ b/charts/temporal/tests/server_deployment_test.yaml
@@ -336,6 +336,75 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
           value: rpc
+  - it: worker livenessProbe defaults to empty
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-worker")].kind'
+      value: Deployment
+      matchMany: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+  - it: non-worker livenessProbe defaults to tcpSocket
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name != "RELEASE-NAME-temporal-worker")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        internal-frontend:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 150
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: rpc
+  - it: livenessProbe is set for all services
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name != "RELEASE-NAME-temporal-worker")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        livenessProbe:
+          timeoutSeconds: 5
+          failureThreshold: 6
+          tcpSocket:
+            port: rpc
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 6
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+  - it: livenessProbe is set for history service
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: '$[?(@.metadata.name == "RELEASE-NAME-temporal-history")].kind'
+      value: Deployment
+      matchMany: true
+    set:
+      server:
+        history:
+          livenessProbe:
+            initialDelaySeconds: 300
+            periodSeconds: 20
+            tcpSocket:
+              port: rpc
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 300
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 20
 
   - it: additional environment variables are set on all services
     template: templates/server-deployment.yaml

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -27,6 +27,9 @@ server:
   # Global default settings (can be overridden per service)
   replicaCount: 1
   readinessProbe: {}
+  # Empty keeps the built-in tcpSocket liveness probe with its start-up delay.
+  # A value replaces it whole, so set the full probe, e.g. timeouts and thresholds for a busy node.
+  livenessProbe: {}
   metrics:
     # Annotate pods and services directly with the following Prometheus annotations.
     # prometheus.io/job
@@ -323,6 +326,7 @@ server:
     # Defaults to a tcpSocket probe; uncomment below for a gRPC probe.
     # gRPC probes don't yet support TLS (kubernetes/enhancements#4939), so opt in only when TLS is off.
     readinessProbe: {}
+    livenessProbe: {}
     # readinessProbe:
     #   grpc:
     #     port: 7233
@@ -382,6 +386,7 @@ server:
     # Defaults to a tcpSocket probe; uncomment below for a gRPC probe.
     # gRPC probes don't yet support TLS (kubernetes/enhancements#4939), so opt in only when TLS is off.
     readinessProbe: {}
+    livenessProbe: {}
     # readinessProbe:
     #   grpc:
     #     port: 7236
@@ -419,6 +424,7 @@ server:
       membershipPort: 6934
       membershipAppProtocol: tcp
     readinessProbe: {}
+    livenessProbe: {}
     metrics:
       annotations:
         enabled: true
@@ -452,6 +458,7 @@ server:
       membershipPort: 6935
       membershipAppProtocol: tcp
     readinessProbe: {}
+    livenessProbe: {}
     metrics:
       annotations:
         enabled: true
@@ -485,6 +492,7 @@ server:
       membershipPort: 6939
       membershipAppProtocol: tcp
     readinessProbe: {}
+    livenessProbe: {}
     metrics:
       annotations:
         enabled: true


### PR DESCRIPTION
## What

Make the server `livenessProbe` configurable, mirroring how `readinessProbe` already works: `server.livenessProbe` as the global default, `server.<service>.livenessProbe` per service, and the current built-in probe when neither is set.

## Why

`server-deployment.yaml` hard-codes the liveness probe, so its budget is identical for every Temporal service and cannot be adjusted. On a node under load the default one second probe timeout restarts a healthy pod: the frontend, history and matching containers answer the TCP check late, Kubernetes counts three failures and kills the process mid-work. The readiness probe of the same containers is already overridable, so today the only way to widen the liveness budget is to patch the rendered Deployment, which `helm upgrade` reverts.

This is the request in #653; #654 proposed the same thing and has been sitting with conflicts since December.

## Behaviour

- Defaults unchanged: non-worker services keep `initialDelaySeconds: 150` with the `rpc` tcpSocket probe, the worker keeps no liveness probe.
- A value replaces the probe whole, per service or globally, so timeouts, periods and thresholds can be set for a busy node.

## Testing

- `helm unittest charts/temporal` — 186 tests pass, including four new cases in `server_deployment_test.yaml`: worker default (absent), non-worker default (tcpSocket with the start-up delay), a global override applied to every service, and a per-service override on history.
- `helm lint charts/temporal` clean; rendered a single-node install with and without overrides and diffed the Deployments.