### PR TITLE
Allow image digests

### DIFF
--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -184,7 +184,8 @@ Define the AppVersion
 {{/*
 Render the image reference for a component.
 
-A component's image is pinned either by tag or digest. The digest takes precedence if both are specified.
+A component's image is pinned either by tag or digest. The digest takes
+precedence and the tag is ignored when both are set.
 
 Digests must be given in full <algorithm>:<hex> form (e.g. sha256:<64 hex
 chars>).
@@ -193,14 +194,17 @@ chars>).
 {{- $global := index . 0 -}}
 {{- $component := index . 1 -}}
 {{- $image := index $global.Values $component "image" -}}
+{{- $tag := $image.tag | default "" | toString -}}
 {{- $digest := $image.digest | default "" | toString -}}
 {{- if $digest -}}
 {{- if not (regexMatch "^[a-z0-9]+([.+_-][a-z0-9]+)*:[a-fA-F0-9]{32,}$" $digest) -}}
 {{- fail (printf "%s.image.digest must be in <algorithm>:<hex> form (e.g. sha256:<64 hex chars>), got %q" $component $digest) -}}
 {{- end -}}
 {{- printf "%s@%s" $image.repository $digest -}}
+{{- else if $tag -}}
+{{- printf "%s:%s" $image.repository $tag -}}
 {{- else -}}
-{{- printf "%s:%v" $image.repository (required (printf "%s.image.tag is required unless %s.image.digest is set" $component $component) $image.tag) -}}
+{{- fail (printf "%s.image.tag is required unless %s.image.digest is set" $component $component) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/temporal/templates/_helpers.tpl
+++ b/charts/temporal/templates/_helpers.tpl
@@ -182,6 +182,29 @@ Define the AppVersion
 {{- end -}}
 
 {{/*
+Render the image reference for a component.
+
+A component's image is pinned either by tag or digest. The digest takes precedence if both are specified.
+
+Digests must be given in full <algorithm>:<hex> form (e.g. sha256:<64 hex
+chars>).
+*/}}
+{{- define "temporal.image" -}}
+{{- $global := index . 0 -}}
+{{- $component := index . 1 -}}
+{{- $image := index $global.Values $component "image" -}}
+{{- $digest := $image.digest | default "" | toString -}}
+{{- if $digest -}}
+{{- if not (regexMatch "^[a-z0-9]+([.+_-][a-z0-9]+)*:[a-fA-F0-9]{32,}$" $digest) -}}
+{{- fail (printf "%s.image.digest must be in <algorithm>:<hex> form (e.g. sha256:<64 hex chars>), got %q" $component $digest) -}}
+{{- end -}}
+{{- printf "%s@%s" $image.repository $digest -}}
+{{- else -}}
+{{- printf "%s:%v" $image.repository (required (printf "%s.image.tag is required unless %s.image.digest is set" $component $component) $image.tag) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the annotations for all resources
 */}}
 {{- define "temporal.resourceAnnotations" -}}

--- a/charts/temporal/templates/admintools-deployment.yaml
+++ b/charts/temporal/templates/admintools-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
         - name: admin-tools
-          image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
+          image: {{ include "temporal.image" (list $ "admintools") | quote }}
           imagePullPolicy: {{ .Values.admintools.image.pullPolicy }}
           env:
             # TEMPORAL_CLI_ADDRESS is deprecated, use TEMPORAL_ADDRESS instead

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ $.Chart.Name }}-{{ $service }}
-          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          image: {{ include "temporal.image" (list $ "server") | quote }}
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           env:
             - name: POD_IP

