### PR TITLE
Render metadata.namespace for namespaced resources

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -25,6 +25,13 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create the Kubernetes namespace for namespaced resources.
+*/}}
+{{- define "temporal.kubernetesNamespace" -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "temporal.chart" -}}

--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -28,7 +28,7 @@ If release name contains chart name it will be used as a full name.
 Create the Kubernetes namespace for namespaced resources.
 */}}
 {{- define "temporal.kubernetesNamespace" -}}
-{{- .Release.Namespace -}}
+{{- .Release.Namespace | quote -}}
 {{- end -}}
 
 {{/*

--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -14,6 +14,7 @@ it via admintools.additionalEnv/additionalVolumes. */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ "admintools") }}
   annotations:
     {{- include "temporal.resourceAnnotations" (list $ "admintools" "deployment") | nindent 4 }}

--- a/charts/temporal/templates/frontend-ingress.yaml
+++ b/charts/temporal/templates/frontend-ingress.yaml
@@ -8,6 +8,7 @@ apiVersion: extensions/v1beta1
   {{- end }}
 kind: Ingress
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ "frontend") }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "frontend" "") | nindent 4 }}

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -3,6 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: "{{ include "temporal.fullname" $ }}-config"
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -8,6 +8,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ $service) }}
   annotations:
     {{- include "temporal.resourceAnnotations" (list $ $service "deployment") | nindent 4 }}

--- a/charts/temporal/templates/server-dynamicconfigmap.yaml
+++ b/charts/temporal/templates/server-dynamicconfigmap.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: "{{ include "temporal.fullname" $ }}-dynamic-config"
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -2,6 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ $jobName }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}

--- a/charts/temporal/templates/server-namespace-job.yaml
+++ b/charts/temporal/templates/server-namespace-job.yaml
@@ -16,6 +16,7 @@ an external ingress host has no chart-managed certificate, so skip TLS there. */
 apiVersion: batch/v1
 kind: Job
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ $jobName }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "database" "") | nindent 4 }}
@@ -58,11 +59,11 @@ spec:
           env:
             - name: TEMPORAL_ADDRESS
               {{- if $useInternalFrontend }}
-              value: "{{ include "temporal.fullname" $ }}-internal-frontend.{{ $.Release.Namespace }}.svc:{{ (index $.Values.server "internal-frontend").service.port }}"
+              value: {{ include "temporal.internalFrontendAddress" $ }}
               {{- else if $.Values.server.frontend.ingress.enabled }}
               value: "{{ index $.Values.server.frontend.ingress.hosts 0 }}"
               {{- else }}
-              value: "{{ include "temporal.fullname" $ }}-frontend.{{ $.Release.Namespace }}.svc:{{ $.Values.server.frontend.service.port }}"
+              value: {{ include "temporal.frontendAddress" $ }}
               {{- end }}
             {{- if $tlsSection }}
             {{- include "temporal.adminClient.tls.env" (list $ $tlsSection) | nindent 12 }}

--- a/charts/temporal/templates/server-pdb.yaml
+++ b/charts/temporal/templates/server-pdb.yaml
@@ -6,6 +6,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ $service) }}-pdb
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}

--- a/charts/temporal/templates/server-secret.yaml
+++ b/charts/temporal/templates/server-secret.yaml
@@ -4,6 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.persistence.secretName" (list $ $store) }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "secret") | nindent 4 }}

--- a/charts/temporal/templates/server-service-monitor.yaml
+++ b/charts/temporal/templates/server-service-monitor.yaml
@@ -6,6 +6,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ $service) }}
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}
@@ -21,9 +22,6 @@ spec:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   jobLabel: {{ include "temporal.componentname" (list $ $service) }}
-  namespaceSelector:
-    matchNames:
-      - "{{ $.Release.Namespace }}"
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "temporal.name" $ }}

--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -5,6 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ $service) }}
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "service") | nindent 4 }}
@@ -49,6 +50,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ (printf "%s-headless" $service)) }}
   labels:
     {{- include "temporal.resourceLabels" (list $ $service "") | nindent 4 }}

--- a/charts/temporal/templates/serviceaccount.yaml
+++ b/charts/temporal/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.serviceAccountName" $ }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}

--- a/charts/temporal/templates/shim-configmap.yaml
+++ b/charts/temporal/templates/shim-configmap.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: "{{ include "temporal.fullname" $ }}-shims"
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}

--- a/charts/temporal/templates/test.yaml
+++ b/charts/temporal/templates/test.yaml
@@ -4,6 +4,7 @@ frontend TLS section (empty unless frontend TLS is enabled). */}}
 apiVersion: v1
 kind: Pod
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" . }}
   name: "{{ include "temporal.fullname" . }}-test-cluster-health"
   labels:
     {{- include "temporal.resourceLabels" (list $ "test" "") | nindent 4 }}

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ "web") }}
   annotations:
     {{- include "temporal.resourceAnnotations" (list $ "web" "deployment") | nindent 4 }}
@@ -47,7 +48,7 @@ spec:
               {{- if .Values.web.temporalAddress }}
               value: {{ .Values.web.temporalAddress }}
               {{- else }}