--- a/charts/temporal/templates/server-job.yaml
+++ b/charts/temporal/templates/server-job.yaml
@@ -43,7 +43,7 @@ spec:
         {{- range $_, $store := (include "temporal.persistence.eachStore" $ | fromYaml) }}
           {{- if $store.config.createDatabase }}
         - name: create-{{ $store.name }}-store
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: {{ include "temporal.image" (list $ "admintools") | quote }}
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
             {{- if eq $store.driver "cassandra" }}
           command: ['temporal-cassandra-tool', 'create', '-k', '{{ $store.config.keyspace }}', '--replication-factor', '{{ $store.config.replicationFactor | default 1 }}'{{- if $store.config.datacenter }}, '--datacenter', '{{ $store.config.datacenter }}'{{- end }}]
@@ -84,7 +84,7 @@ spec:
           {{- if $store.config.manageSchema }}
             {{- $schema := include "temporal.persistence.schema" $store }}
         - name: manage-schema-{{ $store.name }}-store
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: {{ include "temporal.image" (list $ "admintools") | quote }}
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c']
           args:
@@ -139,7 +139,7 @@ spec:
 
       containers:
         - name: done
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: {{ include "temporal.image" (list $ "admintools") | quote }}
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'echo "Store setup completed"']
             {{- with $.Values.schema.resources }}

--- a/charts/temporal/templates/server-namespace-job.yaml
+++ b/charts/temporal/templates/server-namespace-job.yaml
@@ -52,7 +52,7 @@ spec:
       initContainers:
         {{- range $namespace := $.Values.server.config.namespaces.namespace }}
         - name: create-{{ $namespace.name }}-namespace
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: {{ include "temporal.image" (list $ "admintools") | quote }}
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['/bin/sh', '-c']
           args: ['temporal operator namespace describe -n {{ $namespace.name }} || temporal operator namespace create -n {{ $namespace.name }}{{- if hasKey $namespace "retention" }} --retention {{ $namespace.retention }}{{- end }}']
@@ -102,7 +102,7 @@ spec:
         {{- end }}
       containers:
         - name: done
-          image: "{{ $.Values.admintools.image.repository }}:{{ $.Values.admintools.image.tag }}"
+          image: {{ include "temporal.image" (list $ "admintools") | quote }}
           imagePullPolicy: {{ $.Values.admintools.image.pullPolicy }}
           command: ['sh', '-c', 'echo "Namespace setup completed"']
           {{- with $.Values.schema.resources }}

--- a/charts/temporal/templates/test.yaml
+++ b/charts/temporal/templates/test.yaml
@@ -20,7 +20,7 @@ spec:
   {{ include "temporal.componentServiceAccount" (list $ "test") }}
   containers:
   - name: cluster-health
-    image: "{{ .Values.admintools.image.repository }}:{{ .Values.admintools.image.tag }}"
+    image: {{ include "temporal.image" (list $ "admintools") | quote }}
     imagePullPolicy: {{ .Values.admintools.image.pullPolicy }}
     command: ["temporal", "operator", "cluster", "health"]
     env:

--- a/charts/temporal/templates/web-deployment.yaml
+++ b/charts/temporal/templates/web-deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-web
-          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          image: {{ include "temporal.image" (list $ "web") | quote }}
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: TEMPORAL_ADDRESS

--- a/charts/temporal/tests/image_test.yaml
+++ b/charts/temporal/tests/image_test.yaml
@@ -1,0 +1,228 @@
+suite: test image references
+templates:
+  - server-deployment.yaml
+  - web-deployment.yaml
+  - admintools-deployment.yaml
+  - server-job.yaml
+  - server-namespace-job.yaml
+  - test.yaml
+set:
+  server:
+    config:
+      namespaces:
+        create: true
+        namespace:
+          - name: default
+      persistence:
+        defaultStore: default
+        visibilityStore: visibility
+        datastores:
+          default:
+            sql:
+              pluginName: mysql8
+              connectAddr: "temporal-persistence:3306"
+              databaseName: temporal
+          visibility:
+            sql:
+              pluginName: mysql8
+              connectAddr: "temporal-visibility:3306"
+              databaseName: temporal_visibility
+tests:
+  - it: pins images by tag when no digest is set
+    set:
+      server:
+        image:
+          repository: example.com/server
+          tag: v1.2.3
+      admintools:
+        image:
+          repository: example.com/admin-tools
+          tag: v4.5.6
+      web:
+        image:
+          repository: example.com/ui
+          tag: v7.8.9
+    asserts:
+      - template: templates/server-deployment.yaml
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-frontend
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/server:v1.2.3
+      - template: templates/web-deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/ui:v7.8.9
+      - template: templates/admintools-deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/admin-tools:v4.5.6
+      - template: templates/server-job.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/admin-tools:v4.5.6
+      - template: templates/server-namespace-job.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/admin-tools:v4.5.6
+      - template: templates/test.yaml
+        equal:
+          path: spec.containers[0].image
+          value: example.com/admin-tools:v4.5.6
+
+  - it: pins images by digest when a digest is set
+    set:
+      server:
+        image:
+          repository: example.com/server
+          digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      admintools:
+        image:
+          repository: example.com/admin-tools
+          digest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      web:
+        image:
+          repository: example.com/ui
+          digest: sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+    asserts:
+      - template: templates/server-deployment.yaml
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-frontend
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/server@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      - template: templates/server-deployment.yaml
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-history
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/server@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      - template: templates/web-deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/ui@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      - template: templates/admintools-deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/admin-tools@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      - template: templates/test.yaml
+        equal:
+          path: spec.containers[0].image
+          value: example.com/admin-tools@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+  - it: pins the schema job init containers by digest
+    set:
+      admintools:
+        image:
+          repository: example.com/admin-tools
+          digest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    template: templates/server-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=='create-default-store')].image
+          value: example.com/admin-tools@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=='manage-schema-default-store')].image
+          value: example.com/admin-tools@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      - equal:
+          path: spec.template.spec.containers[?(@.name=='done')].image
+          value: example.com/admin-tools@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+  - it: pins the namespace job init containers by digest
+    set:
+      admintools:
+        image:
+          repository: example.com/admin-tools
+          digest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    template: templates/server-namespace-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=='create-default-namespace')].image
+          value: example.com/admin-tools@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      - equal:
+          path: spec.template.spec.containers[?(@.name=='done')].image
+          value: example.com/admin-tools@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+  - it: prefers the digest over the tag when both are set
+    set:
+      server:
+        image:
+          repository: example.com/server
+          tag: v1.2.3
+          digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    template: templates/server-deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-temporal-frontend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/server@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+  - it: keeps digests per component
+    set:
+      server:
+        image:
+          repository: example.com/server
+          tag: v1.2.3
+      web:
+        image:
+          repository: example.com/ui
+          digest: sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+    asserts:
+      - template: templates/server-deployment.yaml
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-temporal-frontend
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/server:v1.2.3
+      - template: templates/web-deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/ui@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+  - it: leaves the pull policy alone when pinning by digest
+    set:
+      web:
+        image:
+          digest: sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+          pullPolicy: Always
+    template: templates/web-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: fails when a digest omits the algorithm prefix
+    set:
+      web:
+        image:
+          digest: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+    template: templates/web-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: 'web.image.digest must be in <algorithm>:<hex> form (e.g. sha256:<64 hex chars>), got "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"'
+
+  - it: fails when a digest is not hex
+    set:
+      server:
+        image:
+          digest: sha256:not-a-digest
+    template: templates/server-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: 'server.image.digest must be in <algorithm>:<hex> form (e.g. sha256:<64 hex chars>), got "sha256:not-a-digest"'
+
+  - it: fails when neither a tag nor a digest is set
+    set:
+      server:
+        image:
+          tag: null
+    template: templates/server-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: server.image.tag is required unless server.image.digest is set

--- a/charts/temporal/tests/image_test.yaml
+++ b/charts/temporal/tests/image_test.yaml
@@ -1,6 +1,7 @@
 suite: test image references
 templates:
   - server-deployment.yaml