-              value: {{ include "temporal.frontendAddress.fqdn" $ }}
+              value: {{ include "temporal.frontendAddress" $ }}
               {{- end }}
           {{- if .Values.web.tls.enabled }}
           {{- include "temporal.web.tls.env" $ | nindent 12 }}

--- a/charts/temporal/templates/web-ingress.yaml
+++ b/charts/temporal/templates/web-ingress.yaml
@@ -8,6 +8,7 @@ apiVersion: extensions/v1beta1
   {{- end }}
 kind: Ingress
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ "web") }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}

--- a/charts/temporal/templates/web-pdb.yaml
+++ b/charts/temporal/templates/web-pdb.yaml
@@ -3,6 +3,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ "web") }}-pdb
   labels:
     {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}

--- a/charts/temporal/templates/web-service.yaml
+++ b/charts/temporal/templates/web-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ include "temporal.kubernetesNamespace" $ }}
   name: {{ include "temporal.componentname" (list $ "web") }}
   labels:
     {{- include "temporal.resourceLabels" (list $ "web" "") | nindent 4 }}

--- a/charts/temporal/tests/namespace_rendering_test.yaml
+++ b/charts/temporal/tests/namespace_rendering_test.yaml
@@ -66,6 +66,14 @@ set:
     podDisruptionBudget:
       maxUnavailable: 1
 tests:
+  - it: renders a numeric namespace as a string
+    template: templates/web-service.yaml
+    release:
+      namespace: "123"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: "123"
   - it: renders namespace on server deployment
     template: templates/server-deployment.yaml
     documentSelector:

--- a/charts/temporal/tests/namespace_rendering_test.yaml
+++ b/charts/temporal/tests/namespace_rendering_test.yaml
@@ -1,0 +1,200 @@
+suite: test kubernetes namespace rendering
+templates:
+  - server-deployment.yaml
+  - server-service.yaml
+  - server-service-monitor.yaml
+  - server-secret.yaml
+  - server-configmap.yaml
+  - server-dynamicconfigmap.yaml
+  - shim-configmap.yaml
+  - server-job.yaml
+  - server-namespace-job.yaml
+  - server-pdb.yaml
+  - frontend-ingress.yaml
+  - web-deployment.yaml
+  - web-service.yaml
+  - web-pdb.yaml
+  - web-ingress.yaml
+  - admintools-deployment.yaml
+  - serviceaccount.yaml
+  - test.yaml
+release:
+  namespace: target-namespace
+set:
+  serviceAccount:
+    create: true
+  shims:
+    dockerize: true
+  server:
+    metrics:
+      serviceMonitor:
+        enabled: true
+    config:
+      namespaces:
+        create: true
+        namespace:
+          - name: default
+      persistence:
+        defaultStore: default
+        visibilityStore: visibility
+        datastores:
+          default:
+            sql:
+              pluginName: postgres12
+              databaseName: temporal
+              connectAddr: postgres.default.svc.cluster.local:5432
+              user: temporal
+              password: secret
+          visibility:
+            sql:
+              pluginName: postgres12
+              databaseName: temporal_visibility
+              connectAddr: postgres.default.svc.cluster.local:5432
+              user: temporal
+              password: secret
+    frontend:
+      ingress:
+        enabled: true
+      podDisruptionBudget:
+        maxUnavailable: 1
+    history:
+      podDisruptionBudget:
+        maxUnavailable: 1
+  web:
+    ingress:
+      enabled: true
+    podDisruptionBudget:
+      maxUnavailable: 1
+tests:
+  - it: renders namespace on server deployment
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on server service
+    template: templates/server-service.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on headless server service
+    template: templates/server-service.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-history-headless
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on service monitor
+    template: templates/server-service-monitor.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on server secret
+    template: templates/server-secret.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-default-store
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on server configmap
+    template: templates/server-configmap.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on dynamic configmap
+    template: templates/server-dynamicconfigmap.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on shim configmap
+    template: templates/shim-configmap.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on schema job
+    template: templates/server-job.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on temporal namespace job
+    template: templates/server-namespace-job.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on server pdb
+    template: templates/server-pdb.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend-pdb
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on frontend ingress
+    template: templates/frontend-ingress.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on web deployment
+    template: templates/web-deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on web service
+    template: templates/web-service.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on web pdb
+    template: templates/web-pdb.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on web ingress
+    template: templates/web-ingress.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on admintools deployment
+    template: templates/admintools-deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on service account
+    template: templates/serviceaccount.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace
+  - it: renders namespace on test pod
+    template: templates/test.yaml
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: target-namespace

--- a/charts/temporal/tests/server_namespace_job_test.yaml
+++ b/charts/temporal/tests/server_namespace_job_test.yaml
@@ -90,7 +90,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="TEMPORAL_ADDRESS")].value
-          value: RELEASE-NAME-temporal-frontend.NAMESPACE.svc:7233
+          value: RELEASE-NAME-temporal-frontend:7233
   - it: sets TEMPORAL_ADDRESS to the internal-frontend service when enabled
     # The namespace job is a one-off admin tools invocation, so by default it
     # targets the internal-frontend when that is enabled.