+  - server-configmap.yaml
   - web-deployment.yaml
   - admintools-deployment.yaml
   - server-job.yaml
@@ -71,19 +72,22 @@ tests:
           path: spec.containers[0].image
           value: example.com/admin-tools:v4.5.6
 
-  - it: pins images by digest when a digest is set
+  - it: pins images by digest, ignoring any tag
     set:
       server:
         image:
           repository: example.com/server
+          tag: v1.2.3
           digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       admintools:
         image:
           repository: example.com/admin-tools
+          tag: v4.5.6
           digest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
       web:
         image:
           repository: example.com/ui
+          tag: v7.8.9
           digest: sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
     asserts:
       - template: templates/server-deployment.yaml
@@ -145,22 +149,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name=='done')].image
           value: example.com/admin-tools@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-
-  - it: prefers the digest over the tag when both are set
-    set:
-      server:
-        image:
-          repository: example.com/server
-          tag: v1.2.3
-          digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    template: templates/server-deployment.yaml
-    documentSelector:
-      path: metadata.name
-      value: RELEASE-NAME-temporal-frontend
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].image
-          value: example.com/server@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
   - it: keeps digests per component
     set:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -23,8 +23,8 @@ server:
   image:
     repository: temporalio/server
     tag: 1.31.2
-    # Pin the image by digest instead of by tag. Takes precedence over `tag`
-    # when set, and must be given as a full <algorithm>:<hex> digest:
+    # Pin the image by digest instead of by tag, given as a full
+    # <algorithm>:<hex> digest. Takes precedence over `tag`
     # digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     pullPolicy: IfNotPresent
   # Global default settings (can be overridden per service)
@@ -541,8 +541,8 @@ admintools:
   image:
     repository: temporalio/admin-tools
     tag: "1.31.2"
-    # Pin the image by digest instead of by tag. Takes precedence over `tag`
-    # when set, and must be given as a full <algorithm>:<hex> digest:
+    # Pin the image by digest instead of by tag, given as a full
+    # <algorithm>:<hex> digest. Takes precedence over `tag`.
     # digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     pullPolicy: IfNotPresent
   service:
@@ -581,8 +581,8 @@ web:
   image:
     repository: temporalio/ui
     tag: 2.52.0
-    # Pin the image by digest instead of by tag. Takes precedence over `tag`
-    # when set, and must be given as a full <algorithm>:<hex> digest:
+    # Pin the image by digest instead of by tag, given as a full
+    # <algorithm>:<hex> digest. Takes precedence over `tag`.
     # digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     pullPolicy: IfNotPresent
   service:

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -23,6 +23,9 @@ server:
   image:
     repository: temporalio/server
     tag: 1.31.2
+    # Pin the image by digest instead of by tag. Takes precedence over `tag`
+    # when set, and must be given as a full <algorithm>:<hex> digest:
+    # digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     pullPolicy: IfNotPresent
   # Global default settings (can be overridden per service)
   # replicaCount: 1
@@ -538,6 +541,9 @@ admintools:
   image:
     repository: temporalio/admin-tools
     tag: "1.31.2"
+    # Pin the image by digest instead of by tag. Takes precedence over `tag`
+    # when set, and must be given as a full <algorithm>:<hex> digest:
+    # digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -575,6 +581,9 @@ web:
   image:
     repository: temporalio/ui
     tag: 2.52.0
+    # Pin the image by digest instead of by tag. Takes precedence over `tag`
+    # when set, and must be given as a full <algorithm>:<hex> digest:
+    # digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     pullPolicy: IfNotPresent
   service:
     # set type to NodePort if access to web needs access from outside the cluster


### PR DESCRIPTION
## What?
Allows pinning images by their digest

## Why?
Both to ensure that the digests behind the tags can't be mutated and to make it easier to pin your own builds of the temporal image.