@@ -106,7 +106,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="TEMPORAL_ADDRESS")].value
-          value: RELEASE-NAME-temporal-internal-frontend.NAMESPACE.svc:7236
+          value: RELEASE-NAME-temporal-internal-frontend:7236
 
   - it: routes the namespace job to the external frontend when useExternalFrontend is set
     set:
@@ -122,7 +122,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-default-namespace")].env[?(@.name=="TEMPORAL_ADDRESS")].value
-          value: RELEASE-NAME-temporal-frontend.NAMESPACE.svc:7233
+          value: RELEASE-NAME-temporal-frontend:7233
   - it: includes additional environment variables
     set:
       server:

--- a/charts/temporal/tests/server_service_monitor_test.yaml
+++ b/charts/temporal/tests/server_service_monitor_test.yaml
@@ -1,0 +1,16 @@
+suite: test server service monitor
+templates:
+  - server-service-monitor.yaml
+set:
+  server:
+    metrics:
+      serviceMonitor:
+        enabled: true
+tests:
+  - it: does not render namespace selector by default
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - notExists:
+          path: spec.namespaceSelector

--- a/charts/temporal/tests/tls_test.yaml
+++ b/charts/temporal/tests/tls_test.yaml
@@ -353,7 +353,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-test-namespace")].env[?(@.name=="TEMPORAL_ADDRESS")].value
-          value: RELEASE-NAME-temporal-frontend.NAMESPACE.svc:7233
+          value: RELEASE-NAME-temporal-frontend:7233
       - contains:
           path: spec.template.spec.initContainers[0].env
           content:
@@ -389,7 +389,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-test-namespace")].env[?(@.name=="TEMPORAL_ADDRESS")].value
-          value: RELEASE-NAME-temporal-internal-frontend.NAMESPACE.svc:7236
+          value: RELEASE-NAME-temporal-internal-frontend:7236
       - contains:
           path: spec.template.spec.initContainers[0].env
           content:
@@ -429,7 +429,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="create-test-namespace")].env[?(@.name=="TEMPORAL_ADDRESS")].value
-          value: RELEASE-NAME-temporal-frontend.NAMESPACE.svc:7233
+          value: RELEASE-NAME-temporal-frontend:7233
       - equal:
           path: spec.template.spec.volumes[?(@.name=='client-tls')].secret.secretName
           value: my-frontend-secret

--- a/charts/temporal/tests/web_service_test.yaml
+++ b/charts/temporal/tests/web_service_test.yaml
@@ -78,7 +78,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: TEMPORAL_ADDRESS
-            value: RELEASE-NAME-temporal-frontend.NAMESPACE.svc:7233
+            value: RELEASE-NAME-temporal-frontend:7233
   - it: TEMPORAL_ADDRESS can be overridden via web.temporalAddress
     template: templates/web-deployment.yaml
     set:
@@ -100,4 +100,4 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: TEMPORAL_ADDRESS
-            value: RELEASE-NAME-temporal-frontend.NAMESPACE.svc:7233
+            value: RELEASE-NAME-temporal-frontend:7233


### PR DESCRIPTION
Note: continuing from contributor @ondrejlevy's  work in https://github.com/temporalio/helm-charts/pull/941

## What was changed

This PR renders `metadata.namespace` for the namespaced resources produced by the Temporal Helm chart, using the Helm release namespace through a shared `temporal.kubernetesNamespace` helper.

The change covers Deployments, Services, ConfigMaps, Secrets, Jobs, PodDisruptionBudgets, Ingresses, ServiceMonitor, ServiceAccount, and the test Pod. It also updates same-namespace Temporal service references to use short service DNS names and removes the default ServiceMonitor `namespaceSelector`, so the ServiceMonitor follows the Prometheus Operator same-namespace default.

Automated helm-unittest coverage was added to assert namespace rendering across the chart resources, including [charts/temporal/tests/namespace_rendering_test.yaml](charts/temporal/tests/namespace_rendering_test.yaml).

  ## Why?

This makes the chart work reliably when rendered through Kustomize `helmCharts` with a target namespace.

Starting with Kustomize `v5.8.0`, namespace propagation to Helm charts changed, and `v5.8.1` completed the namespace propagation fix. In this flow, Kustomize passes the namespace into `helm template --namespace`, but it does not patch missing `metadata.namespace` into the generated Helm output. Therefore charts that do not explicitly render `.Release.Namespace` can still produce manifests without `metadata.namespace`.

That is a problem for GitOps and Kustomize-based deployments where rendered manifests are expected to contain the target namespace explicitly. With this change, rendering the chart through Kustomize `helmCharts` produces namespaced manifests consistently.

  ## Checklist

  1. Closes N/A
  2. How was this tested:

  - helm unit tests passing

  - helm lint values files

  - Rendered the chart with a non-default namespace and verified that every generated resource included it:

    Result: 19 rendered resources and 19 explicit metadata.namespace: target-namespace fields.

  - Ran git diff --check.
  3. Any docs updates needed? N/A